### PR TITLE
Allow loading partial sets of pretrained weights

### DIFF
--- a/src/nn/sparse.rs
+++ b/src/nn/sparse.rs
@@ -44,7 +44,7 @@ pub fn embedding<'a, T: Borrow<super::Path<'a>>>(
     let vs = vs.borrow();
     Embedding {
         ws: vs.var(
-            "embedding",
+            "weight",
             &[num_embeddings, embedding_dim],
             config.ws_init,
         ),

--- a/src/nn/sparse.rs
+++ b/src/nn/sparse.rs
@@ -43,11 +43,7 @@ pub fn embedding<'a, T: Borrow<super::Path<'a>>>(
 ) -> Embedding {
     let vs = vs.borrow();
     Embedding {
-        ws: vs.var(
-            "weight",
-            &[num_embeddings, embedding_dim],
-            config.ws_init,
-        ),
+        ws: vs.var("weight", &[num_embeddings, embedding_dim], config.ws_init),
         config,
     }
 }

--- a/src/nn/var_store.rs
+++ b/src/nn/var_store.rs
@@ -143,7 +143,7 @@ impl VarStore {
     /// weight for only parts of the model are available.
     /// Note that the set of variables stored in the var-store is not changed, only the values
     /// for these tensors are modified.
-    pub fn load_partial<T: AsRef<std::path::Path>>(&mut self, path: T) -> Fallible<()>  {
+    pub fn load_partial<T: AsRef<std::path::Path>>(&mut self, path: T) -> Fallible<()> {
         let named_tensors = Tensor::load_multi_with_device(&path, self.device)?;
         let named_tensors: HashMap<_, _> = named_tensors.into_iter().collect();
         let mut variables = self.variables_.lock().unwrap();
@@ -152,7 +152,11 @@ impl VarStore {
                 Some(src) => {
                     crate::no_grad(|| var.f_copy_(src).map_err(|e| format_err!("{}: {}", name, e)))?
                 }
-                None => println!("cannot find {} in {:?}. Variable value not updated", name, path.as_ref()),
+                None => println!(
+                    "cannot find {} in {:?}. Variable value not updated",
+                    name,
+                    path.as_ref()
+                ),
             }
         }
         Ok(())
@@ -485,8 +489,8 @@ impl<'a> Entry<'a> {
 }
 
 impl<'a, T> Div<T> for &'a mut Path<'a>
-    where
-        T: std::string::ToString,
+where
+    T: std::string::ToString,
 {
     type Output = Path<'a>;
 
@@ -496,8 +500,8 @@ impl<'a, T> Div<T> for &'a mut Path<'a>
 }
 
 impl<'a, T> Div<T> for &'a Path<'a>
-    where
-        T: std::string::ToString,
+where
+    T: std::string::ToString,
 {
     type Output = Path<'a>;
 

--- a/src/nn/var_store.rs
+++ b/src/nn/var_store.rs
@@ -143,10 +143,9 @@ impl VarStore {
     /// weight for only parts of the model are available.
     /// Note that the set of variables stored in the var-store is not changed, only the values
     /// for these tensors are modified.
-    pub fn load_partial<T: AsRef<std::path::Path>>(
-        &mut self,
-        path: T,
-    ) -> Fallible<Option<Vec<String>>> {
+    ///
+    /// Returns a String Vector containing the names of missing variables.
+    pub fn load_partial<T: AsRef<std::path::Path>>(&mut self, path: T) -> Fallible<Vec<String>> {
         let named_tensors = Tensor::load_multi_with_device(&path, self.device)?;
         let named_tensors: HashMap<_, _> = named_tensors.into_iter().collect();
         let mut variables = self.variables_.lock().unwrap();
@@ -161,11 +160,7 @@ impl VarStore {
                 }
             }
         }
-        Ok(if !&missing_variables.is_empty() {
-            Some(missing_variables)
-        } else {
-            None
-        })
+        Ok(missing_variables)
     }
 
     /// Freezes a var store.

--- a/tests/var_store.rs
+++ b/tests/var_store.rs
@@ -15,7 +15,8 @@ fn var_store_entry() {
 
 #[test]
 fn save_and_load_var_store() {
-    let filename = std::env::temp_dir().join(format!("tch-vs-{}", std::process::id()));
+    let filename =
+        std::env::temp_dir().join(format!("tch-vs-load-complete-{}", std::process::id()));
     let add = |vs: &tch::nn::Path| {
         let v = vs.sub("a").sub("b").ones("t2", &[3]);
         let u = vs.zeros("t1", &[4]);
@@ -45,7 +46,10 @@ fn save_and_load_var_store() {
 
 #[test]
 fn save_and_load_partial_var_store() {
-    let filename = std::env::temp_dir().join(format!("tch-vs-{}", std::process::id()));
+    let filename = std::env::temp_dir().join(format!(
+        "tch-vs-partial-load-complete-{}",
+        std::process::id()
+    ));
     let add = |vs: &tch::nn::Path| {
         let v = vs.sub("a").sub("b").ones("t2", &[3]);
         let u = vs.zeros("t1", &[4]);
@@ -70,14 +74,15 @@ fn save_and_load_partial_var_store() {
     assert_eq!(f64::from(&u1.mean(Kind::Float)), 42.0);
     assert_eq!(f64::from(&u2.mean(Kind::Float)), 42.0);
     assert_eq!(f64::from(&v2.mean(Kind::Float)), 2.0);
-    assert!(missing_variables.is_none());
+    assert!(missing_variables.is_empty());
     fs::remove_file(filename).unwrap();
 }
 
 #[test]
 #[should_panic]
 fn save_and_load_var_store_incomplete_file() {
-    let filename = std::env::temp_dir().join(format!("tch-vs-{}", std::process::id()));
+    let filename =
+        std::env::temp_dir().join(format!("tch-vs-load-incomplete-{}", std::process::id()));
     let add = |vs: &tch::nn::Path| {
         let u = vs.zeros("t1", &[4]);
         let _w = vs.sub("a").sub("b").sub("ccc").ones("t123", &[3]);
@@ -109,7 +114,10 @@ fn save_and_load_var_store_incomplete_file() {
 
 #[test]
 fn save_and_load_partial_var_store_incomplete_file() {
-    let filename = std::env::temp_dir().join(format!("tch-vs-{}", std::process::id()));
+    let filename = std::env::temp_dir().join(format!(
+        "tch-vs-partial-load-incomplete-{}",
+        std::process::id()
+    ));
     let add = |vs: &tch::nn::Path| {
         let u = vs.zeros("t1", &[4]);
         let _w = vs.sub("a").sub("b").sub("ccc").ones("t123", &[3]);
@@ -136,7 +144,7 @@ fn save_and_load_partial_var_store_incomplete_file() {
     assert_eq!(f64::from(&u1.mean(Kind::Float)), 42.0);
     assert_eq!(f64::from(&u2.mean(Kind::Float)), 42.0);
     assert_eq!(f64::from(&v2.mean(Kind::Float)), 1.0);
-    assert_eq!(missing_variables, Some(vec!(String::from("a.b.t2"))));
+    assert_eq!(missing_variables, vec!(String::from("a.b.t2")));
     fs::remove_file(filename).unwrap();
 }
 

--- a/tests/var_store.rs
+++ b/tests/var_store.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use tch::{nn::Init, nn::VarStore, Device, Kind};
 
 #[test]
@@ -39,6 +40,7 @@ fn save_and_load_var_store() {
     assert_eq!(f64::from(&u1.mean(Kind::Float)), 42.0);
     assert_eq!(f64::from(&u2.mean(Kind::Float)), 42.0);
     assert_eq!(f64::from(&v2.mean(Kind::Float)), 2.0);
+    fs::remove_file(filename).unwrap();
 }
 
 #[test]
@@ -69,6 +71,7 @@ fn save_and_load_partial_var_store() {
     assert_eq!(f64::from(&u2.mean(Kind::Float)), 42.0);
     assert_eq!(f64::from(&v2.mean(Kind::Float)), 2.0);
     assert!(missing_variables.is_none());
+    fs::remove_file(filename).unwrap();
 }
 
 #[test]
@@ -101,6 +104,7 @@ fn save_and_load_var_store_incomplete_file() {
     assert_eq!(f64::from(&u1.mean(Kind::Float)), 42.0);
     assert_eq!(f64::from(&u2.mean(Kind::Float)), 42.0);
     assert_eq!(f64::from(&v2.mean(Kind::Float)), 1.0);
+    fs::remove_file(filename).unwrap();
 }
 
 #[test]
@@ -133,6 +137,7 @@ fn save_and_load_partial_var_store_incomplete_file() {
     assert_eq!(f64::from(&u2.mean(Kind::Float)), 42.0);
     assert_eq!(f64::from(&v2.mean(Kind::Float)), 1.0);
     assert_eq!(missing_variables, Some(vec!(String::from("a.b.t2"))));
+    fs::remove_file(filename).unwrap();
 }
 
 #[test]

--- a/tests/var_store.rs
+++ b/tests/var_store.rs
@@ -42,6 +42,73 @@ fn save_and_load_var_store() {
 }
 
 #[test]
+#[should_panic]
+fn save_and_load_var_store_incomplete_file() {
+    let filename = std::env::temp_dir().join(format!("tch-vs-{}", std::process::id()));
+    let add = |vs: &tch::nn::Path| {
+        let u = vs.zeros("t1", &[4]);
+        let _w = vs.sub("a").sub("b").sub("ccc").ones("t123", &[3]);
+        let _w = vs.sub("a").sub("b").sub("ccc").ones("t123", &[3]);
+        u
+    };
+    let add_partial = |vs: &tch::nn::Path| {
+        let v = vs.sub("a").sub("b").ones("t2", &[3]);
+        let u = vs.zeros("t1", &[4]);
+        let _w = vs.sub("a").sub("b").sub("ccc").ones("t123", &[3]);
+        let _w = vs.sub("a").sub("b").sub("ccc").ones("t123", &[3]);
+        (u, v)
+    };
+    let vs1 = VarStore::new(Device::Cpu);
+    let mut vs2 = VarStore::new(Device::Cpu);
+    let mut u1 = add(&vs1.root());
+    let (u2, v2) = add_partial(&vs2.root());
+    tch::no_grad(|| {
+        u1 += 42.0;
+    });
+    assert_eq!(f64::from(&u1.mean(Kind::Float)), 42.0);
+    assert_eq!(f64::from(&u2.mean(Kind::Float)), 0.0);
+    assert_eq!(f64::from(&v2.mean(Kind::Float)), 1.0);
+    vs1.save(&filename).unwrap();
+    vs2.load(&filename).unwrap();
+    assert_eq!(f64::from(&u1.mean(Kind::Float)), 42.0);
+    assert_eq!(f64::from(&u2.mean(Kind::Float)), 42.0);
+    assert_eq!(f64::from(&v2.mean(Kind::Float)), 1.0);
+}
+
+#[test]
+fn save_and_load_partial_var_store() {
+    let filename = std::env::temp_dir().join(format!("tch-vs-{}", std::process::id()));
+    let add = |vs: &tch::nn::Path| {
+        let u = vs.zeros("t1", &[4]);
+        let _w = vs.sub("a").sub("b").sub("ccc").ones("t123", &[3]);
+        let _w = vs.sub("a").sub("b").sub("ccc").ones("t123", &[3]);
+        u
+    };
+    let add_partial = |vs: &tch::nn::Path| {
+        let v = vs.sub("a").sub("b").ones("t2", &[3]);
+        let u = vs.zeros("t1", &[4]);
+        let _w = vs.sub("a").sub("b").sub("ccc").ones("t123", &[3]);
+        let _w = vs.sub("a").sub("b").sub("ccc").ones("t123", &[3]);
+        (u, v)
+    };
+    let vs1 = VarStore::new(Device::Cpu);
+    let mut vs2 = VarStore::new(Device::Cpu);
+    let mut u1 = add(&vs1.root());
+    let (u2, v2) = add_partial(&vs2.root());
+    tch::no_grad(|| {
+        u1 += 42.0;
+    });
+    assert_eq!(f64::from(&u1.mean(Kind::Float)), 42.0);
+    assert_eq!(f64::from(&u2.mean(Kind::Float)), 0.0);
+    assert_eq!(f64::from(&v2.mean(Kind::Float)), 1.0);
+    vs1.save(&filename).unwrap();
+    vs2.load_partial(&filename).unwrap();
+    assert_eq!(f64::from(&u1.mean(Kind::Float)), 42.0);
+    assert_eq!(f64::from(&u2.mean(Kind::Float)), 42.0);
+    assert_eq!(f64::from(&v2.mean(Kind::Float)), 1.0);
+}
+
+#[test]
 fn init_test() {
     let vs = VarStore::new(Device::Cpu);
     let zeros = vs.root().zeros("t1", &[3]);

--- a/tests/var_store.rs
+++ b/tests/var_store.rs
@@ -42,19 +42,47 @@ fn save_and_load_var_store() {
 }
 
 #[test]
+fn save_and_load_partial_var_store() {
+    let filename = std::env::temp_dir().join(format!("tch-vs-{}", std::process::id()));
+    let add = |vs: &tch::nn::Path| {
+        let v = vs.sub("a").sub("b").ones("t2", &[3]);
+        let u = vs.zeros("t1", &[4]);
+        let _w = vs.sub("a").sub("b").sub("ccc").ones("t123", &[3]);
+        let _w = vs.sub("a").sub("b").sub("ccc").ones("t123", &[3]);
+        (u, v)
+    };
+    let vs1 = VarStore::new(Device::Cpu);
+    let mut vs2 = VarStore::new(Device::Cpu);
+    let (mut u1, mut v1) = add(&vs1.root());
+    let (u2, v2) = add(&vs2.root());
+    tch::no_grad(|| {
+        u1 += 42.0;
+        v1 *= 2.0;
+    });
+    assert_eq!(f64::from(&u1.mean(Kind::Float)), 42.0);
+    assert_eq!(f64::from(&v1.mean(Kind::Float)), 2.0);
+    assert_eq!(f64::from(&u2.mean(Kind::Float)), 0.0);
+    assert_eq!(f64::from(&v2.mean(Kind::Float)), 1.0);
+    vs1.save(&filename).unwrap();
+    let missing_variables = vs2.load_partial(&filename).unwrap();
+    assert_eq!(f64::from(&u1.mean(Kind::Float)), 42.0);
+    assert_eq!(f64::from(&u2.mean(Kind::Float)), 42.0);
+    assert_eq!(f64::from(&v2.mean(Kind::Float)), 2.0);
+    assert!(missing_variables.is_none());
+}
+
+#[test]
 #[should_panic]
 fn save_and_load_var_store_incomplete_file() {
     let filename = std::env::temp_dir().join(format!("tch-vs-{}", std::process::id()));
     let add = |vs: &tch::nn::Path| {
         let u = vs.zeros("t1", &[4]);
         let _w = vs.sub("a").sub("b").sub("ccc").ones("t123", &[3]);
-        let _w = vs.sub("a").sub("b").sub("ccc").ones("t123", &[3]);
         u
     };
     let add_partial = |vs: &tch::nn::Path| {
         let v = vs.sub("a").sub("b").ones("t2", &[3]);
         let u = vs.zeros("t1", &[4]);
-        let _w = vs.sub("a").sub("b").sub("ccc").ones("t123", &[3]);
         let _w = vs.sub("a").sub("b").sub("ccc").ones("t123", &[3]);
         (u, v)
     };
@@ -76,18 +104,16 @@ fn save_and_load_var_store_incomplete_file() {
 }
 
 #[test]
-fn save_and_load_partial_var_store() {
+fn save_and_load_partial_var_store_incomplete_file() {
     let filename = std::env::temp_dir().join(format!("tch-vs-{}", std::process::id()));
     let add = |vs: &tch::nn::Path| {
         let u = vs.zeros("t1", &[4]);
-        let _w = vs.sub("a").sub("b").sub("ccc").ones("t123", &[3]);
         let _w = vs.sub("a").sub("b").sub("ccc").ones("t123", &[3]);
         u
     };
     let add_partial = |vs: &tch::nn::Path| {
         let v = vs.sub("a").sub("b").ones("t2", &[3]);
         let u = vs.zeros("t1", &[4]);
-        let _w = vs.sub("a").sub("b").sub("ccc").ones("t123", &[3]);
         let _w = vs.sub("a").sub("b").sub("ccc").ones("t123", &[3]);
         (u, v)
     };
@@ -102,10 +128,11 @@ fn save_and_load_partial_var_store() {
     assert_eq!(f64::from(&u2.mean(Kind::Float)), 0.0);
     assert_eq!(f64::from(&v2.mean(Kind::Float)), 1.0);
     vs1.save(&filename).unwrap();
-    vs2.load_partial(&filename).unwrap();
+    let missing_variables = vs2.load_partial(&filename).unwrap();
     assert_eq!(f64::from(&u1.mean(Kind::Float)), 42.0);
     assert_eq!(f64::from(&u2.mean(Kind::Float)), 42.0);
     assert_eq!(f64::from(&v2.mean(Kind::Float)), 1.0);
+    assert_eq!(missing_variables, Some(vec!(String::from("a.b.t2"))));
 }
 
 #[test]


### PR DESCRIPTION
The current load method for loading weights in the var store performs a robust check that all of the variables of the var store can be found in the weights file. This is adequate for running inference or fine-tuning without architecture change.

It is common to load a set of pre-trained weights for the base of a model (e.g. conv blocks, embeddings, language models) and stack a few untrained layers on top of this pre-trained base. These layers are commonly trained from scratch.

Proposing adding a load_partial method that would allow loading a subset of the weights, returning a message with the weights that were not updated instead of panicking.