### PR TITLE
Renamed embeddings weight variable to be aligned with Torch

### DIFF
--- a/src/nn/sparse.rs
+++ b/src/nn/sparse.rs
@@ -44,7 +44,7 @@ pub fn embedding<'a, T: Borrow<super::Path<'a>>>(
     let vs = vs.borrow();
     Embedding {
         ws: vs.var(
-            "embedding",
+            "weight",
             &[num_embeddings, embedding_dim],
             config.ws_init,
         ),

--- a/src/nn/sparse.rs
+++ b/src/nn/sparse.rs
@@ -43,11 +43,7 @@ pub fn embedding<'a, T: Borrow<super::Path<'a>>>(
 ) -> Embedding {
     let vs = vs.borrow();
     Embedding {
-        ws: vs.var(
-            "weight",
-            &[num_embeddings, embedding_dim],
-            config.ws_init,
-        ),
+        ws: vs.var("weight", &[num_embeddings, embedding_dim], config.ws_init),
         config,
     }
 }


### PR DESCRIPTION
The default Embedding implementation in Pytorch uses a parameter variable named "weight" to store the embedding matrix (aligned with the rest of the base modules). https://pytorch.org/docs/stable/_modules/torch/nn/modules/sparse.html#Embedding

Proposing to change the current "embedding" variable name to facilitate loading of pre-trained models from Pytorch.

I looked for use in the current code base, but as far as I could see, no pre-trained embedding layers were loaded so far.
