### PR TITLE
Basic tensor indexing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,16 @@ pub use wrappers::manual_seed;
 pub use wrappers::scalar::Scalar;
 
 mod tensor;
-pub use tensor::{no_grad, no_grad_guard, NoGradGuard, Reduction, Tensor};
+pub use tensor::{
+    no_grad,
+    no_grad_guard,
+    NoGradGuard,
+    Reduction,
+    Tensor,
+    TensorIndexer,
+    NewAxis,
+    IndexOp,
+};
 
 pub mod nn;
 pub mod vision;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,14 +17,7 @@ pub use wrappers::scalar::Scalar;
 
 mod tensor;
 pub use tensor::{
-    no_grad,
-    no_grad_guard,
-    NoGradGuard,
-    Reduction,
-    Tensor,
-    TensorIndexer,
-    NewAxis,
-    IndexOp,
+    no_grad, no_grad_guard, IndexOp, NewAxis, NoGradGuard, Reduction, Tensor, TensorIndexer,
 };
 
 pub mod nn;

--- a/src/tensor/index.rs
+++ b/src/tensor/index.rs
@@ -8,12 +8,12 @@ use std::ops::{
     RangeToInclusive,
     Bound,
 };
-use super::Tensor;
+use crate::Tensor;
 
-// https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html
-
+#[derive(Debug, PartialEq)]
 pub struct NewAxis;
 
+#[derive(Debug, PartialEq)]
 pub enum TensorIndexer {
     Select(i64),
     Narrow(Bound<i64>, Bound<i64>),
@@ -110,7 +110,7 @@ impl_from_range!(RangeInclusive<i64>);
 impl_from_range!(RangeTo<i64>);
 impl_from_range!(RangeToInclusive<i64>);
 
-trait IndexOp<T> {
+pub trait IndexOp<T> {
     fn i(&self, index: T) -> Tensor;
 }
 

--- a/src/tensor/index.rs
+++ b/src/tensor/index.rs
@@ -40,6 +40,13 @@ impl From<&[i64]> for TensorIndexer {
     }
 }
 
+impl From<Vec<i64>> for TensorIndexer {
+    fn from(index: Vec<i64>) -> Self {
+        let tensor = Tensor::of_slice(&index);
+        TensorIndexer::IndexSelect(tensor)
+    }
+}
+
 impl From<&Tensor> for TensorIndexer {
     fn from(tensor: &Tensor) -> Self {
         use super::Kind::*;
@@ -199,6 +206,27 @@ impl<A, B, C, D, E, F> IndexOp<(A, B, C, D, E, F)> for Tensor where
     }
 }
 
+impl<A, B, C, D, E, F, G> IndexOp<(A, B, C, D, E, F, G)> for Tensor where
+    A: Into<TensorIndexer>,
+    B: Into<TensorIndexer>,
+    C: Into<TensorIndexer>,
+    D: Into<TensorIndexer>,
+    E: Into<TensorIndexer>,
+    F: Into<TensorIndexer>,
+    G: Into<TensorIndexer>,
+{
+    fn i(&self, index: (A, B, C, D, E, F, G)) -> Tensor {
+        let a = index.0.into();
+        let b = index.1.into();
+        let c = index.2.into();
+        let d = index.3.into();
+        let e = index.4.into();
+        let f = index.5.into();
+        let g = index.6.into();
+        self.indexer(&[a, b, c, d, e, f, g])
+    }
+}
+
 impl Tensor {
     fn indexer(&self, index_spec: &[TensorIndexer]) -> Tensor {
         use std::ops::Bound::*;
@@ -222,6 +250,7 @@ impl Tensor {
             format!("too many indices for tensor of dimension {}", self.size().len())
         );
 
+        // Apply indexing from left to right
         let mut curr_tensor = self.shallow_clone();
         let mut curr_idx: i64 = 0;
 

--- a/src/tensor/index.rs
+++ b/src/tensor/index.rs
@@ -1,0 +1,266 @@
+use std::ops::{
+    RangeBounds,
+    Range,
+    RangeFrom,
+    RangeFull,
+    RangeInclusive,
+    RangeTo,
+    RangeToInclusive,
+    Bound,
+};
+use super::Tensor;
+use failure::Fallible;
+
+pub enum TensorIndexer<'a> {
+    Select(i64),
+    IndexSelect(&'a [i64]),
+    MaskedSelect(&'a [bool]),
+    TensorSelect(&'a Tensor),
+    Narrow(Bound<i64>, Bound<i64>),
+}
+
+impl<'a> From<i64> for TensorIndexer<'a> {
+    fn from(index: i64) -> Self {
+        TensorIndexer::Select(index)
+    }
+}
+
+impl<'a> From<&'a [i64]> for TensorIndexer<'a> {
+    fn from(indexes: &'a [i64]) -> Self {
+        TensorIndexer::IndexSelect(indexes)
+    }
+}
+
+macro_rules! impl_from_range {
+    ($range_type:ty) => {
+        impl<'a> From<$range_type> for TensorIndexer<'a> {
+            fn from(range: $range_type) -> Self {
+                use std::ops::Bound::*;
+
+                let start = match range.start_bound() {
+                    Included(idx) => Included(*idx),
+                    Excluded(idx) => Excluded(*idx),
+                    Unbounded => Unbounded,
+                };
+
+                let end = match range.end_bound() {
+                    Included(idx) => Included(*idx),
+                    Excluded(idx) => Excluded(*idx),
+                    Unbounded => Unbounded,
+                };
+
+                TensorIndexer::Narrow(start, end)
+            }
+        }
+    }
+}
+
+impl_from_range!(Range<i64>);
+impl_from_range!(RangeFrom<i64>);
+impl_from_range!(RangeFull);
+impl_from_range!(RangeInclusive<i64>);
+impl_from_range!(RangeTo<i64>);
+impl_from_range!(RangeToInclusive<i64>);
+
+impl Tensor {
+    fn indexer<'a>(&self, index_spec: &[TensorIndexer<'a>]) -> Tensor {
+        use std::ops::Bound::*;
+        use TensorIndexer::*;
+
+        assert!(
+            index_spec.len() <= self.size().len(),
+            format!("too many indices for tensor of dimension {}", self.size().len())
+        );
+
+        let mut result_tensor = self.shallow_clone();
+        let mut result_dim: i64 = 0;
+
+        for (index_dim, spec) in index_spec.iter().enumerate() {
+            let dim_len = result_tensor.size()[result_dim as usize] as i64;
+
+            let (next_tensor, next_dim) = match spec {
+                Select(index) => {
+                    (result_tensor.select(result_dim, *index), result_dim)
+                }
+                IndexSelect(indexes) => {
+                    let index_tensor = Tensor::of_slice(indexes);
+                    (
+                        result_tensor.index_select(result_dim, &index_tensor),
+                        result_dim + 1,
+                    )
+                }
+                MaskedSelect(mask) => {
+                    assert!(
+                        mask.len() as i64 == dim_len,
+                        format!("The length of the mask [{}] does not match the shape of the indexed tensor {:?} at index {}", mask.len(), self.size(), index_dim),
+                    );
+
+                    let mut indexes = vec![];
+                    for (idx, selected) in mask.iter().enumerate() {
+                        if *selected {
+                            indexes.push(idx as i64);
+                        }
+                    }
+                    let index_tensor = Tensor::of_slice(&indexes);
+                    (
+                        result_tensor.index_select(result_dim, &index_tensor),
+                        result_dim + 1,
+                    )
+                }
+                TensorSelect(tensor) => {
+                    use super::Kind::*;
+
+                    match tensor.kind() {
+                        Int64 => { // index select
+                            // TODO
+                        }
+                        Uint8 => { // masked select
+                            // TODO
+                        }
+                        _ => {
+                            panic!("the kind of tensors used as indices must be {:?} or {:?}", Int64, Uint8);
+                        }
+                    }
+                }
+                Narrow(Unbounded, Unbounded) => (
+                    result_tensor,
+                    result_dim + 1,
+                ),
+                Narrow(Included(start), Unbounded) => (
+                    result_tensor.narrow(result_dim, *start, dim_len - *start),
+                    result_dim + 1,
+                ),
+                Narrow(Excluded(start), Unbounded) => (
+                    result_tensor.narrow(result_dim, *start + 1, dim_len - *start - 1),
+                    result_dim + 1,
+                ),
+                Narrow(Unbounded, Included(end)) => (
+                    result_tensor.narrow(result_dim, 0, *end + 1),
+                    result_dim + 1,
+                ),
+                Narrow(Unbounded, Excluded(end)) => (
+                    result_tensor.narrow(result_dim, 0, *end),
+                    result_dim + 1,
+                ),
+                Narrow(Included(start), Included(end)) => (
+                    result_tensor.narrow(result_dim, *start, *end - *start + 1),
+                    result_dim + 1,
+                ),
+                Narrow(Included(start), Excluded(end)) => (
+                    result_tensor.narrow(result_dim, *start, *end - *start),
+                    result_dim + 1,
+                ),
+                Narrow(Excluded(start), Included(end)) => (
+                    result_tensor.narrow(result_dim, *start + 1, *end - *start),
+                    result_dim + 1,
+                ),
+                Narrow(Excluded(start), Excluded(end)) => (
+                    result_tensor.narrow(result_dim, *start + 1, *end - *start - 1),
+                    result_dim + 1,
+                ),
+            };
+
+            result_tensor = next_tensor;
+            result_dim = next_dim;
+        }
+
+        result_tensor
+    }
+}
+
+trait IndexOp<T> {
+    fn i(&self, index: T) -> Tensor;
+}
+
+
+impl<'a, A> IndexOp<A> for Tensor where
+    A: Into<TensorIndexer<'a>>,
+{
+    fn i(&self, index: A) -> Tensor {
+        self.indexer(&[index.into()])
+    }
+}
+
+impl<'a, A> IndexOp<(A,)> for Tensor where
+    A: Into<TensorIndexer<'a>>,
+{
+    fn i(&self, index: (A,)) -> Tensor {
+        let a = index.0.into();
+        self.indexer(&[a])
+    }
+}
+
+impl<'a, 'b, A, B> IndexOp<(A, B)> for Tensor where
+        A: Into<TensorIndexer<'a>>,
+        B: Into<TensorIndexer<'b>>,
+{
+    fn i(&self, index: (A, B)) -> Tensor {
+        let a = index.0.into();
+        let b = index.1.into();
+        self.indexer(&[a, b])
+    }
+}
+
+impl<'a, 'b, 'c, A, B, C> IndexOp<(A, B, C)> for Tensor where
+        A: Into<TensorIndexer<'a>>,
+        B: Into<TensorIndexer<'b>>,
+        C: Into<TensorIndexer<'c>>,
+{
+    fn i(&self, index: (A, B, C)) -> Tensor {
+        let a = index.0.into();
+        let b = index.1.into();
+        let c = index.2.into();
+        self.indexer(&[a, b, c])
+    }
+}
+
+impl<'a, 'b, 'c, 'd, A, B, C, D> IndexOp<(A, B, C, D)> for Tensor where
+        A: Into<TensorIndexer<'a>>,
+        B: Into<TensorIndexer<'b>>,
+        C: Into<TensorIndexer<'c>>,
+        D: Into<TensorIndexer<'d>>,
+{
+    fn i(&self, index: (A, B, C, D)) -> Tensor {
+        let a = index.0.into();
+        let b = index.1.into();
+        let c = index.2.into();
+        let d = index.3.into();
+        self.indexer(&[a, b, c, d])
+    }
+}
+
+impl<'a, 'b, 'c, 'd, 'e, A, B, C, D, E> IndexOp<(A, B, C, D, E)> for Tensor where
+        A: Into<TensorIndexer<'a>>,
+        B: Into<TensorIndexer<'b>>,
+        C: Into<TensorIndexer<'c>>,
+        D: Into<TensorIndexer<'d>>,
+        E: Into<TensorIndexer<'e>>,
+{
+    fn i(&self, index: (A, B, C, D, E)) -> Tensor {
+        let a = index.0.into();
+        let b = index.1.into();
+        let c = index.2.into();
+        let d = index.3.into();
+        let e = index.4.into();
+        self.indexer(&[a, b, c, d, e])
+    }
+}
+
+impl<'a, 'b, 'c, 'd, 'e, 'f, A, B, C, D, E, F> IndexOp<(A, B, C, D, E, F)> for Tensor where
+        A: Into<TensorIndexer<'a>>,
+        B: Into<TensorIndexer<'b>>,
+        C: Into<TensorIndexer<'c>>,
+        D: Into<TensorIndexer<'d>>,
+        E: Into<TensorIndexer<'e>>,
+        F: Into<TensorIndexer<'f>>,
+{
+    fn i(&self, index: (A, B, C, D, E, F)) -> Tensor {
+        let a = index.0.into();
+        let b = index.1.into();
+        let c = index.2.into();
+        let d = index.3.into();
+        let e = index.4.into();
+        let f = index.5.into();
+        self.indexer(&[a, b, c, d, e, f])
+    }
+}

--- a/src/tensor/index.rs
+++ b/src/tensor/index.rs
@@ -9,31 +9,72 @@ use std::ops::{
     Bound,
 };
 use super::Tensor;
-use failure::Fallible;
 
-pub enum TensorIndexer<'a> {
+// https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html
+
+pub struct NewAxis;
+
+pub enum TensorIndexer {
     Select(i64),
-    IndexSelect(&'a [i64]),
-    MaskedSelect(&'a [bool]),
-    TensorSelect(&'a Tensor),
     Narrow(Bound<i64>, Bound<i64>),
+    IndexSelect(Tensor),
+    InsertNewAxis,
 }
 
-impl<'a> From<i64> for TensorIndexer<'a> {
+impl From<NewAxis> for TensorIndexer {
+    fn from(_index: NewAxis) -> Self {
+        TensorIndexer::InsertNewAxis
+    }
+}
+
+impl From<i64> for TensorIndexer {
     fn from(index: i64) -> Self {
         TensorIndexer::Select(index)
     }
 }
 
-impl<'a> From<&'a [i64]> for TensorIndexer<'a> {
-    fn from(indexes: &'a [i64]) -> Self {
-        TensorIndexer::IndexSelect(indexes)
+impl From<&[i64]> for TensorIndexer {
+    fn from(index: &[i64]) -> Self {
+        let tensor = index.into();
+        TensorIndexer::IndexSelect(tensor)
+    }
+}
+
+impl From<&Tensor> for TensorIndexer {
+    fn from(tensor: &Tensor) -> Self {
+        use super::Kind::*;
+
+        assert!(
+            tensor.size().len() == 1,
+            "Multi-dimensional tensor is not supported for indexing",
+        );
+
+        match tensor.kind() {
+            Int64 =>
+                TensorIndexer::IndexSelect(tensor.shallow_clone()),
+            Int16 =>
+                TensorIndexer::IndexSelect(tensor.shallow_clone()),
+            Int8 =>
+                TensorIndexer::IndexSelect(tensor.shallow_clone()),
+            Int =>
+                TensorIndexer::IndexSelect(tensor.shallow_clone()),
+            _ => {
+                panic!(
+                    "the kind of tensors used as indices must be one of {:?}, {:?}, {:?}, {:?}",
+                    Int64,
+                    Int16,
+                    Int8,
+                    Int,
+                );
+            }
+        }
+
     }
 }
 
 macro_rules! impl_from_range {
     ($range_type:ty) => {
-        impl<'a> From<$range_type> for TensorIndexer<'a> {
+        impl From<$range_type> for TensorIndexer {
             fn from(range: $range_type) -> Self {
                 use std::ops::Bound::*;
 
@@ -62,127 +103,20 @@ impl_from_range!(RangeInclusive<i64>);
 impl_from_range!(RangeTo<i64>);
 impl_from_range!(RangeToInclusive<i64>);
 
-impl Tensor {
-    fn indexer<'a>(&self, index_spec: &[TensorIndexer<'a>]) -> Tensor {
-        use std::ops::Bound::*;
-        use TensorIndexer::*;
-
-        assert!(
-            index_spec.len() <= self.size().len(),
-            format!("too many indices for tensor of dimension {}", self.size().len())
-        );
-
-        let mut result_tensor = self.shallow_clone();
-        let mut result_dim: i64 = 0;
-
-        for (index_dim, spec) in index_spec.iter().enumerate() {
-            let dim_len = result_tensor.size()[result_dim as usize] as i64;
-
-            let (next_tensor, next_dim) = match spec {
-                Select(index) => {
-                    (result_tensor.select(result_dim, *index), result_dim)
-                }
-                IndexSelect(indexes) => {
-                    let index_tensor = Tensor::of_slice(indexes);
-                    (
-                        result_tensor.index_select(result_dim, &index_tensor),
-                        result_dim + 1,
-                    )
-                }
-                MaskedSelect(mask) => {
-                    assert!(
-                        mask.len() as i64 == dim_len,
-                        format!("The length of the mask [{}] does not match the shape of the indexed tensor {:?} at index {}", mask.len(), self.size(), index_dim),
-                    );
-
-                    let mut indexes = vec![];
-                    for (idx, selected) in mask.iter().enumerate() {
-                        if *selected {
-                            indexes.push(idx as i64);
-                        }
-                    }
-                    let index_tensor = Tensor::of_slice(&indexes);
-                    (
-                        result_tensor.index_select(result_dim, &index_tensor),
-                        result_dim + 1,
-                    )
-                }
-                TensorSelect(tensor) => {
-                    use super::Kind::*;
-
-                    match tensor.kind() {
-                        Int64 => { // index select
-                            // TODO
-                        }
-                        Uint8 => { // masked select
-                            // TODO
-                        }
-                        _ => {
-                            panic!("the kind of tensors used as indices must be {:?} or {:?}", Int64, Uint8);
-                        }
-                    }
-                }
-                Narrow(Unbounded, Unbounded) => (
-                    result_tensor,
-                    result_dim + 1,
-                ),
-                Narrow(Included(start), Unbounded) => (
-                    result_tensor.narrow(result_dim, *start, dim_len - *start),
-                    result_dim + 1,
-                ),
-                Narrow(Excluded(start), Unbounded) => (
-                    result_tensor.narrow(result_dim, *start + 1, dim_len - *start - 1),
-                    result_dim + 1,
-                ),
-                Narrow(Unbounded, Included(end)) => (
-                    result_tensor.narrow(result_dim, 0, *end + 1),
-                    result_dim + 1,
-                ),
-                Narrow(Unbounded, Excluded(end)) => (
-                    result_tensor.narrow(result_dim, 0, *end),
-                    result_dim + 1,
-                ),
-                Narrow(Included(start), Included(end)) => (
-                    result_tensor.narrow(result_dim, *start, *end - *start + 1),
-                    result_dim + 1,
-                ),
-                Narrow(Included(start), Excluded(end)) => (
-                    result_tensor.narrow(result_dim, *start, *end - *start),
-                    result_dim + 1,
-                ),
-                Narrow(Excluded(start), Included(end)) => (
-                    result_tensor.narrow(result_dim, *start + 1, *end - *start),
-                    result_dim + 1,
-                ),
-                Narrow(Excluded(start), Excluded(end)) => (
-                    result_tensor.narrow(result_dim, *start + 1, *end - *start - 1),
-                    result_dim + 1,
-                ),
-            };
-
-            result_tensor = next_tensor;
-            result_dim = next_dim;
-        }
-
-        result_tensor
-    }
-}
-
 trait IndexOp<T> {
     fn i(&self, index: T) -> Tensor;
 }
 
-
-impl<'a, A> IndexOp<A> for Tensor where
-    A: Into<TensorIndexer<'a>>,
+impl<A> IndexOp<A> for Tensor where
+    A: Into<TensorIndexer>,
 {
     fn i(&self, index: A) -> Tensor {
         self.indexer(&[index.into()])
     }
 }
 
-impl<'a, A> IndexOp<(A,)> for Tensor where
-    A: Into<TensorIndexer<'a>>,
+impl<A> IndexOp<(A,)> for Tensor where
+    A: Into<TensorIndexer>,
 {
     fn i(&self, index: (A,)) -> Tensor {
         let a = index.0.into();
@@ -190,9 +124,9 @@ impl<'a, A> IndexOp<(A,)> for Tensor where
     }
 }
 
-impl<'a, 'b, A, B> IndexOp<(A, B)> for Tensor where
-        A: Into<TensorIndexer<'a>>,
-        B: Into<TensorIndexer<'b>>,
+impl<A, B> IndexOp<(A, B)> for Tensor where
+    A: Into<TensorIndexer>,
+    B: Into<TensorIndexer>,
 {
     fn i(&self, index: (A, B)) -> Tensor {
         let a = index.0.into();
@@ -201,10 +135,10 @@ impl<'a, 'b, A, B> IndexOp<(A, B)> for Tensor where
     }
 }
 
-impl<'a, 'b, 'c, A, B, C> IndexOp<(A, B, C)> for Tensor where
-        A: Into<TensorIndexer<'a>>,
-        B: Into<TensorIndexer<'b>>,
-        C: Into<TensorIndexer<'c>>,
+impl<A, B, C> IndexOp<(A, B, C)> for Tensor where
+    A: Into<TensorIndexer>,
+    B: Into<TensorIndexer>,
+    C: Into<TensorIndexer>,
 {
     fn i(&self, index: (A, B, C)) -> Tensor {
         let a = index.0.into();
@@ -214,11 +148,11 @@ impl<'a, 'b, 'c, A, B, C> IndexOp<(A, B, C)> for Tensor where
     }
 }
 
-impl<'a, 'b, 'c, 'd, A, B, C, D> IndexOp<(A, B, C, D)> for Tensor where
-        A: Into<TensorIndexer<'a>>,
-        B: Into<TensorIndexer<'b>>,
-        C: Into<TensorIndexer<'c>>,
-        D: Into<TensorIndexer<'d>>,
+impl<A, B, C, D> IndexOp<(A, B, C, D)> for Tensor where
+    A: Into<TensorIndexer>,
+    B: Into<TensorIndexer>,
+    C: Into<TensorIndexer>,
+    D: Into<TensorIndexer>,
 {
     fn i(&self, index: (A, B, C, D)) -> Tensor {
         let a = index.0.into();
@@ -229,12 +163,12 @@ impl<'a, 'b, 'c, 'd, A, B, C, D> IndexOp<(A, B, C, D)> for Tensor where
     }
 }
 
-impl<'a, 'b, 'c, 'd, 'e, A, B, C, D, E> IndexOp<(A, B, C, D, E)> for Tensor where
-        A: Into<TensorIndexer<'a>>,
-        B: Into<TensorIndexer<'b>>,
-        C: Into<TensorIndexer<'c>>,
-        D: Into<TensorIndexer<'d>>,
-        E: Into<TensorIndexer<'e>>,
+impl<A, B, C, D, E> IndexOp<(A, B, C, D, E)> for Tensor where
+    A: Into<TensorIndexer>,
+    B: Into<TensorIndexer>,
+    C: Into<TensorIndexer>,
+    D: Into<TensorIndexer>,
+    E: Into<TensorIndexer>,
 {
     fn i(&self, index: (A, B, C, D, E)) -> Tensor {
         let a = index.0.into();
@@ -246,13 +180,13 @@ impl<'a, 'b, 'c, 'd, 'e, A, B, C, D, E> IndexOp<(A, B, C, D, E)> for Tensor wher
     }
 }
 
-impl<'a, 'b, 'c, 'd, 'e, 'f, A, B, C, D, E, F> IndexOp<(A, B, C, D, E, F)> for Tensor where
-        A: Into<TensorIndexer<'a>>,
-        B: Into<TensorIndexer<'b>>,
-        C: Into<TensorIndexer<'c>>,
-        D: Into<TensorIndexer<'d>>,
-        E: Into<TensorIndexer<'e>>,
-        F: Into<TensorIndexer<'f>>,
+impl<A, B, C, D, E, F> IndexOp<(A, B, C, D, E, F)> for Tensor where
+    A: Into<TensorIndexer>,
+    B: Into<TensorIndexer>,
+    C: Into<TensorIndexer>,
+    D: Into<TensorIndexer>,
+    E: Into<TensorIndexer>,
+    F: Into<TensorIndexer>,
 {
     fn i(&self, index: (A, B, C, D, E, F)) -> Tensor {
         let a = index.0.into();
@@ -262,5 +196,80 @@ impl<'a, 'b, 'c, 'd, 'e, 'f, A, B, C, D, E, F> IndexOp<(A, B, C, D, E, F)> for T
         let e = index.4.into();
         let f = index.5.into();
         self.indexer(&[a, b, c, d, e, f])
+    }
+}
+
+impl Tensor {
+    fn indexer(&self, index_spec: &[TensorIndexer]) -> Tensor {
+        use std::ops::Bound::*;
+        use TensorIndexer::*;
+
+        assert!(
+            index_spec.len() <= self.size().len(),
+            format!("too many indices for tensor of dimension {}", self.size().len())
+        );
+
+        let mut curr_tensor = self.shallow_clone();
+        let mut curr_idx: i64 = 0;
+
+        for (_spec_idx, spec) in index_spec.iter().enumerate() {
+            let dim_len = curr_tensor.size()[curr_idx as usize] as i64;
+
+            let (next_tensor, next_idx) = match spec {
+                InsertNewAxis => (
+                    curr_tensor.unsqueeze(curr_idx),
+                    curr_idx + 1,
+                ),
+                Select(index) => (
+                    curr_tensor.select(curr_idx, *index),
+                    curr_idx,  // curr_idx is not advanced because select() sequeezes dimension
+                ),
+                Narrow(Unbounded, Unbounded) => (
+                    curr_tensor,
+                    curr_idx + 1,
+                ),
+                Narrow(Included(start), Unbounded) => (
+                    curr_tensor.narrow(curr_idx, *start, dim_len - *start),
+                    curr_idx + 1,
+                ),
+                Narrow(Excluded(start), Unbounded) => (
+                    curr_tensor.narrow(curr_idx, *start + 1, dim_len - *start - 1),
+                    curr_idx + 1,
+                ),
+                Narrow(Unbounded, Included(end)) => (
+                    curr_tensor.narrow(curr_idx, 0, *end + 1),
+                    curr_idx + 1,
+                ),
+                Narrow(Unbounded, Excluded(end)) => (
+                    curr_tensor.narrow(curr_idx, 0, *end),
+                    curr_idx + 1,
+                ),
+                Narrow(Included(start), Included(end)) => (
+                    curr_tensor.narrow(curr_idx, *start, *end - *start + 1),
+                    curr_idx + 1,
+                ),
+                Narrow(Included(start), Excluded(end)) => (
+                    curr_tensor.narrow(curr_idx, *start, *end - *start),
+                    curr_idx + 1,
+                ),
+                Narrow(Excluded(start), Included(end)) => (
+                    curr_tensor.narrow(curr_idx, *start + 1, *end - *start),
+                    curr_idx + 1,
+                ),
+                Narrow(Excluded(start), Excluded(end)) => (
+                    curr_tensor.narrow(curr_idx, *start + 1, *end - *start - 1),
+                    curr_idx + 1,
+                ),
+                IndexSelect(index_tensor) => (
+                    curr_tensor.index_select(curr_idx, index_tensor),
+                    curr_idx + 1,
+                )
+            };
+
+            curr_tensor = next_tensor;
+            curr_idx = next_idx;
+        }
+
+        curr_tensor
     }
 }

--- a/src/tensor/index.rs
+++ b/src/tensor/index.rs
@@ -1,14 +1,7 @@
-use std::ops::{
-    RangeBounds,
-    Range,
-    RangeFrom,
-    RangeFull,
-    RangeInclusive,
-    RangeTo,
-    RangeToInclusive,
-    Bound,
-};
 use crate::Tensor;
+use std::ops::{
+    Bound, Range, RangeBounds, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive,
+};
 
 #[derive(Debug, PartialEq)]
 pub struct NewAxis;
@@ -57,25 +50,17 @@ impl From<&Tensor> for TensorIndexer {
         );
 
         match tensor.kind() {
-            Int64 =>
-                TensorIndexer::IndexSelect(tensor.shallow_clone()),
-            Int16 =>
-                TensorIndexer::IndexSelect(tensor.shallow_clone()),
-            Int8 =>
-                TensorIndexer::IndexSelect(tensor.shallow_clone()),
-            Int =>
-                TensorIndexer::IndexSelect(tensor.shallow_clone()),
+            Int64 => TensorIndexer::IndexSelect(tensor.shallow_clone()),
+            Int16 => TensorIndexer::IndexSelect(tensor.shallow_clone()),
+            Int8 => TensorIndexer::IndexSelect(tensor.shallow_clone()),
+            Int => TensorIndexer::IndexSelect(tensor.shallow_clone()),
             _ => {
                 panic!(
                     "the kind of tensors used as indices must be one of {:?}, {:?}, {:?}, {:?}",
-                    Int64,
-                    Int16,
-                    Int8,
-                    Int,
+                    Int64, Int16, Int8, Int,
                 );
             }
         }
-
     }
 }
 
@@ -100,7 +85,7 @@ macro_rules! impl_from_range {
                 TensorIndexer::Narrow(start, end)
             }
         }
-    }
+    };
 }
 
 impl_from_range!(Range<i64>);
@@ -114,7 +99,8 @@ pub trait IndexOp<T> {
     fn i(&self, index: T) -> Tensor;
 }
 
-impl<A> IndexOp<A> for Tensor where
+impl<A> IndexOp<A> for Tensor
+where
     A: Into<TensorIndexer>,
 {
     fn i(&self, index: A) -> Tensor {
@@ -122,7 +108,8 @@ impl<A> IndexOp<A> for Tensor where
     }
 }
 
-impl<A> IndexOp<(A,)> for Tensor where
+impl<A> IndexOp<(A,)> for Tensor
+where
     A: Into<TensorIndexer>,
 {
     fn i(&self, index: (A,)) -> Tensor {
@@ -131,7 +118,8 @@ impl<A> IndexOp<(A,)> for Tensor where
     }
 }
 
-impl<A, B> IndexOp<(A, B)> for Tensor where
+impl<A, B> IndexOp<(A, B)> for Tensor
+where
     A: Into<TensorIndexer>,
     B: Into<TensorIndexer>,
 {
@@ -142,7 +130,8 @@ impl<A, B> IndexOp<(A, B)> for Tensor where
     }
 }
 
-impl<A, B, C> IndexOp<(A, B, C)> for Tensor where
+impl<A, B, C> IndexOp<(A, B, C)> for Tensor
+where
     A: Into<TensorIndexer>,
     B: Into<TensorIndexer>,
     C: Into<TensorIndexer>,
@@ -155,7 +144,8 @@ impl<A, B, C> IndexOp<(A, B, C)> for Tensor where
     }
 }
 
-impl<A, B, C, D> IndexOp<(A, B, C, D)> for Tensor where
+impl<A, B, C, D> IndexOp<(A, B, C, D)> for Tensor
+where
     A: Into<TensorIndexer>,
     B: Into<TensorIndexer>,
     C: Into<TensorIndexer>,
@@ -170,7 +160,8 @@ impl<A, B, C, D> IndexOp<(A, B, C, D)> for Tensor where
     }
 }
 
-impl<A, B, C, D, E> IndexOp<(A, B, C, D, E)> for Tensor where
+impl<A, B, C, D, E> IndexOp<(A, B, C, D, E)> for Tensor
+where
     A: Into<TensorIndexer>,
     B: Into<TensorIndexer>,
     C: Into<TensorIndexer>,
@@ -187,7 +178,8 @@ impl<A, B, C, D, E> IndexOp<(A, B, C, D, E)> for Tensor where
     }
 }
 
-impl<A, B, C, D, E, F> IndexOp<(A, B, C, D, E, F)> for Tensor where
+impl<A, B, C, D, E, F> IndexOp<(A, B, C, D, E, F)> for Tensor
+where
     A: Into<TensorIndexer>,
     B: Into<TensorIndexer>,
     C: Into<TensorIndexer>,
@@ -206,7 +198,8 @@ impl<A, B, C, D, E, F> IndexOp<(A, B, C, D, E, F)> for Tensor where
     }
 }
 
-impl<A, B, C, D, E, F, G> IndexOp<(A, B, C, D, E, F, G)> for Tensor where
+impl<A, B, C, D, E, F, G> IndexOp<(A, B, C, D, E, F, G)> for Tensor
+where
     A: Into<TensorIndexer>,
     B: Into<TensorIndexer>,
     C: Into<TensorIndexer>,
@@ -233,21 +226,19 @@ impl Tensor {
         use TensorIndexer::*;
 
         // Make sure n. non-newaxis does not exceed n. of dimensions
-        let n_newaxis = index_spec
-            .iter()
-            .fold(
-                0,
-                |mut count, spec| {
-                    if spec == &InsertNewAxis {
-                        count += 1
-                    }
-                    count
-                }
-            );
+        let n_newaxis = index_spec.iter().fold(0, |mut count, spec| {
+            if spec == &InsertNewAxis {
+                count += 1
+            }
+            count
+        });
 
         assert!(
             index_spec.len() <= self.size().len() + n_newaxis,
-            format!("too many indices for tensor of dimension {}", self.size().len())
+            format!(
+                "too many indices for tensor of dimension {}",
+                self.size().len()
+            )
         );
 
         // Apply indexing from left to right
@@ -256,18 +247,12 @@ impl Tensor {
 
         for (_spec_idx, spec) in index_spec.iter().enumerate() {
             let (next_tensor, next_idx) = match spec {
-                InsertNewAxis => (
-                    curr_tensor.unsqueeze(curr_idx),
-                    curr_idx + 1,
-                ),
+                InsertNewAxis => (curr_tensor.unsqueeze(curr_idx), curr_idx + 1),
                 Select(index) => (
                     curr_tensor.select(curr_idx, *index),
-                    curr_idx,  // not advanced because select() sequeezes dimension
+                    curr_idx, // not advanced because select() sequeezes dimension
                 ),
-                Narrow(Unbounded, Unbounded) => (
-                    curr_tensor,
-                    curr_idx + 1,
-                ),
+                Narrow(Unbounded, Unbounded) => (curr_tensor, curr_idx + 1),
                 Narrow(Included(start), Unbounded) => {
                     let dim_len = curr_tensor.size()[curr_idx as usize] as i64;
                     (
@@ -282,14 +267,12 @@ impl Tensor {
                         curr_idx + 1,
                     )
                 }
-                Narrow(Unbounded, Included(end)) => (
-                    curr_tensor.narrow(curr_idx, 0, *end + 1),
-                    curr_idx + 1,
-                ),
-                Narrow(Unbounded, Excluded(end)) => (
-                    curr_tensor.narrow(curr_idx, 0, *end),
-                    curr_idx + 1,
-                ),
+                Narrow(Unbounded, Included(end)) => {
+                    (curr_tensor.narrow(curr_idx, 0, *end + 1), curr_idx + 1)
+                }
+                Narrow(Unbounded, Excluded(end)) => {
+                    (curr_tensor.narrow(curr_idx, 0, *end), curr_idx + 1)
+                }
                 Narrow(Included(start), Included(end)) => (
                     curr_tensor.narrow(curr_idx, *start, *end - *start + 1),
                     curr_idx + 1,
@@ -309,7 +292,7 @@ impl Tensor {
                 IndexSelect(index_tensor) => (
                     curr_tensor.index_select(curr_idx, index_tensor),
                     curr_idx + 1,
-                )
+                ),
             };
 
             curr_tensor = next_tensor;

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -9,6 +9,7 @@ mod npy;
 mod index;
 
 pub use super::wrappers::tensor::{no_grad, no_grad_guard, NoGradGuard, Reduction, Tensor};
+pub use index::{TensorIndexer, NewAxis, IndexOp};
 
 macro_rules! impl_op {
     ($trait:ident, $rhs:ident, $func:ident, $op:ident) => {

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -6,6 +6,7 @@ use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssi
 
 mod iter;
 mod npy;
+mod index;
 
 pub use super::wrappers::tensor::{no_grad, no_grad_guard, NoGradGuard, Reduction, Tensor};
 

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -4,12 +4,12 @@ use failure::Fallible;
 use std::convert::{TryFrom, TryInto};
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
+mod index;
 mod iter;
 mod npy;
-mod index;
 
 pub use super::wrappers::tensor::{no_grad, no_grad_guard, NoGradGuard, Reduction, Tensor};
-pub use index::{TensorIndexer, NewAxis, IndexOp};
+pub use index::{IndexOp, NewAxis, TensorIndexer};
 
 macro_rules! impl_op {
     ($trait:ident, $rhs:ident, $func:ident, $op:ident) => {

--- a/tests/tensor_indexing.rs
+++ b/tests/tensor_indexing.rs
@@ -7,13 +7,13 @@ fn integer_index() {
 
     let tensor = Tensor::arange1(0, 2 * 3, opt).view(&[2, 3]);
     let result = tensor.i(1);
-    let expect = Tensor::arange1(3, 6, opt);
-    assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
+    assert_eq!(result.size(), &[3]);
+    assert_eq!(Vec::<i64>::from(result), &[3, 4, 5]);
 
     let tensor = Tensor::arange1(0, 2 * 3, opt).view(&[2, 3]);
     let result = tensor.i((.., 2));
-    let expect = Tensor::of_slice(&[2_f32, 5.]).view(&[2]);
-    assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
+    assert_eq!(result.size(), &[2]);
+    assert_eq!(Vec::<i64>::from(result), &[2, 5]);
 }
 
 #[test]
@@ -23,44 +23,44 @@ fn range_index() {
     // Range
     let tensor = Tensor::arange1(0, 4 * 3, opt).view(&[4, 3]);
     let result = tensor.i(1..3);
-    let expect = Tensor::arange1(1 * 3, 3 * 3, opt).view(&[2, 3]);
-    assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
+    assert_eq!(result.size(), &[2, 3]);
+    assert_eq!(Vec::<i64>::from(result), &[3, 4, 5, 6, 7, 8]);
 
     // RangeFull
-    let tensor = Tensor::arange1(0, 4 * 3, opt).view(&[4, 3]);
+    let tensor = Tensor::arange1(0, 2 * 3, opt).view(&[2, 3]);
     let result = tensor.i(..);
-    let expect = Tensor::arange1(0, 4 * 3, opt).view(&[4, 3]);
-    assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
+    assert_eq!(result.size(), &[2, 3]);
+    assert_eq!(Vec::<i64>::from(result), &[0, 1, 2, 3, 4, 5]);
 
     // RangeFrom
     let tensor = Tensor::arange1(0, 4 * 3, opt).view(&[4, 3]);
     let result = tensor.i(2..);
-    let expect = Tensor::arange1(2 * 3, 4 * 3, opt).view(&[2, 3]);
-    assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
+    assert_eq!(result.size(), &[2, 3]);
+    assert_eq!(Vec::<i64>::from(result), &[6, 7, 8, 9, 10, 11]);
 
     // RangeTo
     let tensor = Tensor::arange1(0, 4 * 3, opt).view(&[4, 3]);
     let result = tensor.i(..2);
-    let expect = Tensor::arange1(0, 2 * 3, opt).view(&[2, 3]);
-    assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
+    assert_eq!(result.size(), &[2, 3]);
+    assert_eq!(Vec::<i64>::from(result), &[0, 1, 2, 3, 4, 5]);
 
     // RangeInclusive
     let tensor = Tensor::arange1(0, 4 * 3, opt).view(&[4, 3]);
     let result = tensor.i(1..=2);
-    let expect = Tensor::arange1(1 * 3, 3 * 3, opt).view(&[2, 3]);
-    assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
+    assert_eq!(result.size(), &[2, 3]);
+    assert_eq!(Vec::<i64>::from(result), &[3, 4, 5, 6, 7, 8]);
 
     // RangeTo
     let tensor = Tensor::arange1(0, 4 * 3, opt).view(&[4, 3]);
     let result = tensor.i(..1);
-    let expect = Tensor::arange1(0, 1 * 3, opt).view(&[1, 3]);
-    assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
+    assert_eq!(result.size(), &[1, 3]);
+    assert_eq!(Vec::<i64>::from(result), &[0, 1, 2]);
 
     // RangeToInclusive
     let tensor = Tensor::arange1(0, 4 * 3, opt).view(&[4, 3]);
     let result = tensor.i(..=1);
-    let expect = Tensor::arange1(0, 2 * 3, opt).view(&[2, 3]);
-    assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
+    assert_eq!(result.size(), &[2, 3]);
+    assert_eq!(Vec::<i64>::from(result), &[0, 1, 2, 3, 4, 5]);
 }
 
 #[test]
@@ -70,14 +70,14 @@ fn slice_index() {
     let tensor = Tensor::arange1(0, 6 * 2, opt).view(&[6, 2]);
     let index: &[_] = &[1, 3, 5];
     let result = tensor.i(index);
-    let expect = Tensor::of_slice(&[2_f32, 3., 6., 7., 10., 11.]).view(&[3, 2]);
-    assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
+    assert_eq!(result.size(), &[3, 2]);
+    assert_eq!(Vec::<i64>::from(result), &[2, 3, 6, 7, 10, 11]);
 
     let tensor = Tensor::arange1(0, 3 * 4, opt).view(&[3, 4]);
     let index: &[_] = &[3, 0];
     let result = tensor.i((.., index));
-    let expect = Tensor::of_slice(&[3_f32, 0., 7., 4., 11., 8.]).view(&[3, 2]);
-    assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
+    assert_eq!(result.size(), &[3, 2]);
+    assert_eq!(Vec::<i64>::from(result), &[3, 0, 7, 4, 11, 8]);
 }
 
 #[test]
@@ -86,18 +86,18 @@ fn new_index() {
 
     let tensor = Tensor::arange1(0, 2 * 3, opt).view(&[2, 3]);
     let result = tensor.i((NewAxis,));
-    let expect = Tensor::arange1(0, 1 * 2 * 3, opt).view(&[1, 2, 3]);
-    assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
+    assert_eq!(result.size(), &[1, 2, 3]);
+    assert_eq!(Vec::<i64>::from(result), &[0, 1, 2, 3, 4, 5]);
 
     let tensor = Tensor::arange1(0, 2 * 3, opt).view(&[2, 3]);
     let result = tensor.i((.., NewAxis));
-    let expect = Tensor::arange1(0, 2 * 1 * 3, opt).view(&[2, 1, 3]);
-    assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
+    assert_eq!(result.size(), &[2, 1, 3]);
+    assert_eq!(Vec::<i64>::from(result), &[0, 1, 2, 3, 4, 5]);
 
     let tensor = Tensor::arange1(0, 2 * 3, opt).view(&[2, 3]);
     let result = tensor.i((.., .., NewAxis));
-    let expect = Tensor::arange1(0, 2 * 3 * 1, opt).view(&[2, 3, 1]);
-    assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
+    assert_eq!(result.size(), &[2, 3, 1]);
+    assert_eq!(Vec::<i64>::from(result), &[0, 1, 2, 3, 4, 5]);
 }
 
 #[test]
@@ -106,9 +106,9 @@ fn complex_index() {
 
     let tensor = Tensor::arange1(0, 2 * 3 * 5 * 7, opt).view(&[2, 3, 5, 7]);
     let result = tensor.i((1, 1..2, vec![2, 3, 0].as_slice(), NewAxis, 3..));
-    let expect = Tensor::of_slice(&[
-        157_f32, 158., 159., 160., 164., 165., 166., 167., 143., 144., 145., 146.,
-    ])
-    .view(&[1, 3, 1, 4]);
-    assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
+    assert_eq!(result.size(), &[1, 3, 1, 4]);
+    assert_eq!(
+        Vec::<i64>::from(result),
+        &[157, 158, 159, 160, 164, 165, 166, 167, 143, 144, 145, 146]
+    );
 }

--- a/tests/tensor_indexing.rs
+++ b/tests/tensor_indexing.rs
@@ -1,0 +1,140 @@
+use tch::{Tensor, Kind, Device};
+use tch::{NewAxis, IndexOp};
+
+#[test]
+fn integer_index() {
+    let opt = (Kind::Float, Device::Cpu);
+
+    let tensor = Tensor::arange1(0, 2 * 3, opt)
+        .view(&[2, 3]);
+    let result = tensor.i(1);
+    let expect = Tensor::arange1(3, 6, opt);
+    assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
+
+    let tensor = Tensor::arange1(0, 2 * 3, opt)
+        .view(&[2, 3]);
+    let result = tensor.i((.., 2));
+    let expect = Tensor::of_slice(&[2_f32, 5.])
+        .view(&[2]);
+    assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
+}
+
+#[test]
+fn range_index() {
+    let opt = (Kind::Float, Device::Cpu);
+
+    // Range
+    let tensor = Tensor::arange1(0, 4 * 3, opt)
+        .view(&[4, 3]);
+    let result = tensor.i(1..3);
+    let expect = Tensor::arange1(1 * 3, 3 * 3, opt)
+        .view(&[2, 3]);
+    assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
+
+    // RangeFull
+    let tensor = Tensor::arange1(0, 4 * 3, opt)
+        .view(&[4, 3]);
+    let result = tensor.i(..);
+    let expect = Tensor::arange1(0, 4 * 3, opt)
+        .view(&[4, 3]);
+    assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
+
+    // RangeFrom
+    let tensor = Tensor::arange1(0, 4 * 3, opt)
+        .view(&[4, 3]);
+    let result = tensor.i(2..);
+    let expect = Tensor::arange1(2 * 3, 4 * 3, opt)
+        .view(&[2, 3]);
+    assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
+
+    // RangeTo
+    let tensor = Tensor::arange1(0, 4 * 3, opt)
+        .view(&[4, 3]);
+    let result = tensor.i(..2);
+    let expect = Tensor::arange1(0, 2 * 3, opt)
+        .view(&[2, 3]);
+    assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
+
+    // RangeInclusive
+    let tensor = Tensor::arange1(0, 4 * 3, opt)
+        .view(&[4, 3]);
+    let result = tensor.i(1..=2);
+    let expect = Tensor::arange1(1 * 3, 3 * 3, opt)
+        .view(&[2, 3]);
+    assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
+
+    // RangeTo
+    let tensor = Tensor::arange1(0, 4 * 3, opt)
+        .view(&[4, 3]);
+    let result = tensor.i(..1);
+    let expect = Tensor::arange1(0, 1 * 3, opt)
+        .view(&[1, 3]);
+    assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
+
+    // RangeToInclusive
+    let tensor = Tensor::arange1(0, 4 * 3, opt)
+        .view(&[4, 3]);
+    let result = tensor.i(..=1);
+    let expect = Tensor::arange1(0, 2 * 3, opt)
+        .view(&[2, 3]);
+    assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
+}
+
+#[test]
+fn slice_index() {
+    let opt = (Kind::Float, Device::Cpu);
+
+    let tensor = Tensor::arange1(0, 6 * 2, opt)
+        .view(&[6, 2]);
+    let index: &[_] = &[1, 3, 5];
+    let result = tensor.i(index);
+    let expect = Tensor::of_slice(&[2_f32, 3., 6., 7., 10., 11.])
+        .view(&[3, 2]);
+    assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
+
+    let tensor = Tensor::arange1(0, 3 * 4, opt)
+        .view(&[3, 4]);
+    let index: &[_] = &[3, 0];
+    let result = tensor.i((.., index));
+    let expect = Tensor::of_slice(&[3_f32, 0., 7., 4., 11., 8.])
+        .view(&[3, 2]);
+    assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
+}
+
+#[test]
+fn new_index() {
+    let opt = (Kind::Float, Device::Cpu);
+
+    let tensor = Tensor::arange1(0, 2 * 3, opt)
+        .view(&[2, 3]);
+    let result = tensor.i((NewAxis,));
+    let expect = Tensor::arange1(0, 1 * 2 * 3, opt)
+        .view(&[1, 2, 3]);
+    assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
+
+    let tensor = Tensor::arange1(0, 2 * 3, opt)
+        .view(&[2, 3]);
+    let result = tensor.i((.., NewAxis));
+    let expect = Tensor::arange1(0, 2 * 1 * 3, opt)
+        .view(&[2, 1, 3]);
+    assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
+
+    let tensor = Tensor::arange1(0, 2 * 3, opt)
+        .view(&[2, 3]);
+    let result = tensor.i((.., .., NewAxis,));
+    let expect = Tensor::arange1(0, 2 * 3 * 1, opt)
+        .view(&[2, 3, 1]);
+    assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
+}
+
+#[test]
+fn complex_index() {
+    let opt = (Kind::Float, Device::Cpu);
+
+    let tensor = Tensor::arange1(0, 2 * 3 * 5 * 7, opt)
+        .view(&[2, 3, 5, 7]);
+    let result = tensor.i((1, 1..2, vec![2, 3, 0].as_slice(), NewAxis, 3..));
+    let expect = Tensor::of_slice(&[157_f32, 158., 159., 160., 164., 165., 166., 167., 143., 144., 145., 146.])
+        .view(&[1, 3, 1, 4]);
+    assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
+}

--- a/tests/tensor_indexing.rs
+++ b/tests/tensor_indexing.rs
@@ -1,21 +1,18 @@
-use tch::{Tensor, Kind, Device};
-use tch::{NewAxis, IndexOp};
+use tch::{Device, Kind, Tensor};
+use tch::{IndexOp, NewAxis};
 
 #[test]
 fn integer_index() {
     let opt = (Kind::Float, Device::Cpu);
 
-    let tensor = Tensor::arange1(0, 2 * 3, opt)
-        .view(&[2, 3]);
+    let tensor = Tensor::arange1(0, 2 * 3, opt).view(&[2, 3]);
     let result = tensor.i(1);
     let expect = Tensor::arange1(3, 6, opt);
     assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
 
-    let tensor = Tensor::arange1(0, 2 * 3, opt)
-        .view(&[2, 3]);
+    let tensor = Tensor::arange1(0, 2 * 3, opt).view(&[2, 3]);
     let result = tensor.i((.., 2));
-    let expect = Tensor::of_slice(&[2_f32, 5.])
-        .view(&[2]);
+    let expect = Tensor::of_slice(&[2_f32, 5.]).view(&[2]);
     assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
 }
 
@@ -24,59 +21,45 @@ fn range_index() {
     let opt = (Kind::Float, Device::Cpu);
 
     // Range
-    let tensor = Tensor::arange1(0, 4 * 3, opt)
-        .view(&[4, 3]);
+    let tensor = Tensor::arange1(0, 4 * 3, opt).view(&[4, 3]);
     let result = tensor.i(1..3);
-    let expect = Tensor::arange1(1 * 3, 3 * 3, opt)
-        .view(&[2, 3]);
+    let expect = Tensor::arange1(1 * 3, 3 * 3, opt).view(&[2, 3]);
     assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
 
     // RangeFull
-    let tensor = Tensor::arange1(0, 4 * 3, opt)
-        .view(&[4, 3]);
+    let tensor = Tensor::arange1(0, 4 * 3, opt).view(&[4, 3]);
     let result = tensor.i(..);
-    let expect = Tensor::arange1(0, 4 * 3, opt)
-        .view(&[4, 3]);
+    let expect = Tensor::arange1(0, 4 * 3, opt).view(&[4, 3]);
     assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
 
     // RangeFrom
-    let tensor = Tensor::arange1(0, 4 * 3, opt)
-        .view(&[4, 3]);
+    let tensor = Tensor::arange1(0, 4 * 3, opt).view(&[4, 3]);
     let result = tensor.i(2..);
-    let expect = Tensor::arange1(2 * 3, 4 * 3, opt)
-        .view(&[2, 3]);
+    let expect = Tensor::arange1(2 * 3, 4 * 3, opt).view(&[2, 3]);
     assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
 
     // RangeTo
-    let tensor = Tensor::arange1(0, 4 * 3, opt)
-        .view(&[4, 3]);
+    let tensor = Tensor::arange1(0, 4 * 3, opt).view(&[4, 3]);
     let result = tensor.i(..2);
-    let expect = Tensor::arange1(0, 2 * 3, opt)
-        .view(&[2, 3]);
+    let expect = Tensor::arange1(0, 2 * 3, opt).view(&[2, 3]);
     assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
 
     // RangeInclusive
-    let tensor = Tensor::arange1(0, 4 * 3, opt)
-        .view(&[4, 3]);
+    let tensor = Tensor::arange1(0, 4 * 3, opt).view(&[4, 3]);
     let result = tensor.i(1..=2);
-    let expect = Tensor::arange1(1 * 3, 3 * 3, opt)
-        .view(&[2, 3]);
+    let expect = Tensor::arange1(1 * 3, 3 * 3, opt).view(&[2, 3]);
     assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
 
     // RangeTo
-    let tensor = Tensor::arange1(0, 4 * 3, opt)
-        .view(&[4, 3]);
+    let tensor = Tensor::arange1(0, 4 * 3, opt).view(&[4, 3]);
     let result = tensor.i(..1);
-    let expect = Tensor::arange1(0, 1 * 3, opt)
-        .view(&[1, 3]);
+    let expect = Tensor::arange1(0, 1 * 3, opt).view(&[1, 3]);
     assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
 
     // RangeToInclusive
-    let tensor = Tensor::arange1(0, 4 * 3, opt)
-        .view(&[4, 3]);
+    let tensor = Tensor::arange1(0, 4 * 3, opt).view(&[4, 3]);
     let result = tensor.i(..=1);
-    let expect = Tensor::arange1(0, 2 * 3, opt)
-        .view(&[2, 3]);
+    let expect = Tensor::arange1(0, 2 * 3, opt).view(&[2, 3]);
     assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
 }
 
@@ -84,20 +67,16 @@ fn range_index() {
 fn slice_index() {
     let opt = (Kind::Float, Device::Cpu);
 
-    let tensor = Tensor::arange1(0, 6 * 2, opt)
-        .view(&[6, 2]);
+    let tensor = Tensor::arange1(0, 6 * 2, opt).view(&[6, 2]);
     let index: &[_] = &[1, 3, 5];
     let result = tensor.i(index);
-    let expect = Tensor::of_slice(&[2_f32, 3., 6., 7., 10., 11.])
-        .view(&[3, 2]);
+    let expect = Tensor::of_slice(&[2_f32, 3., 6., 7., 10., 11.]).view(&[3, 2]);
     assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
 
-    let tensor = Tensor::arange1(0, 3 * 4, opt)
-        .view(&[3, 4]);
+    let tensor = Tensor::arange1(0, 3 * 4, opt).view(&[3, 4]);
     let index: &[_] = &[3, 0];
     let result = tensor.i((.., index));
-    let expect = Tensor::of_slice(&[3_f32, 0., 7., 4., 11., 8.])
-        .view(&[3, 2]);
+    let expect = Tensor::of_slice(&[3_f32, 0., 7., 4., 11., 8.]).view(&[3, 2]);
     assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
 }
 
@@ -105,25 +84,19 @@ fn slice_index() {
 fn new_index() {
     let opt = (Kind::Float, Device::Cpu);
 
-    let tensor = Tensor::arange1(0, 2 * 3, opt)
-        .view(&[2, 3]);
+    let tensor = Tensor::arange1(0, 2 * 3, opt).view(&[2, 3]);
     let result = tensor.i((NewAxis,));
-    let expect = Tensor::arange1(0, 1 * 2 * 3, opt)
-        .view(&[1, 2, 3]);
+    let expect = Tensor::arange1(0, 1 * 2 * 3, opt).view(&[1, 2, 3]);
     assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
 
-    let tensor = Tensor::arange1(0, 2 * 3, opt)
-        .view(&[2, 3]);
+    let tensor = Tensor::arange1(0, 2 * 3, opt).view(&[2, 3]);
     let result = tensor.i((.., NewAxis));
-    let expect = Tensor::arange1(0, 2 * 1 * 3, opt)
-        .view(&[2, 1, 3]);
+    let expect = Tensor::arange1(0, 2 * 1 * 3, opt).view(&[2, 1, 3]);
     assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
 
-    let tensor = Tensor::arange1(0, 2 * 3, opt)
-        .view(&[2, 3]);
-    let result = tensor.i((.., .., NewAxis,));
-    let expect = Tensor::arange1(0, 2 * 3 * 1, opt)
-        .view(&[2, 3, 1]);
+    let tensor = Tensor::arange1(0, 2 * 3, opt).view(&[2, 3]);
+    let result = tensor.i((.., .., NewAxis));
+    let expect = Tensor::arange1(0, 2 * 3 * 1, opt).view(&[2, 3, 1]);
     assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
 }
 
@@ -131,10 +104,11 @@ fn new_index() {
 fn complex_index() {
     let opt = (Kind::Float, Device::Cpu);
 
-    let tensor = Tensor::arange1(0, 2 * 3 * 5 * 7, opt)
-        .view(&[2, 3, 5, 7]);
+    let tensor = Tensor::arange1(0, 2 * 3 * 5 * 7, opt).view(&[2, 3, 5, 7]);
     let result = tensor.i((1, 1..2, vec![2, 3, 0].as_slice(), NewAxis, 3..));
-    let expect = Tensor::of_slice(&[157_f32, 158., 159., 160., 164., 165., 166., 167., 143., 144., 145., 146.])
-        .view(&[1, 3, 1, 4]);
+    let expect = Tensor::of_slice(&[
+        157_f32, 158., 159., 160., 164., 165., 166., 167., 143., 144., 145., 146.,
+    ])
+    .view(&[1, 3, 1, 4]);
     assert!(result.eq1(&expect).all().int64_value(&[]) == 1);
 }


### PR DESCRIPTION
This PR aims to provide an `Tensor::i()` for convenient indexing. It covers integer (i64), Range*, slice of integers and new axis insertion. The following illustrates the usage.

```rust
use tch::{Tensor, IndexOp, NewAxis};

let tensor = Tensor::arange1(0, 2 * 3 * 5 * 7, opt).view(&[2, 3, 5, 7]);
let result = tensor.i((1, 1..2, vec![2, 3, 0].as_slice(), NewAxis, 3..)); 
```

So far, it allows basic indexing similar to that in [NumPy's indexing manual](https://docs.scipy.org/doc/numpy-1.13.0/reference/arrays.indexing.html). Advanced indexing schemes such as boolean array and multi-dimensional index array are not yet supported.

Note that in some cases the indexing result would slightly different NumPy's. For example:

```rust
let tensor = Tensor::zeros(&[3, 4, 5], opt);
let indexed = tensor.i(..1, vec![0, 3], vec![2, 1, 3]);
dbg!(indexed.size()); // result shape [1, 2, 3]
```

However, NumPy throws a shape mismatch error. According to NumPy's manual, multiple arrays as indexes will trigger advanced indexing. It expects `[0, 3]` and `[2, 1, 3]` have identical shape but actually not.
```python
# NumPy example
array[:1, [0, 3], [2, 1, 3]] // shape mismatch error
```

The NumPy promises that basic indexing always build the view of tensor, and I expect this PR respect this rule. In contrast, advanced indexing always makes a copy. That's one reason I decided to make it simple and put it apart.