### PR TITLE
Improve the build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-/target
-torch-sys/target
+target/
 _build/
 data/
 gen/.merlin

--- a/torch-sys/Cargo.toml
+++ b/torch-sys/Cargo.toml
@@ -18,4 +18,6 @@ libc = "0.2.0"
 [build-dependencies]
 cc = "1.0"
 cmake = "0.1"
-zip = "0.5.0"
+failure = "0.1"
+reqwest = "0.9"
+zip = "0.5"

--- a/torch-sys/build.rs
+++ b/torch-sys/build.rs
@@ -1,100 +1,119 @@
-// The LIBTORCH environment variable is used to locate the libtorch
-// library. If not set this build script will try downloading and
-// extracting a pre-built binary version of libtorch.
-use cmake::Config;
 use std::env;
-use std::path::PathBuf;
-use std::process::Command;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
 
-fn make(libtorch: &PathBuf, libtorch_lib: &PathBuf) {
+use cmake::Config;
+use failure::Fallible;
+use reqwest;
+use zip;
+
+const TORCH_VERSION: &'static str = "1.0.1";
+
+fn download<P: reqwest::IntoUrl, Q: AsRef<Path>>(source_url: P, target_file: Q) -> Fallible<()> {
+    let mut resp = reqwest::get(source_url)?;
+    let f = fs::File::create(&target_file)?;
+    let mut writer = io::BufWriter::new(f);
+    resp.copy_to(&mut writer)?;
+    Ok(())
+}
+
+fn extract<P: AsRef<Path>>(filename: P, outpath: P) {
+    let file = fs::File::open(&filename).unwrap();
+    let buf = io::BufReader::new(file);
+    let mut archive = zip::ZipArchive::new(buf).unwrap();
+    for i in 0..archive.len() {
+        let mut file = archive.by_index(i).unwrap();
+        let outpath = outpath.as_ref().join(file.sanitized_name());
+        if !(&*file.name()).ends_with('/') {
+            println!(
+                "File {} extracted to \"{}\" ({} bytes)",
+                i,
+                outpath.as_path().display(),
+                file.size()
+            );
+            if let Some(p) = outpath.parent() {
+                if !p.exists() {
+                    fs::create_dir_all(&p).unwrap();
+                }
+            }
+            let mut outfile = fs::File::create(&outpath).unwrap();
+            io::copy(&mut file, &mut outfile).unwrap();
+        }
+    }
+}
+
+fn prepare_libtorch_dir() -> PathBuf {
+    if let Ok(libtorch) = env::var("LIBTORCH") {
+        PathBuf::from(libtorch)
+    } else {
+        let libtorch_dir = PathBuf::from(env::var("OUT_DIR").unwrap()).join("libtorch");
+        if !libtorch_dir.exists() {
+            fs::create_dir(&libtorch_dir).unwrap_or_default();
+            let os = env::var("CARGO_CFG_TARGET_OS").expect("Unable to get TARGET_OS");
+            let libtorch_url = match os.as_str() {
+                "linux" => format!(
+                    "https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-{}.zip",
+                    TORCH_VERSION
+                ),
+                "macos" => format!(
+                    "https://download.pytorch.org/libtorch/cpu/libtorch-macos-{}.zip",
+                    TORCH_VERSION
+                ),
+                _ => panic!("Unsupported OS"),
+            };
+
+            let filename = libtorch_dir.join(format!("v{}.zip", TORCH_VERSION));
+            download(&libtorch_url, &filename).unwrap();
+            extract(&filename, &libtorch_dir);
+        }
+
+        libtorch_dir
+    }
+}
+
+fn make<P: AsRef<Path>>(libtorch: P) {
     let libtorch_cxx11_abi = env::var("LIBTORCH_CXX11_ABI").unwrap_or("0".to_string());
     cc::Build::new()
         .cpp(true)
-        .include(libtorch.join("include"))
-        .include(libtorch.join("include/torch/csrc/api/include"))
+        .include(libtorch.as_ref().join("include"))
+        .include(libtorch.as_ref().join("include/torch/csrc/api/include"))
         .flag(&format!(
             "-Wl,-rpath={}",
-            libtorch_lib.to_string_lossy().into_owned()
+            libtorch.as_ref().join("lib").display()
         ))
         .flag("-std=c++11")
+        .flag("-fPIC")
         .flag(&format!("-D_GLIBCXX_USE_CXX11_ABI={}", libtorch_cxx11_abi))
         .file("libtch/torch_api.cpp")
         .warnings(false)
         .compile("libtorch");
 }
 
-fn cmake(libtorch: &PathBuf) {
+fn cmake<P: AsRef<Path>>(libtorch: P) {
     let dst = Config::new("libtch")
-        .define("CMAKE_PREFIX_PATH", libtorch)
+        .define("CMAKE_PREFIX_PATH", libtorch.as_ref())
         .build();
+
     println!("cargo:rustc-link-search=native={}", dst.display());
     println!("cargo:rustc-link-lib=static=tch");
     println!("cargo:rustc-link-lib=stdc++");
 }
 
-fn maybe_download(filename: &std::path::Path, url: &str) {
-    if !filename.exists() {
-        Command::new("wget")
-            .args(&[url, "-nv", "-O", &filename.to_string_lossy().into_owned()])
-            .status().unwrap();
-    }
-}
-
-fn unzip_all(absolute_filename: &std::path::Path, outpath: &std::path::Path) {
-    let file = std::fs::File::open(&absolute_filename).unwrap();
-    let mut archive = zip::ZipArchive::new(file).unwrap();
-    for i in 0..archive.len() {
-        let mut file = archive.by_index(i).unwrap();
-        let outpath = outpath.join(file.sanitized_name());
-        if !(&*file.name()).ends_with('/') {
-            println!("File {} extracted to \"{}\" ({} bytes)", i, outpath.as_path().display(), file.size());
-            if let Some(p) = outpath.parent() {
-                if !p.exists() {
-                    std::fs::create_dir_all(&p).unwrap();
-                }
-            }
-            let mut outfile = std::fs::File::create(&outpath).unwrap();
-            std::io::copy(&mut file, &mut outfile).unwrap();
-        }
-    }
-}
-
 fn main() {
-    let out_path = PathBuf::from(&env::var("OUT_DIR").unwrap());
-    let libtorch =
-        if let Ok(libtorch) = env::var("LIBTORCH") { PathBuf::from(libtorch) }
-        else {
-            let libtorch = out_path.join("libtorch");
-            if !libtorch.exists() {
-                let url = match env::consts::OS {
-                    "macos" => "https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.0.1.zip",
-                    "linux" => "https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-1.0.1.zip",
-                    otherwise => panic!("unsupported os {}", otherwise)
-                };
-                let filename = url.split("/").last().unwrap();
-                let download_dir = PathBuf::from(&env::var("CARGO_MANIFEST_DIR").unwrap()).join("target");
-                if !download_dir.exists() {
-                    std::fs::create_dir(&download_dir).unwrap();
-                }
-                let absolute_filename = download_dir.join(filename);
-                println!("Downloading {}", url);
-                println!("To {:?}", absolute_filename);
-                maybe_download(&absolute_filename, &url);
-                println!("Extracting in {:?}", libtorch);
-                unzip_all(&absolute_filename, &out_path)
-            }
-            libtorch
-        };
-    let libtorch_lib = libtorch.join("lib");
+    let libtorch_dir = prepare_libtorch_dir();
+    let libtorch = libtorch_dir.join("libtorch");
     println!(
         "cargo:rustc-link-search=native={}",
-        libtorch_lib.to_string_lossy().into_owned()
+        libtorch.join("lib").display()
     );
+
     if env::var("LIBTORCH_USE_CMAKE").is_ok() {
         cmake(&libtorch)
     } else {
-        make(&libtorch, &libtorch_lib)
+        make(&libtorch)
     }
+
     println!("cargo:rustc-link-lib=c10");
     println!("cargo:rustc-link-lib=caffe2");
     println!("cargo:rustc-link-lib=torch");

--- a/torch-sys/build.rs
+++ b/torch-sys/build.rs
@@ -68,7 +68,7 @@ fn prepare_libtorch_dir() -> PathBuf {
             extract(&filename, &libtorch_dir);
         }
 
-        libtorch_dir
+        libtorch_dir.join("libtorch")
     }
 }
 
@@ -101,8 +101,7 @@ fn cmake<P: AsRef<Path>>(libtorch: P) {
 }
 
 fn main() {
-    let libtorch_dir = prepare_libtorch_dir();
-    let libtorch = libtorch_dir.join("libtorch");
+    let libtorch = prepare_libtorch_dir();
     println!(
         "cargo:rustc-link-search=native={}",
         libtorch.join("lib").display()

--- a/torch-sys/libtch/CMakeLists.txt
+++ b/torch-sys/libtch/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 project(tch)
 
 find_package(Torch REQUIRED)

--- a/torch-sys/src/lib.rs
+++ b/torch-sys/src/lib.rs
@@ -28,10 +28,16 @@ extern "C" {
     pub fn at_dim(arg: *mut C_tensor) -> c_int;
     pub fn at_requires_grad(arg: *mut C_tensor) -> c_int;
     pub fn at_shape(arg: *mut C_tensor, sz: *mut i64);
-    pub fn at_double_value_at_indexes(arg: *mut C_tensor, idx: *const c_int, idx_len: c_int) -> f64;
+    pub fn at_double_value_at_indexes(arg: *mut C_tensor, idx: *const c_int, idx_len: c_int)
+        -> f64;
     pub fn at_int64_value_at_indexes(arg: *mut C_tensor, idx: *const c_int, idx_len: c_int) -> i64;
     pub fn at_free(arg: *mut C_tensor);
-    pub fn at_copy_data(arg: *mut C_tensor, vs: *const c_void, numel: i64, elt_size_in_bytes: c_int);
+    pub fn at_copy_data(
+        arg: *mut C_tensor,
+        vs: *const c_void,
+        numel: i64,
+        elt_size_in_bytes: c_int,
+    );
     pub fn at_scalar_type(arg: *mut C_tensor) -> c_int;
     pub fn at_device(arg: *mut C_tensor) -> c_int;
     pub fn at_tensor_of_data(

--- a/torch-sys/src/lib.rs
+++ b/torch-sys/src/lib.rs
@@ -28,16 +28,10 @@ extern "C" {
     pub fn at_dim(arg: *mut C_tensor) -> c_int;
     pub fn at_requires_grad(arg: *mut C_tensor) -> c_int;
     pub fn at_shape(arg: *mut C_tensor, sz: *mut i64);
-    pub fn at_double_value_at_indexes(arg: *mut C_tensor, idx: *const c_int, idx_len: c_int)
-        -> f64;
+    pub fn at_double_value_at_indexes(arg: *mut C_tensor, idx: *const c_int, idx_len: c_int) -> f64;
     pub fn at_int64_value_at_indexes(arg: *mut C_tensor, idx: *const c_int, idx_len: c_int) -> i64;
     pub fn at_free(arg: *mut C_tensor);
-    pub fn at_copy_data(
-        arg: *mut C_tensor,
-        vs: *const c_void,
-        numel: i64,
-        elt_size_in_bytes: c_int,
-    );
+    pub fn at_copy_data(arg: *mut C_tensor, vs: *const c_void, numel: i64, elt_size_in_bytes: c_int);
     pub fn at_scalar_type(arg: *mut C_tensor) -> c_int;
     pub fn at_device(arg: *mut C_tensor) -> c_int;
     pub fn at_tensor_of_data(


### PR DESCRIPTION
This PR contains

1. More idiomatic `build.rs`
2. cmake minimum version fix
3. `.gitignore` cleanup

Tested locally w/o `LIBTORCH` was set and w/o `LIBTORCH_USE_CMAKE` was set.

Note that `LIBTORCH` now should be the root repo containing `libtorch`.

[#4](https://github.com/LaurentMazare/tch-rs/issues/4) 