### PR TITLE
Extended Embedding configuration and added unit tests

### DIFF
--- a/src/nn/sparse.rs
+++ b/src/nn/sparse.rs
@@ -8,6 +8,7 @@ pub struct EmbeddingConfig {
     pub sparse: bool,
     pub scale_grad_by_freq: bool,
     pub ws_init: super::Init,
+    pub padding_idx: i64,
 }
 
 impl Default for EmbeddingConfig {
@@ -19,6 +20,7 @@ impl Default for EmbeddingConfig {
                 mean: 0.,
                 stdev: 1.,
             },
+            padding_idx: -1,
         }
     }
 }
@@ -55,7 +57,7 @@ impl super::module::Module for Embedding {
         Tensor::embedding(
             &self.ws,
             xs,
-            -1,
+            self.config.padding_idx,
             self.config.scale_grad_by_freq,
             self.config.sparse,
         )

--- a/tests/nn_tests.rs
+++ b/tests/nn_tests.rs
@@ -227,8 +227,10 @@ fn embedding_test(embedding_config: nn::EmbeddingConfig) {
     } else {
         embedding_config.padding_idx
     };
-    let input = Tensor::of_slice(&[padding_idx, batch_dim]);
+    let input = Tensor::of_slice(&vec![padding_idx; 1]);
     let output = embeddings.forward(&input);
+    assert_eq!(output.size(), [1, output_dim]);
+    assert_eq!(output.get(0), embeddings.ws.get(padding_idx));
 }
 
 #[test]

--- a/tests/nn_tests.rs
+++ b/tests/nn_tests.rs
@@ -207,3 +207,39 @@ fn lstm() {
         ..Default::default()
     });
 }
+
+fn embedding_test(embedding_config: nn::EmbeddingConfig) {
+    let batch_dim = 5;
+    let seq_len = 7;
+    let input_dim = 10;
+    let output_dim = 4;
+    let vs = nn::VarStore::new(tch::Device::Cpu);
+    let embeddings = nn::embedding(&vs.root(), input_dim, output_dim, embedding_config);
+
+    // forward test
+    let input = Tensor::randint(10, &[batch_dim, seq_len], kind::INT64_CPU);
+    let output = embeddings.forward(&input);
+    assert_eq!(output.size(), [batch_dim, seq_len, output_dim]);
+
+    // padding test
+    let padding_idx = if embedding_config.padding_idx < 0 {
+        input_dim + embedding_config.padding_idx
+    } else {
+        embedding_config.padding_idx
+    };
+    let input = Tensor::of_slice(&[padding_idx, batch_dim]);
+    let output = embeddings.forward(&input);
+}
+
+#[test]
+fn embedding() {
+    embedding_test(Default::default());
+    embedding_test(nn::EmbeddingConfig {
+        padding_idx: -1,
+        ..Default::default()
+    });
+    embedding_test(nn::EmbeddingConfig {
+        padding_idx: 0,
+        ..Default::default()
+    });
+}


### PR DESCRIPTION
The padding index was set to a value of -1 for all embedding layers created. Being able to configure this value is useful when working with pretrained models. Added this field to the EmbeddingConfig (keeping the default to -1). Added a few unit tests for the embedding layer that were missing.