### PR TITLE
Bug fix: undefined reference to ato_rms_prop

### DIFF
--- a/torch-sys/libtch/torch_api.cpp
+++ b/torch-sys/libtch/torch_api.cpp
@@ -377,12 +377,12 @@ optimizer ato_adam(double learning_rate,
   return nullptr;
 }
 
-optimizer ato_rmsprop(double learning_rate,
-                      double alpha,
-                      double eps,
-                      double weight_decay,
-                      double momentum,
-                      int centered) {
+optimizer ato_rms_prop(double learning_rate,
+                       double alpha,
+                       double eps,
+                       double weight_decay,
+                       double momentum,
+                       int centered) {
   PROTECT(
     auto options =
       torch::optim::RMSpropOptions(learning_rate)

--- a/torch-sys/libtch/torch_api.h
+++ b/torch-sys/libtch/torch_api.h
@@ -83,12 +83,12 @@ optimizer ato_adam(double learning_rate,
                    double beta1,
                    double beta2,
                    double weight_decay);
-optimizer ato_rmsprop(double learning_rate,
-                      double alpha,
-                      double eps,
-                      double weight_decay,
-                      double momentum,
-                      int centered);
+optimizer ato_rms_prop(double learning_rate,
+                       double alpha,
+                       double eps,
+                       double weight_decay,
+                       double momentum,
+                       int centered);
 optimizer ato_sgd(double learning_rate,
                   double momentum,
                   double dampening,


### PR DESCRIPTION
This is due to inconsistent names in `torch_api.h` (`ato_rmsprop`) and in `wrappers/optimizer.rs` (`ato_rms_prop`).