### PR TITLE
Fix some warnings in `examples/translation`

### DIFF
--- a/examples/translation/lang.rs
+++ b/examples/translation/lang.rs
@@ -39,7 +39,7 @@ impl Lang {
     }
 
     pub fn add_sentence(&mut self, sentence: &str) {
-        for word in sentence.split_whitespace() {
+        for _word in sentence.split_whitespace() {
             self.add_word(sentence);
         }
     }
@@ -62,9 +62,5 @@ impl Lang {
 
     pub fn get_index(&self, word: &str) -> Option<usize> {
         self.word_to_index_and_count.get(word).map(|x| x.0)
-    }
-
-    pub fn get_word(&self, index: usize) -> &str {
-        &self.index_to_word.get(&index).unwrap()
     }
 }

--- a/examples/translation/main.rs
+++ b/examples/translation/main.rs
@@ -170,7 +170,7 @@ pub fn main() -> failure::Fallible<()> {
     let vs = nn::VarStore::new(device);
     let model = Model::new(vs.root(), &ilang, &olang, HIDDEN_SIZE);
     let opt = nn::Adam::default().build(&vs, LEARNING_RATE)?;
-    for idx in 1..=SAMPLES {
+    for _idx in 1..=SAMPLES {
         let (input_, target) = pairs.choose(&mut rng).unwrap();
         let loss = model.train_loss(&input_, &target);
         opt.backward_step(&loss)


### PR DESCRIPTION
These were some unused function and variable warnings.