### PR TITLE
Make Tensor must_use

### DIFF
--- a/src/wrappers/tensor.rs
+++ b/src/wrappers/tensor.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 use torch_sys::*;
 
 /// A tensor object.
+#[must_use]
 pub struct Tensor {
     pub(super) c_tensor: *mut C_tensor,
 }


### PR DESCRIPTION
Many methods of `Tensor` return a new `Tensor`; at the moment it's easy to ignore these new `Tensor`s. By making `Tensor` `must_use`, users will get a warning whenever a `Tensor` is left unused.