### PR TITLE
Fix the bug in constant weight initializer

### DIFF
--- a/src/nn/init.rs
+++ b/src/nn/init.rs
@@ -24,7 +24,7 @@ pub fn init(i: Init, dims: &[i64], device: Device) -> Tensor {
             // Optimize the case for which a single C++ code can be done.
             if cst == 0. {
                 Tensor::zeros(dims, (Kind::Float, device))
-            } else if (cst - 1.) <= std::f64::EPSILON {
+            } else if (cst - 1.).abs() <= std::f64::EPSILON {
                 Tensor::ones(dims, (Kind::Float, device))
             } else {
                 Tensor::ones(dims, (Kind::Float, device)) * cst


### PR DESCRIPTION
In `init` function the branch for `Init::Const` contains an optimization for zeroes and ones initialization. "Ones "optimization is supposed to happen when `cst` is close to 1 but it was triggered when `cst` was just lower than 1. Fixed by adding `abs()` to the expression.