### PR TITLE
Entry API for VarStore

### DIFF
--- a/src/nn/var_store.rs
+++ b/src/nn/var_store.rs
@@ -33,9 +33,11 @@ pub struct Path<'a> {
     var_store: &'a VarStore,
 }
 
+/// An Entry holds an entry corresponding to a given name in Path.
+#[derive(Debug)]
 pub struct Entry<'a> {
     name: &'a str,
-    variables: MutexGuard<'a, HashMap<String, Variable>>, // Hold the mutex guard
+    variables: MutexGuard<'a, HashMap<String, Variable>>, // This field holds the mutex lock
     path: &'a Path<'a>,
 }
 
@@ -353,6 +355,7 @@ impl<'a> Path<'a> {
         variables.get(&path).map(|v| v.tensor.shallow_clone())
     }
 
+    /// Gets the entry corresponding to a given name for in-place manipulation.
     pub fn entry<'b>(&'b self, name: &'b str) -> Entry<'b> {
         let variables = self.var_store.variables.lock().unwrap();
         Entry {

--- a/tests/var_store.rs
+++ b/tests/var_store.rs
@@ -1,0 +1,16 @@
+use std::thread;
+use tch::{Device, nn::VarStore};
+
+#[test]
+fn var_store_entry() {
+    let vs = VarStore::new(Device::Cpu);
+    let root = vs.root();
+
+    let t1 = root.entry("key")
+        .or_zeros(&[3, 1 , 4]);
+    let t2 = root.entry("key")
+        .or_zeros(&[1, 5 , 9]);
+
+    assert_eq!(t1.size(), &[3, 1, 4]);
+    assert_eq!(t2.size(), &[3, 1, 4]);
+}


### PR DESCRIPTION
This PR continues the work on #48 issue. It aims to to provide entry API for `VarStore` for convenience of reusing named variables. It makes sure the explicit semantics of variable creation and reuse.

The example demonstrates the usage of this API. It builds to models with shared model parameters.
```rust
use tch::nn::Path;

impl MyModel {
    fn new(&self, path: &Path) {
        let embedding = path.entry("embedding").or_zeros(&[3, 4, 5]);  // reuse
        // ...
    }
}

fn main() {
    let vs = VarStore::new(Device::Cpu);
    let root = vs.root();
    let orig_model = MyModel::new(&root);
    let mirror_model = MyModel::new(&root);

    // Do separate work
    // ...
}
```