### PR TITLE
Properly free IValue::tuple elements (issue #123).

### DIFF
--- a/src/wrappers/jit.rs
+++ b/src/wrappers/jit.rs
@@ -24,7 +24,13 @@ impl IValue {
                 IValue::Double(f) => ati_double(*f),
                 IValue::Tuple(v) => {
                     let v = v.iter().map(Self::to_c).collect::<Fallible<Vec<_>>>()?;
-                    ati_tuple(v.as_ptr(), v.len() as c_int)
+                    let tuple = ati_tuple(v.as_ptr(), v.len() as c_int);
+                    
+                    for x in v {
+                        ati_free(x);
+                    }
+
+                    tuple
                 }
             }
         });
@@ -103,7 +109,7 @@ impl CModule {
         let c_ivalue =
             unsafe_torch_err!({ atm_forward_(self.c_module, ts.as_ptr(), ts.len() as c_int) });
         for x in ts {
-            unsafe { ati_free_deep(x) }
+            unsafe { ati_free(x) }
         }
         IValue::of_c(c_ivalue)
     }

--- a/src/wrappers/jit.rs
+++ b/src/wrappers/jit.rs
@@ -25,7 +25,6 @@ impl IValue {
                 IValue::Tuple(v) => {
                     let v = v.iter().map(Self::to_c).collect::<Fallible<Vec<_>>>()?;
                     let tuple = ati_tuple(v.as_ptr(), v.len() as c_int);
-                    
                     for x in v {
                         ati_free(x);
                     }

--- a/torch-sys/libtch/torch_api.cpp
+++ b/torch-sys/libtch/torch_api.cpp
@@ -632,12 +632,4 @@ void ati_free(ivalue i) {
   delete(i);
 }
 
-void ati_free_deep(ivalue i) {
-  if (i->isTuple()) {
-    auto vec = i->toTuple()->elements();
-    for (int j = 0; j < vec.size(); ++j) ati_free_deep(&vec[j]);
-  }
-  delete(i);
-}
-
 #include "torch_api_generated.cpp.h"

--- a/torch-sys/libtch/torch_api.h
+++ b/torch-sys/libtch/torch_api.h
@@ -134,7 +134,6 @@ void ati_to_tuple(ivalue, ivalue *, int);
 int ati_tag(ivalue);
 
 void ati_free(ivalue);
-void ati_free_deep(ivalue);
 
 #include "torch_api_generated.h"
 

--- a/torch-sys/src/lib.rs
+++ b/torch-sys/src/lib.rs
@@ -153,7 +153,6 @@ extern "C" {
     pub fn ati_to_tuple(arg: *mut CIValue, outputs: *mut *mut CIValue, n: c_int) -> c_int;
 
     pub fn ati_free(arg: *mut CIValue);
-    pub fn ati_free_deep(arg: *mut CIValue);
 
     pub fn atm_load(filename: *const c_char) -> *mut CModule_;
     pub fn atm_forward(m: *mut CModule_, args: *const *mut C_tensor, n: c_int) -> *mut C_tensor;


### PR DESCRIPTION
The 'ati_deep_free' function is removed as it causes heap corruption. The IValue::to_c function has been modified to avoid the memory leaks that the 'ati_deep_free' function tried to solve.

See more details in the issue https://github.com/LaurentMazare/tch-rs/issues/123.