### PR TITLE
Add example `custom-optimizer` with Adam optimizer

### DIFF
--- a/examples/custom-optimizer/README.md
+++ b/examples/custom-optimizer/README.md
@@ -1,0 +1,7 @@
+## Custom Optimizer - Sparse Adam optimizer
+
+This example implements an Adam optimizer for sparse and dense gradients. This is useful for large embedding matrices, where the gradient is very sparse. Instead of updating the whole embedding, just a small portion of the matrix is updated and therefore a significant speed-up in training time is gained. 
+
+For the dense update step it uses the `addcdiv_` (fraction and then add assign in-place) and `addcmul_` (multiply and then add assign in-place) functions and for the sparse part `index_select` and `index_add` to reduce the necessary work. The sparse gradient update subroutine is only faster for sparse matrices. There is a `force_sparse` parameter, which enforces that the sparse subroutine is used, even for dense gradients. This is only for testing purposes, because the problem is actual of dense nature.
+
+As a toy example, a MNIST classification problem is solved with help of the Adam implementation. For further information take a look at the implementation [here](https://github.com/pytorch/pytorch/blob/master/torch/optim/sparse_adam.py) and the [paper](https://arxiv.org/abs/1412.6980). The Adam optimizer should reach 97% in about 170 epochs.

--- a/examples/custom-optimizer/main.rs
+++ b/examples/custom-optimizer/main.rs
@@ -1,0 +1,60 @@
+// This should rearch 97% accuracy.
+
+extern crate tch;
+
+mod sparse_adam;
+
+use tch::{nn, nn::Module, Device};
+
+const IMAGE_DIM: i64 = 784;
+const HIDDEN_NODES: i64 = 128;
+const LABELS: i64 = 10;
+
+fn net(vs: &nn::Path) -> impl Module {
+    nn::seq()
+        .add(nn::linear(
+            vs / "layer1",
+            IMAGE_DIM,
+            HIDDEN_NODES,
+            Default::default(),
+        ))
+        .add_fn(|xs| xs.relu())
+        .add(nn::linear(vs, HIDDEN_NODES, LABELS, Default::default()))
+}
+
+pub fn run() -> failure::Fallible<()> {
+    let m = tch::vision::mnist::load_dir("data")?;
+    let vs = nn::VarStore::new(Device::Cpu);
+    let net = net(&vs.root());
+
+    // force a sparse update step (in order to test on dense problem)
+    let force_sparse = false;
+    // create a custom optimizer with learning rate `0.005`, beta_1 `0.9` and beta2 `0.999`
+    let mut opt = sparse_adam::SparseAdam::new(&vs, 5e-3, 0.9, 0.999, 1e-8, force_sparse);
+
+    for epoch in 1..200 {
+        let loss = net
+            .forward(&m.train_images)
+            .cross_entropy_for_logits(&m.train_labels);
+
+        // call custom optimizer
+        opt.zero_grad();
+        loss.backward();
+        opt.step();
+
+        let test_accuracy = net
+            .forward(&m.test_images)
+            .accuracy_for_logits(&m.test_labels);
+        println!(
+            "epoch: {:4} train loss: {:8.5} test acc: {:5.2}%",
+            epoch,
+            f64::from(&loss),
+            100. * f64::from(&test_accuracy),
+        );
+    }
+    Ok(())
+}
+
+fn main() {
+    run().unwrap();
+}

--- a/examples/custom-optimizer/sparse_adam.rs
+++ b/examples/custom-optimizer/sparse_adam.rs
@@ -1,0 +1,139 @@
+use std::sync::{Mutex, Arc};
+use tch::nn::{VarStore, Variables};
+use tch::{Tensor, Kind, Device, no_grad};
+
+/// Buffer of first/second order moment for the Adam optimizer
+struct Buffer {
+    pub first_moment: Tensor,
+    pub second_moment: Tensor,
+    idx: usize
+}
+
+impl Buffer {
+    pub fn new(size: &[i64]) -> Buffer {
+        Buffer {
+            first_moment: Tensor::zeros(size, (Kind::Float, Device::Cpu)),
+            second_moment: Tensor::zeros(size, (Kind::Float, Device::Cpu)),
+            idx: 0
+        }
+    }
+
+    // Return and increment the timestep
+    pub fn inc(&mut self) -> usize {
+        let old_val = self.idx;
+        self.idx += 1;
+
+        old_val
+    }
+}
+
+/// Sparse-Adam optimizer supporting sparse and dense gradients
+///
+/// This demonstrates how a custom optimizer can be implemented. It handles a shared copy of the
+/// variables store `vars` and updates it by traversing the computation graph.
+pub struct SparseAdam {
+    lr: f64,
+    beta1: f64,
+    beta2: f64,
+    eps: f64,
+    force_sparse: bool,
+
+    vars: Arc<Mutex<Variables>>,
+    buffers: Vec<Buffer>,
+}
+
+impl SparseAdam {
+    pub fn new(vs: &VarStore, lr: f64, beta1: f64, beta2: f64, eps: f64, force_sparse: bool) -> SparseAdam {
+        let vars = vs.variables_.clone();
+        
+        // create buffers for every trainable variable
+        let buffers = vars.lock().unwrap().trainable_variables
+            .iter()
+            .map(|x| Buffer::new(&x.size()))
+            .collect();
+
+        SparseAdam {
+            lr,
+            beta1,
+            beta2,
+            eps,
+            force_sparse,
+            vars,
+            buffers,
+        }
+    }
+
+    /// Ensure that the gradient update is not part of the autograd routine
+    pub fn step(&mut self) {
+        no_grad(|| self._step());
+    }
+
+    pub fn _step(&mut self) {
+        let mut vars = self.vars.lock().unwrap();
+
+        // iterate through all trainable variables
+        for (tensor, buffer) in vars.trainable_variables.iter_mut().zip(&mut self.buffers) {
+            buffer.inc();
+            let mut grad = tensor.grad();
+
+            // calculate both bias correction values
+            let bias_correction1 = 1.0 - self.beta1.powf(buffer.idx as f64);
+            let bias_correction2 = 1.0 - self.beta2.powf(buffer.idx as f64);
+
+            // check whether the gradient is sparse
+            if grad.is_sparse() || self.force_sparse {
+                // deduplicate coordinates in the sparse matrix
+                if !grad.is_sparse() && self.force_sparse {
+                    grad = grad.to_sparse1(1);
+                }
+
+                let grad = grad.coalesce();
+                // get indices and values of the sparse gradient
+                let indices = grad.indices().squeeze();
+                let values = grad.values();
+
+                // for SGD we would do:
+                //tensor.index_add_(0, &indices, &(-self.lr * &values));
+
+                // update both moments
+                // old = b*old + (1-b) * new <==> old += (1-b) * (new - old)
+                let update_first_moment = (1.0 - self.beta1) * (&values - buffer.first_moment.index_select(0, &indices));
+                let update_second_moment = (1.0 - self.beta2) * (&values * &values - buffer.second_moment.index_select(0, &indices));
+
+                let _ = buffer.first_moment.index_add_(0, &indices, &update_first_moment);
+                let _ = buffer.second_moment.index_add_(0, &indices, &update_second_moment);
+
+                // first part of update step -lr * m_t / (1-b_1^t)
+                let part1 = buffer.first_moment.index_select(0, &indices) * (-self.lr / bias_correction1);
+                // second part of update step sqrt(v_t / (1-b_2^t)) + eps
+                let part2 = (buffer.second_moment.index_select(0, &indices) / bias_correction2).sqrt() + self.eps;
+
+                let _ = tensor.index_add_(0, &indices, &(part1/part2));
+            } else {
+                // update first moment
+                buffer.first_moment *= self.beta1;
+                buffer.first_moment += (1.0-self.beta1) * &grad;
+                // update second raw moment
+                buffer.second_moment *= self.beta2;
+                let scaled_grad = grad * (1.0-self.beta2).sqrt();
+                let _ = buffer.second_moment.addcmul_(&scaled_grad, &scaled_grad);
+
+                // first part of update step -lr * m_t / (1-b_1^t)
+                let part1 = &buffer.first_moment * (-self.lr / bias_correction1);
+                // second part of update step sqrt(v_t / (1-b_2^t)) + eps
+                let part2 = (&buffer.second_moment / bias_correction2).sqrt() + self.eps;
+                
+                // calculate fraction and update parameters
+                let _ = tensor.addcdiv_(&part1, &part2);
+            }
+        }
+    }
+
+    // zero the gradient for all trainable variables
+    pub fn zero_grad(&mut self) {
+        let mut vars = self.vars.lock().unwrap();
+        for var in &mut vars.trainable_variables {
+            var.zero_grad();
+        }
+    }
+}

--- a/src/nn/mod.rs
+++ b/src/nn/mod.rs
@@ -6,7 +6,7 @@ mod init;
 pub use init::{init, Init};
 
 mod var_store;
-pub use var_store::{Path, VarStore};
+pub use var_store::{Path, VarStore, Variables};
 
 mod module;
 pub use module::{Module, ModuleT};


### PR DESCRIPTION
This example demonstrates how a custom optimizer can be implemented in Rust. This Adam optimizer supports sparse, as well as, dense gradient updates and can be used in problems, where only a small portion of the training parameters are updated. (e.g. embedding matrices)

The toy example is a modified version of the MNIST-NN example. It reaches 97% in about 170 epochs for both sparse and dense mode.