### PR TITLE
`TryFrom` and `TryInto` for `ndarray` types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ readme = "README.md"
 failure = "0.1"
 lazy_static = "1.3.0"
 libc = "0.2.0"
+ndarray = "0.12"
 rand = "0.6.5"
 torch-sys = { version = "0.1.0", path = "torch-sys" }
 zip = "0.5"

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -455,7 +455,7 @@ where
         // TODO: Replace this with `?` once it works with `std::option::ErrorNone`
         let slice = match value.as_slice() {
             None => failure::bail!("cannot convert to slice"),
-            Some(v) => v
+            Some(v) => v,
         };
         let tn = Self::of_slice(slice);
         let shape: Vec<i64> = value.shape().iter().map(|s| *s as i64).collect();

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -452,7 +452,12 @@ where
     type Error = Fallible<Tensor>;
 
     fn try_from(value: ndarray::Array<f64, D>) -> Result<Self, Self::Error> {
-        let tn = Self::of_slice(value.as_slice().unwrap());
+        // TODO: Replace this with `?` once it works with `std::option::ErrorNone`
+        let slice = match value.as_slice() {
+            None => failure::bail!("cannot convert to slice"),
+            Some(v) => v
+        };
+        let tn = Self::of_slice(slice);
         let shape: Vec<i64> = value.shape().iter().map(|s| *s as i64).collect();
         Ok(tn.reshape(&shape))
     }

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -449,7 +449,7 @@ impl<D> TryFrom<ndarray::Array<f64, D>> for Tensor
 where
     D: ndarray::Dimension,
 {
-    type Error = Fallible<Tensor>;
+    type Error = failure::Error;
 
     fn try_from(value: ndarray::Array<f64, D>) -> Result<Self, Self::Error> {
         // TODO: Replace this with `?` once it works with `std::option::ErrorNone`

--- a/tests/tensor_tests.rs
+++ b/tests/tensor_tests.rs
@@ -1,3 +1,4 @@
+use std::convert::{TryFrom, TryInto};
 use tch::Tensor;
 
 #[test]
@@ -190,4 +191,18 @@ fn values_at_index() {
     assert_eq!(t.double_value(&[]), 42.0);
     assert!(t.f_int64_value(&[0]).is_err());
     assert!(t.f_double_value(&[0]).is_err());
+}
+
+#[test]
+fn into_ndarray() {
+    let tensor = Tensor::of_slice(&[1., 2., 3., 4.]).reshape(&[2, 2]);
+    let nd: ndarray::ArrayD<f64> = (&tensor).try_into().unwrap();
+    assert_eq!(Vec::<f64>::from(tensor).as_slice(), nd.as_slice().unwrap());
+}
+
+#[test]
+fn from_ndarray() {
+    let nd = ndarray::arr2(&[[1f64, 2.], [3., 4.]]);
+    let tensor = Tensor::try_from(nd.clone()).unwrap();
+    assert_eq!(Vec::<f64>::from(tensor).as_slice(), nd.as_slice().unwrap());
 }

--- a/tests/tensor_tests.rs
+++ b/tests/tensor_tests.rs
@@ -194,15 +194,29 @@ fn values_at_index() {
 }
 
 #[test]
-fn into_ndarray() {
+fn into_ndarray_f64() {
     let tensor = Tensor::of_slice(&[1., 2., 3., 4.]).reshape(&[2, 2]);
     let nd: ndarray::ArrayD<f64> = (&tensor).try_into().unwrap();
     assert_eq!(Vec::<f64>::from(tensor).as_slice(), nd.as_slice().unwrap());
 }
 
 #[test]
-fn from_ndarray() {
+fn into_ndarray_i64() {
+    let tensor = Tensor::of_slice(&[1, 2, 3, 4]).reshape(&[2, 2]);
+    let nd: ndarray::ArrayD<i64> = (&tensor).try_into().unwrap();
+    assert_eq!(Vec::<i64>::from(tensor).as_slice(), nd.as_slice().unwrap());
+}
+
+#[test]
+fn from_ndarray_f64() {
     let nd = ndarray::arr2(&[[1f64, 2.], [3., 4.]]);
     let tensor = Tensor::try_from(nd.clone()).unwrap();
     assert_eq!(Vec::<f64>::from(tensor).as_slice(), nd.as_slice().unwrap());
+}
+
+#[test]
+fn from_ndarray_i64() {
+    let nd = ndarray::arr2(&[[1i64, 2], [3, 4]]);
+    let tensor = Tensor::try_from(nd.clone()).unwrap();
+    assert_eq!(Vec::<i64>::from(tensor).as_slice(), nd.as_slice().unwrap());
 }


### PR DESCRIPTION
This is a first implementation of #52. There still is an `unwrap()` in the `try_from` function which we should get rid of. Unfortunately, `?` does not seem to work with `std::option::NoneError` yet.

@LaurentMazare Do you have an idea how to fix this?