### PR TITLE
Add optim trait to make optimizers impl configurable.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ failure = "0.1"
 libc = "0.2.0"
 rand = "0.6.5"
 torch-sys = { version = "0.0.3", path = "torch-sys" }
+derive_builder = "0.7.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,9 @@
 #[macro_use]
+extern crate derive_builder;
+
+#[macro_use]
 extern crate failure;
+
 extern crate libc;
 
 #[macro_use]

--- a/src/nn/c_optimizer.rs
+++ b/src/nn/c_optimizer.rs
@@ -2,18 +2,18 @@ use crate::Tensor;
 use failure::Fallible;
 use libc::c_int;
 
-pub struct COptimizer {
+pub(in crate::nn) struct COptimizer {
     c_optimizer: *mut torch_sys::C_optimizer,
 }
 
 impl COptimizer {
-    pub fn adam(lr: f64, beta1: f64, beta2: f64, wd: f64) -> Fallible<COptimizer> {
+    pub(in crate::nn) fn adam(lr: f64, beta1: f64, beta2: f64, wd: f64) -> Fallible<COptimizer> {
         let c_optimizer = unsafe_torch_err!({ torch_sys::ato_adam(lr, beta1, beta2, wd) });
         Ok(COptimizer { c_optimizer })
     }
 
     // Maybe we should use the builder pattern to provide default values for these ?
-    pub fn rms_prop(
+    pub(in crate::nn) fn rms_prop(
         lr: f64,
         alpha: f64,
         eps: f64,
@@ -21,26 +21,25 @@ impl COptimizer {
         momentum: f64,
         centered: bool,
     ) -> Fallible<COptimizer> {
-        let centered = if centered { 1 } else { 0 };
-        let c_optimizer =
-            unsafe_torch_err!({ torch_sys::ato_rms_prop(lr, alpha, eps, wd, momentum, centered) });
+        let c_optimizer = unsafe_torch_err!({
+            torch_sys::ato_rms_prop(lr, alpha, eps, wd, momentum, centered as i32)
+        });
         Ok(COptimizer { c_optimizer })
     }
 
-    pub fn sgd(
+    pub(in crate::nn) fn sgd(
         lr: f64,
         momentum: f64,
         dampening: f64,
         wd: f64,
         nesterov: bool,
     ) -> Fallible<COptimizer> {
-        let nesterov = if nesterov { 1 } else { 0 };
         let c_optimizer =
-            unsafe_torch_err!({ torch_sys::ato_sgd(lr, momentum, dampening, wd, nesterov) });
+            unsafe_torch_err!({ torch_sys::ato_sgd(lr, momentum, dampening, wd, nesterov as i32) });
         Ok(COptimizer { c_optimizer })
     }
 
-    pub fn add_parameters(&mut self, ts: &[Tensor]) -> Fallible<()> {
+    pub(in crate::nn) fn add_parameters(&mut self, ts: &[Tensor]) -> Fallible<()> {
         let ts: Vec<_> = ts.iter().map(|x| x.c_tensor).collect();
         unsafe_torch_err!({
             torch_sys::ato_add_parameters(self.c_optimizer, ts.as_ptr(), ts.len() as c_int)
@@ -48,22 +47,22 @@ impl COptimizer {
         Ok(())
     }
 
-    pub fn set_learning_rate(&mut self, lr: f64) -> Fallible<()> {
+    pub(in crate::nn) fn set_learning_rate(&mut self, lr: f64) -> Fallible<()> {
         unsafe_torch_err!({ torch_sys::ato_set_learning_rate(self.c_optimizer, lr) });
         Ok(())
     }
 
-    pub fn set_momentum(&mut self, m: f64) -> Fallible<()> {
+    pub(in crate::nn) fn set_momentum(&mut self, m: f64) -> Fallible<()> {
         unsafe_torch_err!({ torch_sys::ato_set_momentum(self.c_optimizer, m) });
         Ok(())
     }
 
-    pub fn zero_grad(&self) -> Fallible<()> {
+    pub(in crate::nn) fn zero_grad(&self) -> Fallible<()> {
         unsafe_torch_err!({ torch_sys::ato_zero_grad(self.c_optimizer) });
         Ok(())
     }
 
-    pub fn step(&self) -> Fallible<()> {
+    pub(in crate::nn) fn step(&self) -> Fallible<()> {
         unsafe_torch_err!({ torch_sys::ato_step(self.c_optimizer) });
         Ok(())
     }


### PR DESCRIPTION
This PR add the `Optim<Config>` trait so that implementations of different optimizers adhere to a common extensible interface.

@LaurentMazare Please check.