### PR TITLE
Allow building with FFI stubs without linking to torch.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,13 @@ cpython = { version = "0.2.0", optional = true }
 members = ["torch-sys"]
 
 [features]
+default = ["real-ffi"]
 python = ["cpython"]
+real-ffi = ["torch-sys/real-ffi"]
 
 [[example]]
 name = "reinforcement-learning"
 required-features = ["python"]
+
+[package.metadata.docs.rs]
+no-default-feautres = true

--- a/gen/gen.ml
+++ b/gen/gen.ml
@@ -567,17 +567,16 @@ let write_ffi funcs filename =
       pm "use crate::{C_scalar, C_tensor};";
       pm "use libc::c_int;";
       pm "";
-      pm "extern \"C\" {";
       Map.iteri funcs ~f:(fun ~key:exported_name ~data:func ->
           match func.Func.returns with
           | `fixed _ ->
-              pm "    pub fn atg_%s(out__: *mut *mut C_tensor, %s);"
+              pm "    pub_ffi!(fn atg_%s(out__: *mut *mut C_tensor, %s));"
                 exported_name
                 (Func.c_rust_args_list func)
           | `dynamic ->
-              pm "    pub fn atg_%s(%s) -> *mut *mut C_tensor;" exported_name
+              pm "    pub_ffi!(fn atg_%s(%s) -> *mut *mut C_tensor);" exported_name
                 (Func.c_rust_args_list func));
-      pm "}")
+      )
 
 let methods =
   let c name args = { Func.name; args; returns = `fixed 1; kind = `method_ } in

--- a/torch-sys/Cargo.toml
+++ b/torch-sys/Cargo.toml
@@ -12,12 +12,19 @@ keywords = ["pytorch", "ffi", "deep-learning", "machine-learning"]
 categories = ["external-ffi-bindings", "science"]
 license = "MIT/Apache-2.0"
 
+[features]
+default = ["real-ffi"]
+real-ffi = ["cc", "cmake", "curl", "failure", "zip"]
+
 [dependencies]
 libc = "0.2.0"
 
 [build-dependencies]
-cc = "1.0"
-cmake = "0.1"
-curl = "0.4.9"
-failure = "0.1"
-zip = "0.5"
+cc = { version = "1.0", optional = true }
+cmake = { version = "0.1", optional = true }
+curl = { version = "0.4.9", optional = true }
+failure = { version = "0.1", optional = true }
+zip = { version = "0.5", optional = true }
+
+[package.metadata.docs.rs]
+no-default-feautres = true

--- a/torch-sys/build.rs
+++ b/torch-sys/build.rs
@@ -5,191 +5,203 @@
 //
 // On Linux, the TORCH_CUDA_VERSION environment variable can be used,
 // like 9.0, 90, or cu90 to specify the version of CUDA to use for libtorch.
+
+#[cfg(feature = "real-ffi")]
 #[macro_use]
 extern crate failure;
 
-use std::env;
-use std::fs;
-use std::io;
-use std::io::Write;
-use std::path::{Path, PathBuf};
+#[cfg(feature = "real-ffi")]
+mod real_ffi {
+    use std::env;
+    use std::fs;
+    use std::io;
+    use std::io::Write;
+    use std::path::{Path, PathBuf};
 
-use cmake::Config;
-use curl::easy::Easy;
-use failure::Fallible;
-use zip;
+    use cmake::Config;
+    use curl::easy::Easy;
+    use failure::Fallible;
+    use zip;
 
-const TORCH_VERSION: &'static str = "1.4.0";
+    const TORCH_VERSION: &'static str = "1.4.0";
 
-fn download<P: AsRef<Path>>(source_url: &str, target_file: P) -> Fallible<()> {
-    let f = fs::File::create(&target_file)?;
-    let mut writer = io::BufWriter::new(f);
-    let mut easy = Easy::new();
-    easy.url(&source_url)?;
-    easy.write_function(move |data| Ok(writer.write(data).unwrap()))?;
-    easy.perform()?;
-    let response_code = easy.response_code()?;
-    if response_code == 200 {
-        Ok(())
-    } else {
-        Err(format_err!(
-            "Unexpected response code {} for {}",
-            response_code,
-            source_url
-        ))
+    fn download<P: AsRef<Path>>(source_url: &str, target_file: P) -> Fallible<()> {
+        let f = fs::File::create(&target_file)?;
+        let mut writer = io::BufWriter::new(f);
+        let mut easy = Easy::new();
+        easy.url(&source_url)?;
+        easy.write_function(move |data| Ok(writer.write(data).unwrap()))?;
+        easy.perform()?;
+        let response_code = easy.response_code()?;
+        if response_code == 200 {
+            Ok(())
+        } else {
+            Err(format_err!(
+                "Unexpected response code {} for {}",
+                response_code,
+                source_url
+            ))
+        }
     }
-}
 
-fn extract<P: AsRef<Path>>(filename: P, outpath: P) -> Fallible<()> {
-    let file = fs::File::open(&filename)?;
-    let buf = io::BufReader::new(file);
-    let mut archive = zip::ZipArchive::new(buf)?;
-    for i in 0..archive.len() {
-        let mut file = archive.by_index(i)?;
-        let outpath = outpath.as_ref().join(file.sanitized_name());
-        if !(&*file.name()).ends_with('/') {
-            println!(
-                "File {} extracted to \"{}\" ({} bytes)",
-                i,
-                outpath.as_path().display(),
-                file.size()
-            );
-            if let Some(p) = outpath.parent() {
-                if !p.exists() {
-                    fs::create_dir_all(&p)?;
+    fn extract<P: AsRef<Path>>(filename: P, outpath: P) -> Fallible<()> {
+        let file = fs::File::open(&filename)?;
+        let buf = io::BufReader::new(file);
+        let mut archive = zip::ZipArchive::new(buf)?;
+        for i in 0..archive.len() {
+            let mut file = archive.by_index(i)?;
+            let outpath = outpath.as_ref().join(file.sanitized_name());
+            if !(&*file.name()).ends_with('/') {
+                println!(
+                    "File {} extracted to \"{}\" ({} bytes)",
+                    i,
+                    outpath.as_path().display(),
+                    file.size()
+                );
+                if let Some(p) = outpath.parent() {
+                    if !p.exists() {
+                        fs::create_dir_all(&p)?;
+                    }
                 }
+                let mut outfile = fs::File::create(&outpath)?;
+                io::copy(&mut file, &mut outfile)?;
             }
-            let mut outfile = fs::File::create(&outpath)?;
-            io::copy(&mut file, &mut outfile)?;
+        }
+        Ok(())
+    }
+
+    fn prepare_libtorch_dir() -> PathBuf {
+        let os = env::var("CARGO_CFG_TARGET_OS").expect("Unable to get TARGET_OS");
+
+        let device = match env::var("TORCH_CUDA_VERSION") {
+            Ok(cuda_env) => match os.as_str() {
+                "linux" | "windows" => cuda_env
+                    .trim()
+                    .to_lowercase()
+                    .trim_start_matches("cu")
+                    .split(".")
+                    .take(2)
+                    .fold("cu".to_string(), |mut acc, curr| {
+                        acc += curr;
+                        acc
+                    }),
+                os_str => panic!(
+                    "CUDA was specified with `TORCH_CUDA_VERSION`, but pre-built \
+                     binaries with CUDA are only available for Linux and Windows, not: {}.",
+                    os_str
+                ),
+            },
+            Err(_) => "cpu".to_string(),
+        };
+
+        if let Ok(libtorch) = env::var("LIBTORCH") {
+            PathBuf::from(libtorch)
+        } else {
+            let libtorch_dir = PathBuf::from(env::var("OUT_DIR").unwrap()).join("libtorch");
+            if !libtorch_dir.exists() {
+                fs::create_dir(&libtorch_dir).unwrap_or_default();
+                let libtorch_url = match os.as_str() {
+                    "linux" => format!(
+                        "https://download.pytorch.org/libtorch/{}/libtorch-cxx11-abi-shared-with-deps-{}{}.zip",
+                        device, TORCH_VERSION, match device.as_ref() { "cpu" => "%2Bcpu", "cu92" => "%2Bcu92", _ => "" }
+                    ),
+                    "macos" => format!(
+                        "https://download.pytorch.org/libtorch/cpu/libtorch-macos-{}.zip",
+                        TORCH_VERSION
+                    ),
+                    "windows" => format!(
+                        "https://download.pytorch.org/libtorch/{}/libtorch-win-shared-with-deps-{}.zip",
+                        device,
+                        TORCH_VERSION
+                    ),
+                    _ => panic!("Unsupported OS"),
+                };
+
+                let filename = libtorch_dir.join(format!("v{}.zip", TORCH_VERSION));
+                download(&libtorch_url, &filename).unwrap();
+                extract(&filename, &libtorch_dir).unwrap();
+            }
+
+            libtorch_dir.join("libtorch")
         }
     }
-    Ok(())
-}
 
-fn prepare_libtorch_dir() -> PathBuf {
-    let os = env::var("CARGO_CFG_TARGET_OS").expect("Unable to get TARGET_OS");
+    fn make<P: AsRef<Path>>(libtorch: P) {
+        let os = env::var("CARGO_CFG_TARGET_OS").expect("Unable to get TARGET_OS");
 
-    let device = match env::var("TORCH_CUDA_VERSION") {
-        Ok(cuda_env) => match os.as_str() {
-            "linux" | "windows" => cuda_env
-                .trim()
-                .to_lowercase()
-                .trim_start_matches("cu")
-                .split(".")
-                .take(2)
-                .fold("cu".to_string(), |mut acc, curr| {
-                    acc += curr;
-                    acc
-                }),
-            os_str => panic!(
-                "CUDA was specified with `TORCH_CUDA_VERSION`, but pre-built \
-                 binaries with CUDA are only available for Linux and Windows, not: {}.",
-                os_str
-            ),
-        },
-        Err(_) => "cpu".to_string(),
-    };
-
-    if let Ok(libtorch) = env::var("LIBTORCH") {
-        PathBuf::from(libtorch)
-    } else {
-        let libtorch_dir = PathBuf::from(env::var("OUT_DIR").unwrap()).join("libtorch");
-        if !libtorch_dir.exists() {
-            fs::create_dir(&libtorch_dir).unwrap_or_default();
-            let libtorch_url = match os.as_str() {
-                "linux" => format!(
-                    "https://download.pytorch.org/libtorch/{}/libtorch-cxx11-abi-shared-with-deps-{}{}.zip",
-                    device, TORCH_VERSION, match device.as_ref() { "cpu" => "%2Bcpu", "cu92" => "%2Bcu92", _ => "" }
-                ),
-                "macos" => format!(
-                    "https://download.pytorch.org/libtorch/cpu/libtorch-macos-{}.zip",
-                    TORCH_VERSION
-                ),
-                "windows" => format!(
-                    "https://download.pytorch.org/libtorch/{}/libtorch-win-shared-with-deps-{}.zip",
-                    device,
-                    TORCH_VERSION
-                ),
-                _ => panic!("Unsupported OS"),
-            };
-
-            let filename = libtorch_dir.join(format!("v{}.zip", TORCH_VERSION));
-            download(&libtorch_url, &filename).unwrap();
-            extract(&filename, &libtorch_dir).unwrap();
-        }
-
-        libtorch_dir.join("libtorch")
+        match os.as_str() {
+            "linux" | "macos" => {
+                let libtorch_cxx11_abi = env::var("LIBTORCH_CXX11_ABI").unwrap_or("1".to_string());
+                cc::Build::new()
+                    .cpp(true)
+                    .pic(true)
+                    .warnings(false)
+                    .include(libtorch.as_ref().join("include"))
+                    .include(libtorch.as_ref().join("include/torch/csrc/api/include"))
+                    .flag(&format!(
+                        "-Wl,-rpath={}",
+                        libtorch.as_ref().join("lib").display()
+                    ))
+                    .flag("-std=c++11")
+                    .flag(&format!("-D_GLIBCXX_USE_CXX11_ABI={}", libtorch_cxx11_abi))
+                    .file("libtch/torch_api.cpp")
+                    .compile("tch");
+            }
+            "windows" => {
+                // TODO: Pass "/link" "LIBPATH:{}" to cl.exe in order to emulate rpath.
+                //       Not yet supported by cc=rs.
+                //       https://github.com/alexcrichton/cc-rs/issues/323
+                cc::Build::new()
+                    .cpp(true)
+                    .pic(true)
+                    .warnings(false)
+                    .include(libtorch.as_ref().join("include"))
+                    .include(libtorch.as_ref().join("include/torch/csrc/api/include"))
+                    .file("libtch/torch_api.cpp")
+                    .compile("tch");
+            }
+            _ => panic!("Unsupported OS"),
+        };
     }
-}
 
-fn make<P: AsRef<Path>>(libtorch: P) {
-    let os = env::var("CARGO_CFG_TARGET_OS").expect("Unable to get TARGET_OS");
+    fn cmake<P: AsRef<Path>>(libtorch: P) {
+        let dst = Config::new("libtch")
+            .define("CMAKE_PREFIX_PATH", libtorch.as_ref())
+            .build();
 
-    match os.as_str() {
-        "linux" | "macos" => {
-            let libtorch_cxx11_abi = env::var("LIBTORCH_CXX11_ABI").unwrap_or("1".to_string());
-            cc::Build::new()
-                .cpp(true)
-                .pic(true)
-                .warnings(false)
-                .include(libtorch.as_ref().join("include"))
-                .include(libtorch.as_ref().join("include/torch/csrc/api/include"))
-                .flag(&format!(
-                    "-Wl,-rpath={}",
-                    libtorch.as_ref().join("lib").display()
-                ))
-                .flag("-std=c++11")
-                .flag(&format!("-D_GLIBCXX_USE_CXX11_ABI={}", libtorch_cxx11_abi))
-                .file("libtch/torch_api.cpp")
-                .compile("tch");
+        println!("cargo:rustc-link-search=native={}", dst.display());
+        println!("cargo:rustc-link-lib=static=tch");
+        println!("cargo:rustc-link-lib=stdc++");
+    }
+
+    pub fn main() {
+        let libtorch = prepare_libtorch_dir();
+        println!(
+            "cargo:rustc-link-search=native={}",
+            libtorch.join("lib").display()
+        );
+
+        if env::var("LIBTORCH_USE_CMAKE").is_ok() {
+            cmake(&libtorch)
+        } else {
+            make(&libtorch)
         }
-        "windows" => {
-            // TODO: Pass "/link" "LIBPATH:{}" to cl.exe in order to emulate rpath.
-            //       Not yet supported by cc=rs.
-            //       https://github.com/alexcrichton/cc-rs/issues/323
-            cc::Build::new()
-                .cpp(true)
-                .pic(true)
-                .warnings(false)
-                .include(libtorch.as_ref().join("include"))
-                .include(libtorch.as_ref().join("include/torch/csrc/api/include"))
-                .file("libtch/torch_api.cpp")
-                .compile("tch");
+
+        println!("cargo:rustc-link-lib=static=tch");
+        println!("cargo:rustc-link-lib=torch");
+        println!("cargo:rustc-link-lib=c10");
+
+        let target = env::var("TARGET").unwrap();
+
+        if !target.contains("msvc") && !target.contains("apple") {
+            println!("cargo:rustc-link-lib=gomp");
         }
-        _ => panic!("Unsupported OS"),
-    };
-}
-
-fn cmake<P: AsRef<Path>>(libtorch: P) {
-    let dst = Config::new("libtch")
-        .define("CMAKE_PREFIX_PATH", libtorch.as_ref())
-        .build();
-
-    println!("cargo:rustc-link-search=native={}", dst.display());
-    println!("cargo:rustc-link-lib=static=tch");
-    println!("cargo:rustc-link-lib=stdc++");
+    }
 }
 
 fn main() {
-    let libtorch = prepare_libtorch_dir();
-    println!(
-        "cargo:rustc-link-search=native={}",
-        libtorch.join("lib").display()
-    );
-
-    if env::var("LIBTORCH_USE_CMAKE").is_ok() {
-        cmake(&libtorch)
-    } else {
-        make(&libtorch)
-    }
-
-    println!("cargo:rustc-link-lib=static=tch");
-    println!("cargo:rustc-link-lib=torch");
-    println!("cargo:rustc-link-lib=c10");
-
-    let target = env::var("TARGET").unwrap();
-
-    if !target.contains("msvc") && !target.contains("apple") {
-        println!("cargo:rustc-link-lib=gomp");
+    #[cfg(feature = "real-ffi")]
+    {
+        real_ffi::main()
     }
 }

--- a/torch-sys/src/c_generated.rs
+++ b/torch-sys/src/c_generated.rs
@@ -3,6045 +3,1100 @@
 use crate::{C_scalar, C_tensor};
 use libc::c_int;
 
-extern "C" {
-    pub fn atg___and__(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg___and__1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg___iand__(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg___iand__1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg___ilshift__(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg___ilshift__1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg___ior__(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg___ior__1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg___irshift__(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg___irshift__1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg___ixor__(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg___ixor__1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg___lshift__(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg___lshift__1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg___or__(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg___or__1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg___rshift__(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg___rshift__1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg___xor__(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg___xor__1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg__adaptive_avg_pool2d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-    );
-    pub fn atg__adaptive_avg_pool2d_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-    );
-    pub fn atg__addr(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        vec1_: *mut C_tensor,
-        vec2_: *mut C_tensor,
-    );
-    pub fn atg__addr_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        vec1_: *mut C_tensor,
-        vec2_: *mut C_tensor,
-    );
-    pub fn atg__addr_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        vec1_: *mut C_tensor,
-        vec2_: *mut C_tensor,
-    );
-    pub fn atg__baddbmm_mkl_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        batch1_: *mut C_tensor,
-        batch2_: *mut C_tensor,
-    );
-    pub fn atg__cast_byte(out__: *mut *mut C_tensor, self_: *mut C_tensor, non_blocking_: c_int);
-    pub fn atg__cast_char(out__: *mut *mut C_tensor, self_: *mut C_tensor, non_blocking_: c_int);
-    pub fn atg__cast_double(out__: *mut *mut C_tensor, self_: *mut C_tensor, non_blocking_: c_int);
-    pub fn atg__cast_float(out__: *mut *mut C_tensor, self_: *mut C_tensor, non_blocking_: c_int);
-    pub fn atg__cast_half(out__: *mut *mut C_tensor, self_: *mut C_tensor, non_blocking_: c_int);
-    pub fn atg__cast_int(out__: *mut *mut C_tensor, self_: *mut C_tensor, non_blocking_: c_int);
-    pub fn atg__cast_long(out__: *mut *mut C_tensor, self_: *mut C_tensor, non_blocking_: c_int);
-    pub fn atg__cast_short(out__: *mut *mut C_tensor, self_: *mut C_tensor, non_blocking_: c_int);
-    pub fn atg__cat(
-        out__: *mut *mut C_tensor,
-        tensors_data: *const *mut C_tensor,
-        tensors_len: c_int,
-        dim_: i64,
-    );
-    pub fn atg__cat_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        tensors_data: *const *mut C_tensor,
-        tensors_len: c_int,
-        dim_: i64,
-    );
-    pub fn atg__cdist_backward(
-        out__: *mut *mut C_tensor,
-        grad_: *mut C_tensor,
-        x1_: *mut C_tensor,
-        x2_: *mut C_tensor,
-        p_: f64,
-        cdist_: *mut C_tensor,
-    );
-    pub fn atg__cholesky_helper(out__: *mut *mut C_tensor, self_: *mut C_tensor, upper_: c_int);
-    pub fn atg__cholesky_solve_helper(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        A_: *mut C_tensor,
-        upper_: c_int,
-    );
-    pub fn atg__coalesced_(out__: *mut *mut C_tensor, self_: *mut C_tensor, coalesced_: c_int);
-    pub fn atg__convolution(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        transposed_: c_int,
-        output_padding_data: *const i64,
-        output_padding_len: c_int,
-        groups_: i64,
-        benchmark_: c_int,
-        deterministic_: c_int,
-        cudnn_enabled_: c_int,
-    );
-    pub fn atg__convolution_nogroup(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        transposed_: c_int,
-        output_padding_data: *const i64,
-        output_padding_len: c_int,
-    );
-    pub fn atg__copy_from(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dst_: *mut C_tensor,
-        non_blocking_: c_int,
-    );
-    pub fn atg__ctc_loss(
-        out__: *mut *mut C_tensor,
-        log_probs_: *mut C_tensor,
-        targets_: *mut C_tensor,
-        input_lengths_data: *const i64,
-        input_lengths_len: c_int,
-        target_lengths_data: *const i64,
-        target_lengths_len: c_int,
-        blank_: i64,
-        zero_infinity_: c_int,
-    );
-    pub fn atg__ctc_loss_backward(
-        out__: *mut *mut C_tensor,
-        grad_: *mut C_tensor,
-        log_probs_: *mut C_tensor,
-        targets_: *mut C_tensor,
-        input_lengths_data: *const i64,
-        input_lengths_len: c_int,
-        target_lengths_data: *const i64,
-        target_lengths_len: c_int,
-        neg_log_likelihood_: *mut C_tensor,
-        log_alpha_: *mut C_tensor,
-        blank_: i64,
-        zero_infinity_: c_int,
-    );
-    pub fn atg__cudnn_ctc_loss(
-        out__: *mut *mut C_tensor,
-        log_probs_: *mut C_tensor,
-        targets_: *mut C_tensor,
-        input_lengths_data: *const i64,
-        input_lengths_len: c_int,
-        target_lengths_data: *const i64,
-        target_lengths_len: c_int,
-        blank_: i64,
-        deterministic_: c_int,
-        zero_infinity_: c_int,
-    );
-    pub fn atg__cudnn_init_dropout_state(
-        out__: *mut *mut C_tensor,
-        dropout_: f64,
-        train_: c_int,
-        dropout_seed_: i64,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg__cudnn_rnn(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        weight_data: *const *mut C_tensor,
-        weight_len: c_int,
-        weight_stride0_: i64,
-        weight_buf_: *mut C_tensor,
-        hx_: *mut C_tensor,
-        cx_: *mut C_tensor,
-        mode_: i64,
-        hidden_size_: i64,
-        num_layers_: i64,
-        batch_first_: c_int,
-        dropout_: f64,
-        train_: c_int,
-        bidirectional_: c_int,
-        batch_sizes_data: *const i64,
-        batch_sizes_len: c_int,
-        dropout_state_: *mut C_tensor,
-    );
-    pub fn atg__cudnn_rnn_flatten_weight(
-        out__: *mut *mut C_tensor,
-        weight_arr_data: *const *mut C_tensor,
-        weight_arr_len: c_int,
-        weight_stride0_: i64,
-        input_size_: i64,
-        mode_: i64,
-        hidden_size_: i64,
-        num_layers_: i64,
-        batch_first_: c_int,
-        bidirectional_: c_int,
-    );
-    pub fn atg__cumprod(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64);
-    pub fn atg__cumprod_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-    );
-    pub fn atg__cumsum(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64);
-    pub fn atg__cumsum_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-    );
-    pub fn atg__dim_arange(out__: *mut *mut C_tensor, like_: *mut C_tensor, dim_: i64);
-    pub fn atg__dirichlet_grad(
-        out__: *mut *mut C_tensor,
-        x_: *mut C_tensor,
-        alpha_: *mut C_tensor,
-        total_: *mut C_tensor,
-    );
-    pub fn atg__embedding_bag(
-        out__: *mut *mut C_tensor,
-        weight_: *mut C_tensor,
-        indices_: *mut C_tensor,
-        offsets_: *mut C_tensor,
-        scale_grad_by_freq_: c_int,
-        mode_: i64,
-        sparse_: c_int,
-        per_sample_weights_: *mut C_tensor,
-    );
-    pub fn atg__embedding_bag_backward(
-        out__: *mut *mut C_tensor,
-        grad_: *mut C_tensor,
-        indices_: *mut C_tensor,
-        offsets_: *mut C_tensor,
-        offset2bag_: *mut C_tensor,
-        bag_size_: *mut C_tensor,
-        maximum_indices_: *mut C_tensor,
-        num_weights_: i64,
-        scale_grad_by_freq_: c_int,
-        mode_: i64,
-        sparse_: c_int,
-        per_sample_weights_: *mut C_tensor,
-    );
-    pub fn atg__embedding_bag_dense_backward(
-        out__: *mut *mut C_tensor,
-        grad_: *mut C_tensor,
-        indices_: *mut C_tensor,
-        offsets_: *mut C_tensor,
-        offset2bag_: *mut C_tensor,
-        bag_size_: *mut C_tensor,
-        maximum_indices_: *mut C_tensor,
-        num_weights_: i64,
-        scale_grad_by_freq_: c_int,
-        mode_: i64,
-        per_sample_weights_: *mut C_tensor,
-    );
-    pub fn atg__embedding_bag_per_sample_weights_backward(
-        out__: *mut *mut C_tensor,
-        grad_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        indices_: *mut C_tensor,
-        offsets_: *mut C_tensor,
-        offset2bag_: *mut C_tensor,
-        mode_: i64,
-    );
-    pub fn atg__embedding_bag_sparse_backward(
-        out__: *mut *mut C_tensor,
-        grad_: *mut C_tensor,
-        indices_: *mut C_tensor,
-        offsets_: *mut C_tensor,
-        offset2bag_: *mut C_tensor,
-        bag_size_: *mut C_tensor,
-        num_weights_: i64,
-        scale_grad_by_freq_: c_int,
-        mode_: i64,
-        per_sample_weights_: *mut C_tensor,
-    );
-    pub fn atg__empty_affine_quantized(
-        out__: *mut *mut C_tensor,
-        size_data: *const i64,
-        size_len: c_int,
-        options_kind: c_int,
-        options_device: c_int,
-        scale_: f64,
-        zero_point_: i64,
-    );
-    pub fn atg__empty_per_channel_affine_quantized(
-        out__: *mut *mut C_tensor,
-        size_data: *const i64,
-        size_len: c_int,
-        scales_: *mut C_tensor,
-        zero_points_: *mut C_tensor,
-        axis_: i64,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg__fft_with_size(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        signal_ndim_: i64,
-        complex_input_: c_int,
-        complex_output_: c_int,
-        inverse_: c_int,
-        checked_signal_sizes_data: *const i64,
-        checked_signal_sizes_len: c_int,
-        normalized_: c_int,
-        onesided_: c_int,
-        output_sizes_data: *const i64,
-        output_sizes_len: c_int,
-    );
-    pub fn atg__fused_dropout(out__: *mut *mut C_tensor, self_: *mut C_tensor, p_: f64);
-    pub fn atg__gather_sparse_backward(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        index_: *mut C_tensor,
-        grad_: *mut C_tensor,
-    );
-    pub fn atg__index_copy_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        index_: *mut C_tensor,
-        source_: *mut C_tensor,
-    );
-    pub fn atg__index_put_impl_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        indices_data: *const *mut C_tensor,
-        indices_len: c_int,
-        values_: *mut C_tensor,
-        accumulate_: c_int,
-        unsafe_: c_int,
-    );
-    pub fn atg__indices(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg__inverse_helper(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg__log_softmax(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        half_to_float_: c_int,
-    );
-    pub fn atg__log_softmax_backward_data(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        output_: *mut C_tensor,
-        dim_: i64,
-        self_: *mut C_tensor,
-    );
-    pub fn atg__lu_solve_helper(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        LU_data_: *mut C_tensor,
-        LU_pivots_: *mut C_tensor,
-    );
-    pub fn atg__lu_with_info(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        pivot_: c_int,
-        check_errors_: c_int,
-    );
-    pub fn atg__make_per_channel_quantized_tensor(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        scale_: *mut C_tensor,
-        zero_point_: *mut C_tensor,
-        axis_: i64,
-    );
-    pub fn atg__make_per_tensor_quantized_tensor(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        scale_: f64,
-        zero_point_: i64,
-    );
-    pub fn atg__masked_scale(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        mask_: *mut C_tensor,
-        scale_: f64,
-    );
-    pub fn atg__max(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int);
-    pub fn atg__max_out(
-        out__: *mut *mut C_tensor,
-        max_: *mut C_tensor,
-        max_indices_: *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        keepdim_: c_int,
-    );
-    pub fn atg__min(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int);
-    pub fn atg__min_out(
-        out__: *mut *mut C_tensor,
-        min_: *mut C_tensor,
-        min_indices_: *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        keepdim_: c_int,
-    );
-    pub fn atg__mkldnn_reshape(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        shape_data: *const i64,
-        shape_len: c_int,
-    );
-    pub fn atg__mkldnn_transpose(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim0_: i64,
-        dim1_: i64,
-    );
-    pub fn atg__mkldnn_transpose_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim0_: i64,
-        dim1_: i64,
-    );
-    pub fn atg__mode(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int);
-    pub fn atg__mode_out(
-        out__: *mut *mut C_tensor,
-        values_: *mut C_tensor,
-        indices_: *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        keepdim_: c_int,
-    );
-    pub fn atg__multinomial_alias_draw(
-        out__: *mut *mut C_tensor,
-        J_: *mut C_tensor,
-        q_: *mut C_tensor,
-        num_samples_: i64,
-    );
-    pub fn atg__multinomial_alias_setup(out__: *mut *mut C_tensor, probs_: *mut C_tensor);
-    pub fn atg__nnpack_spatial_convolution(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-    );
-    pub fn atg__nnpack_spatial_convolution_backward_input(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-    );
-    pub fn atg__nnpack_spatial_convolution_backward_weight(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        weightsize_data: *const i64,
-        weightsize_len: c_int,
-        grad_output_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-    );
-    pub fn atg__pack_padded_sequence(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        lengths_: *mut C_tensor,
-        batch_first_: c_int,
-    );
-    pub fn atg__pack_padded_sequence_backward(
-        out__: *mut *mut C_tensor,
-        grad_: *mut C_tensor,
-        input_size_data: *const i64,
-        input_size_len: c_int,
-        batch_sizes_: *mut C_tensor,
-        batch_first_: c_int,
-    );
-    pub fn atg__pad_packed_sequence(
-        out__: *mut *mut C_tensor,
-        data_: *mut C_tensor,
-        batch_sizes_: *mut C_tensor,
-        batch_first_: c_int,
-        padding_value_: *mut C_scalar,
-        total_length_: i64,
-    );
-    pub fn atg__pdist_backward(
-        out__: *mut *mut C_tensor,
-        grad_: *mut C_tensor,
-        self_: *mut C_tensor,
-        p_: f64,
-        pdist_: *mut C_tensor,
-    );
-    pub fn atg__qr_helper(out__: *mut *mut C_tensor, self_: *mut C_tensor, some_: c_int);
-    pub fn atg__reshape_from_tensor(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        shape_: *mut C_tensor,
-    );
-    pub fn atg__s_where(
-        out__: *mut *mut C_tensor,
-        condition_: *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_tensor,
-    );
-    pub fn atg__sample_dirichlet(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg__shape_as_tensor(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg__sobol_engine_draw(
-        out__: *mut *mut C_tensor,
-        quasi_: *mut C_tensor,
-        n_: i64,
-        sobolstate_: *mut C_tensor,
-        dimension_: i64,
-        num_generated_: i64,
-        dtype_: c_int,
-    );
-    pub fn atg__sobol_engine_ff_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        n_: i64,
-        sobolstate_: *mut C_tensor,
-        dimension_: i64,
-        num_generated_: i64,
-    );
-    pub fn atg__sobol_engine_initialize_state_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dimension_: i64,
-    );
-    pub fn atg__sobol_engine_scramble_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        ltm_: *mut C_tensor,
-        dimension_: i64,
-    );
-    pub fn atg__softmax(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        half_to_float_: c_int,
-    );
-    pub fn atg__softmax_backward_data(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        output_: *mut C_tensor,
-        dim_: i64,
-        self_: *mut C_tensor,
-    );
-    pub fn atg__solve_helper(out__: *mut *mut C_tensor, self_: *mut C_tensor, A_: *mut C_tensor);
-    pub fn atg__sparse_addmm(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        sparse_: *mut C_tensor,
-        dense_: *mut C_tensor,
-    );
-    pub fn atg__sparse_coo_tensor_unsafe(
-        out__: *mut *mut C_tensor,
-        indices_: *mut C_tensor,
-        values_: *mut C_tensor,
-        size_data: *const i64,
-        size_len: c_int,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg__sparse_coo_tensor_with_dims(
-        out__: *mut *mut C_tensor,
-        sparse_dim_: i64,
-        dense_dim_: i64,
-        size_data: *const i64,
-        size_len: c_int,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg__sparse_coo_tensor_with_dims_and_tensors(
-        out__: *mut *mut C_tensor,
-        sparse_dim_: i64,
-        dense_dim_: i64,
-        size_data: *const i64,
-        size_len: c_int,
-        indices_: *mut C_tensor,
-        values_: *mut C_tensor,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg__sparse_mm(out__: *mut *mut C_tensor, sparse_: *mut C_tensor, dense_: *mut C_tensor);
-    pub fn atg__sparse_sum(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg__sparse_sum1(out__: *mut *mut C_tensor, self_: *mut C_tensor, dtype_: c_int);
-    pub fn atg__sparse_sum2(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_data: *const i64,
-        dim_len: c_int,
-    );
-    pub fn atg__sparse_sum3(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_data: *const i64,
-        dim_len: c_int,
-        dtype_: c_int,
-    );
-    pub fn atg__sparse_sum_backward(
-        out__: *mut *mut C_tensor,
-        grad_: *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_data: *const i64,
-        dim_len: c_int,
-    );
-    pub fn atg__standard_gamma(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg__standard_gamma_grad(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        output_: *mut C_tensor,
-    );
-    pub fn atg__std(out__: *mut *mut C_tensor, self_: *mut C_tensor, unbiased_: c_int);
-    pub fn atg__svd_helper(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        some_: c_int,
-        compute_uv_: c_int,
-    );
-    pub fn atg__symeig_helper(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        eigenvectors_: c_int,
-        upper_: c_int,
-    );
-    pub fn atg__test_optional_float(out__: *mut *mut C_tensor, self_: *mut C_tensor, scale_: f64);
-    pub fn atg__triangular_solve_helper(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        A_: *mut C_tensor,
-        upper_: c_int,
-        transpose_: c_int,
-        unitriangular_: c_int,
-    );
-    pub fn atg__trilinear(
-        out__: *mut *mut C_tensor,
-        i1_: *mut C_tensor,
-        i2_: *mut C_tensor,
-        i3_: *mut C_tensor,
-        expand1_data: *const i64,
-        expand1_len: c_int,
-        expand2_data: *const i64,
-        expand2_len: c_int,
-        expand3_data: *const i64,
-        expand3_len: c_int,
-        sumdim_data: *const i64,
-        sumdim_len: c_int,
-        unroll_dim_: i64,
-    );
-    pub fn atg__unique(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        sorted_: c_int,
-        return_inverse_: c_int,
-    );
-    pub fn atg__unique2(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        sorted_: c_int,
-        return_inverse_: c_int,
-        return_counts_: c_int,
-    );
-    pub fn atg__unsafe_view(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        size_data: *const i64,
-        size_len: c_int,
-    );
-    pub fn atg__values(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg__var(out__: *mut *mut C_tensor, self_: *mut C_tensor, unbiased_: c_int);
-    pub fn atg__weight_norm(
-        out__: *mut *mut C_tensor,
-        v_: *mut C_tensor,
-        g_: *mut C_tensor,
-        dim_: i64,
-    );
-    pub fn atg__weight_norm_cuda_interface(
-        out__: *mut *mut C_tensor,
-        v_: *mut C_tensor,
-        g_: *mut C_tensor,
-        dim_: i64,
-    );
-    pub fn atg__weight_norm_cuda_interface_backward(
-        out__: *mut *mut C_tensor,
-        grad_w_: *mut C_tensor,
-        saved_v_: *mut C_tensor,
-        saved_g_: *mut C_tensor,
-        saved_norms_: *mut C_tensor,
-        dim_: i64,
-    );
-    pub fn atg__weight_norm_differentiable_backward(
-        out__: *mut *mut C_tensor,
-        grad_w_: *mut C_tensor,
-        saved_v_: *mut C_tensor,
-        saved_g_: *mut C_tensor,
-        saved_norms_: *mut C_tensor,
-        dim_: i64,
-    );
-    pub fn atg_abs(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_abs_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_abs_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_acos(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_acos_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_acos_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_adaptive_avg_pool1d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-    );
-    pub fn atg_adaptive_avg_pool2d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-    );
-    pub fn atg_adaptive_avg_pool2d_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-    );
-    pub fn atg_adaptive_avg_pool3d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-    );
-    pub fn atg_adaptive_avg_pool3d_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-    );
-    pub fn atg_adaptive_avg_pool3d_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-    );
-    pub fn atg_adaptive_avg_pool3d_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-    );
-    pub fn atg_adaptive_max_pool1d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-    );
-    pub fn atg_adaptive_max_pool2d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-    );
-    pub fn atg_adaptive_max_pool2d_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        indices_: *mut C_tensor,
-    );
-    pub fn atg_adaptive_max_pool2d_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        indices_: *mut C_tensor,
-    );
-    pub fn atg_adaptive_max_pool2d_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        indices_: *mut C_tensor,
-        self_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-    );
-    pub fn atg_adaptive_max_pool3d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-    );
-    pub fn atg_adaptive_max_pool3d_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        indices_: *mut C_tensor,
-    );
-    pub fn atg_adaptive_max_pool3d_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        indices_: *mut C_tensor,
-    );
-    pub fn atg_adaptive_max_pool3d_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        indices_: *mut C_tensor,
-        self_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-    );
-    pub fn atg_add(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_add1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg_add_(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_add_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg_add_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_tensor,
-    );
-    pub fn atg_addbmm(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        batch1_: *mut C_tensor,
-        batch2_: *mut C_tensor,
-    );
-    pub fn atg_addbmm_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        batch1_: *mut C_tensor,
-        batch2_: *mut C_tensor,
-    );
-    pub fn atg_addbmm_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        batch1_: *mut C_tensor,
-        batch2_: *mut C_tensor,
-    );
-    pub fn atg_addcdiv(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        tensor1_: *mut C_tensor,
-        tensor2_: *mut C_tensor,
-    );
-    pub fn atg_addcdiv_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        tensor1_: *mut C_tensor,
-        tensor2_: *mut C_tensor,
-    );
-    pub fn atg_addcdiv_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        tensor1_: *mut C_tensor,
-        tensor2_: *mut C_tensor,
-    );
-    pub fn atg_addcmul(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        tensor1_: *mut C_tensor,
-        tensor2_: *mut C_tensor,
-    );
-    pub fn atg_addcmul_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        tensor1_: *mut C_tensor,
-        tensor2_: *mut C_tensor,
-    );
-    pub fn atg_addcmul_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        tensor1_: *mut C_tensor,
-        tensor2_: *mut C_tensor,
-    );
-    pub fn atg_addmm(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        mat1_: *mut C_tensor,
-        mat2_: *mut C_tensor,
-    );
-    pub fn atg_addmm_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        mat1_: *mut C_tensor,
-        mat2_: *mut C_tensor,
-    );
-    pub fn atg_addmm_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        mat1_: *mut C_tensor,
-        mat2_: *mut C_tensor,
-    );
-    pub fn atg_addmv(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        mat_: *mut C_tensor,
-        vec_: *mut C_tensor,
-    );
-    pub fn atg_addmv_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        mat_: *mut C_tensor,
-        vec_: *mut C_tensor,
-    );
-    pub fn atg_addmv_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        mat_: *mut C_tensor,
-        vec_: *mut C_tensor,
-    );
-    pub fn atg_addr(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        vec1_: *mut C_tensor,
-        vec2_: *mut C_tensor,
-    );
-    pub fn atg_addr_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        vec1_: *mut C_tensor,
-        vec2_: *mut C_tensor,
-    );
-    pub fn atg_addr_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        vec1_: *mut C_tensor,
-        vec2_: *mut C_tensor,
-    );
-    pub fn atg_affine_grid_generator(
-        out__: *mut *mut C_tensor,
-        theta_: *mut C_tensor,
-        size_data: *const i64,
-        size_len: c_int,
-        align_corners_: c_int,
-    );
-    pub fn atg_affine_grid_generator_backward(
-        out__: *mut *mut C_tensor,
-        grad_: *mut C_tensor,
-        size_data: *const i64,
-        size_len: c_int,
-        align_corners_: c_int,
-    );
-    pub fn atg_alias(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_align_as(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_align_tensors(
-        tensors_data: *const *mut C_tensor,
-        tensors_len: c_int,
-    ) -> *mut *mut C_tensor;
-    pub fn atg_all(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_all1(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int);
-    pub fn atg_all_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        keepdim_: c_int,
-    );
-    pub fn atg_alpha_dropout(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        p_: f64,
-        train_: c_int,
-    );
-    pub fn atg_alpha_dropout_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        p_: f64,
-        train_: c_int,
-    );
-    pub fn atg_angle(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_angle_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_any(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_any1(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int);
-    pub fn atg_any_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        keepdim_: c_int,
-    );
-    pub fn atg_arange(
-        out__: *mut *mut C_tensor,
-        end_: *mut C_scalar,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_arange1(
-        out__: *mut *mut C_tensor,
-        start_: *mut C_scalar,
-        end_: *mut C_scalar,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_arange2(
-        out__: *mut *mut C_tensor,
-        start_: *mut C_scalar,
-        end_: *mut C_scalar,
-        step_: *mut C_scalar,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_arange_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, end_: *mut C_scalar);
-    pub fn atg_arange_out1(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        start_: *mut C_scalar,
-        end_: *mut C_scalar,
-    );
-    pub fn atg_argmax(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int);
-    pub fn atg_argmin(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int);
-    pub fn atg_argsort(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        descending_: c_int,
-    );
-    pub fn atg_as_strided(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        size_data: *const i64,
-        size_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        storage_offset_: i64,
-    );
-    pub fn atg_as_strided_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        size_data: *const i64,
-        size_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        storage_offset_: i64,
-    );
-    pub fn atg_asin(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_asin_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_asin_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_atan(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_atan2(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_atan2_(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_atan2_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_tensor,
-    );
-    pub fn atg_atan_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_atan_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_avg_pool1d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        ceil_mode_: c_int,
-        count_include_pad_: c_int,
-    );
-    pub fn atg_avg_pool2d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        ceil_mode_: c_int,
-        count_include_pad_: c_int,
-        divisor_override_: i64,
-    );
-    pub fn atg_avg_pool2d_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        ceil_mode_: c_int,
-        count_include_pad_: c_int,
-        divisor_override_: i64,
-    );
-    pub fn atg_avg_pool2d_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        ceil_mode_: c_int,
-        count_include_pad_: c_int,
-        divisor_override_: i64,
-    );
-    pub fn atg_avg_pool2d_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        ceil_mode_: c_int,
-        count_include_pad_: c_int,
-        divisor_override_: i64,
-    );
-    pub fn atg_avg_pool3d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        ceil_mode_: c_int,
-        count_include_pad_: c_int,
-        divisor_override_: i64,
-    );
-    pub fn atg_avg_pool3d_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        ceil_mode_: c_int,
-        count_include_pad_: c_int,
-        divisor_override_: i64,
-    );
-    pub fn atg_avg_pool3d_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        ceil_mode_: c_int,
-        count_include_pad_: c_int,
-        divisor_override_: i64,
-    );
-    pub fn atg_avg_pool3d_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        ceil_mode_: c_int,
-        count_include_pad_: c_int,
-        divisor_override_: i64,
-    );
-    pub fn atg_baddbmm(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        batch1_: *mut C_tensor,
-        batch2_: *mut C_tensor,
-    );
-    pub fn atg_baddbmm_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        batch1_: *mut C_tensor,
-        batch2_: *mut C_tensor,
-    );
-    pub fn atg_baddbmm_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        batch1_: *mut C_tensor,
-        batch2_: *mut C_tensor,
-    );
-    pub fn atg_bartlett_window(
-        out__: *mut *mut C_tensor,
-        window_length_: i64,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_bartlett_window1(
-        out__: *mut *mut C_tensor,
-        window_length_: i64,
-        periodic_: c_int,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_batch_norm(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-        running_mean_: *mut C_tensor,
-        running_var_: *mut C_tensor,
-        training_: c_int,
-        momentum_: f64,
-        eps_: f64,
-        cudnn_enabled_: c_int,
-    );
-    pub fn atg_batch_norm_backward_elemt(
-        out__: *mut *mut C_tensor,
-        grad_out_: *mut C_tensor,
-        input_: *mut C_tensor,
-        mean_: *mut C_tensor,
-        invstd_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        mean_dy_: *mut C_tensor,
-        mean_dy_xmu_: *mut C_tensor,
-    );
-    pub fn atg_batch_norm_backward_reduce(
-        out__: *mut *mut C_tensor,
-        grad_out_: *mut C_tensor,
-        input_: *mut C_tensor,
-        mean_: *mut C_tensor,
-        invstd_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        input_g_: c_int,
-        weight_g_: c_int,
-        bias_g_: c_int,
-    );
-    pub fn atg_batch_norm_elemt(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-        mean_: *mut C_tensor,
-        invstd_: *mut C_tensor,
-        eps_: f64,
-    );
-    pub fn atg_batch_norm_elemt_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        input_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-        mean_: *mut C_tensor,
-        invstd_: *mut C_tensor,
-        eps_: f64,
-    );
-    pub fn atg_batch_norm_gather_stats(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        mean_: *mut C_tensor,
-        invstd_: *mut C_tensor,
-        running_mean_: *mut C_tensor,
-        running_var_: *mut C_tensor,
-        momentum_: f64,
-        eps_: f64,
-        count_: i64,
-    );
-    pub fn atg_batch_norm_gather_stats_with_counts(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        mean_: *mut C_tensor,
-        invstd_: *mut C_tensor,
-        running_mean_: *mut C_tensor,
-        running_var_: *mut C_tensor,
-        momentum_: f64,
-        eps_: f64,
-        counts_data: *const i64,
-        counts_len: c_int,
-    );
-    pub fn atg_batch_norm_stats(out__: *mut *mut C_tensor, input_: *mut C_tensor, eps_: f64);
-    pub fn atg_batch_norm_update_stats(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        running_mean_: *mut C_tensor,
-        running_var_: *mut C_tensor,
-        momentum_: f64,
-    );
-    pub fn atg_bernoulli(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_bernoulli1(out__: *mut *mut C_tensor, self_: *mut C_tensor, p_: f64);
-    pub fn atg_bernoulli_(out__: *mut *mut C_tensor, self_: *mut C_tensor, p_: *mut C_tensor);
-    pub fn atg_bernoulli_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, p_: f64);
-    pub fn atg_bernoulli_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_bilinear(
-        out__: *mut *mut C_tensor,
-        input1_: *mut C_tensor,
-        input2_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-    );
-    pub fn atg_binary_cross_entropy(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        reduction_: i64,
-    );
-    pub fn atg_binary_cross_entropy_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        reduction_: i64,
-    );
-    pub fn atg_binary_cross_entropy_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        reduction_: i64,
-    );
-    pub fn atg_binary_cross_entropy_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        reduction_: i64,
-    );
-    pub fn atg_binary_cross_entropy_with_logits(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        pos_weight_: *mut C_tensor,
-        reduction_: i64,
-    );
-    pub fn atg_binary_cross_entropy_with_logits_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        pos_weight_: *mut C_tensor,
-        reduction_: i64,
-    );
-    pub fn atg_bincount(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        weights_: *mut C_tensor,
-        minlength_: i64,
-    );
-    pub fn atg_bitwise_not(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_bitwise_not_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_bitwise_not_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-    );
-    pub fn atg_bitwise_xor(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg_bitwise_xor1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_bitwise_xor_(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg_bitwise_xor_1(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_tensor,
-    );
-    pub fn atg_bitwise_xor_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_tensor,
-    );
-    pub fn atg_bitwise_xor_out1(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_scalar,
-    );
-    pub fn atg_blackman_window(
-        out__: *mut *mut C_tensor,
-        window_length_: i64,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_blackman_window1(
-        out__: *mut *mut C_tensor,
-        window_length_: i64,
-        periodic_: c_int,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_bmm(out__: *mut *mut C_tensor, self_: *mut C_tensor, mat2_: *mut C_tensor);
-    pub fn atg_bmm_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        mat2_: *mut C_tensor,
-    );
-    pub fn atg_broadcast_tensors(
-        tensors_data: *const *mut C_tensor,
-        tensors_len: c_int,
-    ) -> *mut *mut C_tensor;
-    pub fn atg_cartesian_prod(
-        out__: *mut *mut C_tensor,
-        tensors_data: *const *mut C_tensor,
-        tensors_len: c_int,
-    );
-    pub fn atg_cat(
-        out__: *mut *mut C_tensor,
-        tensors_data: *const *mut C_tensor,
-        tensors_len: c_int,
-        dim_: i64,
-    );
-    pub fn atg_cat_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        tensors_data: *const *mut C_tensor,
-        tensors_len: c_int,
-        dim_: i64,
-    );
-    pub fn atg_cauchy_(out__: *mut *mut C_tensor, self_: *mut C_tensor, median_: f64, sigma_: f64);
-    pub fn atg_cdist(
-        out__: *mut *mut C_tensor,
-        x1_: *mut C_tensor,
-        x2_: *mut C_tensor,
-        p_: f64,
-        compute_mode_: i64,
-    );
-    pub fn atg_ceil(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_ceil_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_ceil_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_celu(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_celu_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_chain_matmul(
-        out__: *mut *mut C_tensor,
-        matrices_data: *const *mut C_tensor,
-        matrices_len: c_int,
-    );
-    pub fn atg_cholesky(out__: *mut *mut C_tensor, self_: *mut C_tensor, upper_: c_int);
-    pub fn atg_cholesky_inverse(out__: *mut *mut C_tensor, self_: *mut C_tensor, upper_: c_int);
-    pub fn atg_cholesky_inverse_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        upper_: c_int,
-    );
-    pub fn atg_cholesky_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        upper_: c_int,
-    );
-    pub fn atg_cholesky_solve(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        input2_: *mut C_tensor,
-        upper_: c_int,
-    );
-    pub fn atg_cholesky_solve_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        input2_: *mut C_tensor,
-        upper_: c_int,
-    );
-    pub fn atg_chunk(self_: *mut C_tensor, chunks_: i64, dim_: i64) -> *mut *mut C_tensor;
-    pub fn atg_clamp(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        min_: *mut C_scalar,
-        max_: *mut C_scalar,
-    );
-    pub fn atg_clamp_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        min_: *mut C_scalar,
-        max_: *mut C_scalar,
-    );
-    pub fn atg_clamp_max(out__: *mut *mut C_tensor, self_: *mut C_tensor, max_: *mut C_scalar);
-    pub fn atg_clamp_max_(out__: *mut *mut C_tensor, self_: *mut C_tensor, max_: *mut C_scalar);
-    pub fn atg_clamp_max_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        max_: *mut C_scalar,
-    );
-    pub fn atg_clamp_min(out__: *mut *mut C_tensor, self_: *mut C_tensor, min_: *mut C_scalar);
-    pub fn atg_clamp_min_(out__: *mut *mut C_tensor, self_: *mut C_tensor, min_: *mut C_scalar);
-    pub fn atg_clamp_min_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        min_: *mut C_scalar,
-    );
-    pub fn atg_clamp_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        min_: *mut C_scalar,
-        max_: *mut C_scalar,
-    );
-    pub fn atg_coalesce(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_col2im(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-    );
-    pub fn atg_col2im_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-    );
-    pub fn atg_col2im_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-    );
-    pub fn atg_col2im_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-    );
-    pub fn atg_combinations(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        r_: i64,
-        with_replacement_: c_int,
-    );
-    pub fn atg_conj(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_conj_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_constant_pad_nd(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        pad_data: *const i64,
-        pad_len: c_int,
-    );
-    pub fn atg_contiguous(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_conv1d(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        groups_: i64,
-    );
-    pub fn atg_conv2d(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        groups_: i64,
-    );
-    pub fn atg_conv3d(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        groups_: i64,
-    );
-    pub fn atg_conv_tbc(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-        pad_: i64,
-    );
-    pub fn atg_conv_tbc_backward(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        input_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-        pad_: i64,
-    );
-    pub fn atg_conv_transpose1d(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        output_padding_data: *const i64,
-        output_padding_len: c_int,
-        groups_: i64,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-    );
-    pub fn atg_conv_transpose2d(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        output_padding_data: *const i64,
-        output_padding_len: c_int,
-        groups_: i64,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-    );
-    pub fn atg_conv_transpose3d(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        output_padding_data: *const i64,
-        output_padding_len: c_int,
-        groups_: i64,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-    );
-    pub fn atg_convolution(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        transposed_: c_int,
-        output_padding_data: *const i64,
-        output_padding_len: c_int,
-        groups_: i64,
-    );
-    pub fn atg_convolution_overrideable(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        transposed_: c_int,
-        output_padding_data: *const i64,
-        output_padding_len: c_int,
-        groups_: i64,
-    );
-    pub fn atg_copy_sparse_to_sparse_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        src_: *mut C_tensor,
-        non_blocking_: c_int,
-    );
-    pub fn atg_cos(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_cos_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_cos_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_cosh(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_cosh_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_cosh_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_cosine_embedding_loss(
-        out__: *mut *mut C_tensor,
-        input1_: *mut C_tensor,
-        input2_: *mut C_tensor,
-        target_: *mut C_tensor,
-        margin_: f64,
-        reduction_: i64,
-    );
-    pub fn atg_cosine_similarity(
-        out__: *mut *mut C_tensor,
-        x1_: *mut C_tensor,
-        x2_: *mut C_tensor,
-        dim_: i64,
-        eps_: f64,
-    );
-    pub fn atg_cross(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_tensor,
-        dim_: i64,
-    );
-    pub fn atg_cross_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_tensor,
-        dim_: i64,
-    );
-    pub fn atg_ctc_loss(
-        out__: *mut *mut C_tensor,
-        log_probs_: *mut C_tensor,
-        targets_: *mut C_tensor,
-        input_lengths_data: *const i64,
-        input_lengths_len: c_int,
-        target_lengths_data: *const i64,
-        target_lengths_len: c_int,
-        blank_: i64,
-        reduction_: i64,
-        zero_infinity_: c_int,
-    );
-    pub fn atg_ctc_loss1(
-        out__: *mut *mut C_tensor,
-        log_probs_: *mut C_tensor,
-        targets_: *mut C_tensor,
-        input_lengths_: *mut C_tensor,
-        target_lengths_: *mut C_tensor,
-        blank_: i64,
-        reduction_: i64,
-        zero_infinity_: c_int,
-    );
-    pub fn atg_cudnn_affine_grid_generator(
-        out__: *mut *mut C_tensor,
-        theta_: *mut C_tensor,
-        n_: i64,
-        C_: i64,
-        H_: i64,
-        W_: i64,
-    );
-    pub fn atg_cudnn_affine_grid_generator_backward(
-        out__: *mut *mut C_tensor,
-        grad_: *mut C_tensor,
-        n_: i64,
-        C_: i64,
-        H_: i64,
-        W_: i64,
-    );
-    pub fn atg_cudnn_batch_norm(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-        running_mean_: *mut C_tensor,
-        running_var_: *mut C_tensor,
-        training_: c_int,
-        exponential_average_factor_: f64,
-        epsilon_: f64,
-    );
-    pub fn atg_cudnn_batch_norm_backward(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        running_mean_: *mut C_tensor,
-        running_var_: *mut C_tensor,
-        save_mean_: *mut C_tensor,
-        save_var_: *mut C_tensor,
-        epsilon_: f64,
-        reserveSpace_: *mut C_tensor,
-    );
-    pub fn atg_cudnn_convolution(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        groups_: i64,
-        benchmark_: c_int,
-        deterministic_: c_int,
-    );
-    pub fn atg_cudnn_convolution_backward_bias(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-    );
-    pub fn atg_cudnn_convolution_backward_input(
-        out__: *mut *mut C_tensor,
-        self_size_data: *const i64,
-        self_size_len: c_int,
-        grad_output_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        groups_: i64,
-        benchmark_: c_int,
-        deterministic_: c_int,
-    );
-    pub fn atg_cudnn_convolution_backward_weight(
-        out__: *mut *mut C_tensor,
-        weight_size_data: *const i64,
-        weight_size_len: c_int,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        groups_: i64,
-        benchmark_: c_int,
-        deterministic_: c_int,
-    );
-    pub fn atg_cudnn_convolution_transpose(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-        output_padding_data: *const i64,
-        output_padding_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        groups_: i64,
-        benchmark_: c_int,
-        deterministic_: c_int,
-    );
-    pub fn atg_cudnn_convolution_transpose_backward_bias(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-    );
-    pub fn atg_cudnn_convolution_transpose_backward_input(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        groups_: i64,
-        benchmark_: c_int,
-        deterministic_: c_int,
-    );
-    pub fn atg_cudnn_convolution_transpose_backward_weight(
-        out__: *mut *mut C_tensor,
-        weight_size_data: *const i64,
-        weight_size_len: c_int,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        groups_: i64,
-        benchmark_: c_int,
-        deterministic_: c_int,
-    );
-    pub fn atg_cudnn_grid_sampler(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        grid_: *mut C_tensor,
-    );
-    pub fn atg_cudnn_grid_sampler_backward(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        grid_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-    );
-    pub fn atg_cumprod(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, dtype_: c_int);
-    pub fn atg_cumprod_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        dtype_: c_int,
-    );
-    pub fn atg_cumsum(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, dtype_: c_int);
-    pub fn atg_cumsum_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        dtype_: c_int,
-    );
-    pub fn atg_data(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_dequantize(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_det(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_detach(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_detach_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_diag(out__: *mut *mut C_tensor, self_: *mut C_tensor, diagonal_: i64);
-    pub fn atg_diag_embed(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        offset_: i64,
-        dim1_: i64,
-        dim2_: i64,
-    );
-    pub fn atg_diag_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        diagonal_: i64,
-    );
-    pub fn atg_diagflat(out__: *mut *mut C_tensor, self_: *mut C_tensor, offset_: i64);
-    pub fn atg_diagonal(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        offset_: i64,
-        dim1_: i64,
-        dim2_: i64,
-    );
-    pub fn atg_digamma(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_digamma_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_digamma_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_dist(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_div(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_div1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg_div_(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_div_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg_div_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_tensor,
-    );
-    pub fn atg_dot(out__: *mut *mut C_tensor, self_: *mut C_tensor, tensor_: *mut C_tensor);
-    pub fn atg_dot_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        tensor_: *mut C_tensor,
-    );
-    pub fn atg_dropout(out__: *mut *mut C_tensor, input_: *mut C_tensor, p_: f64, train_: c_int);
-    pub fn atg_dropout_(out__: *mut *mut C_tensor, self_: *mut C_tensor, p_: f64, train_: c_int);
-    pub fn atg_eig(out__: *mut *mut C_tensor, self_: *mut C_tensor, eigenvectors_: c_int);
-    pub fn atg_eig_out(
-        out__: *mut *mut C_tensor,
-        e_: *mut C_tensor,
-        v_: *mut C_tensor,
-        self_: *mut C_tensor,
-        eigenvectors_: c_int,
-    );
-    pub fn atg_elu(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_elu_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_elu_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        alpha_: *mut C_scalar,
-        scale_: *mut C_scalar,
-        input_scale_: *mut C_scalar,
-        output_: *mut C_tensor,
-    );
-    pub fn atg_elu_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        alpha_: *mut C_scalar,
-        scale_: *mut C_scalar,
-        input_scale_: *mut C_scalar,
-        output_: *mut C_tensor,
-    );
-    pub fn atg_elu_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_embedding(
-        out__: *mut *mut C_tensor,
-        weight_: *mut C_tensor,
-        indices_: *mut C_tensor,
-        padding_idx_: i64,
-        scale_grad_by_freq_: c_int,
-        sparse_: c_int,
-    );
-    pub fn atg_embedding_backward(
-        out__: *mut *mut C_tensor,
-        grad_: *mut C_tensor,
-        indices_: *mut C_tensor,
-        num_weights_: i64,
-        padding_idx_: i64,
-        scale_grad_by_freq_: c_int,
-        sparse_: c_int,
-    );
-    pub fn atg_embedding_bag(
-        out__: *mut *mut C_tensor,
-        weight_: *mut C_tensor,
-        indices_: *mut C_tensor,
-        offsets_: *mut C_tensor,
-        scale_grad_by_freq_: c_int,
-        mode_: i64,
-        sparse_: c_int,
-        per_sample_weights_: *mut C_tensor,
-    );
-    pub fn atg_embedding_dense_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        indices_: *mut C_tensor,
-        num_weights_: i64,
-        padding_idx_: i64,
-        scale_grad_by_freq_: c_int,
-    );
-    pub fn atg_embedding_renorm_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        indices_: *mut C_tensor,
-        max_norm_: f64,
-        norm_type_: f64,
-    );
-    pub fn atg_embedding_sparse_backward(
-        out__: *mut *mut C_tensor,
-        grad_: *mut C_tensor,
-        indices_: *mut C_tensor,
-        num_weights_: i64,
-        padding_idx_: i64,
-        scale_grad_by_freq_: c_int,
-    );
-    pub fn atg_empty(
-        out__: *mut *mut C_tensor,
-        size_data: *const i64,
-        size_len: c_int,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_empty_like(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_empty_like1(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_empty_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        size_data: *const i64,
-        size_len: c_int,
-    );
-    pub fn atg_empty_strided(
-        out__: *mut *mut C_tensor,
-        size_data: *const i64,
-        size_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_eq(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg_eq1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_eq_(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg_eq_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_eq_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_scalar,
-    );
-    pub fn atg_eq_out1(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_tensor,
-    );
-    pub fn atg_erf(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_erf_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_erf_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_erfc(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_erfc_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_erfc_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_erfinv(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_erfinv_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_erfinv_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_exp(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_exp_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_exp_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_expand(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        size_data: *const i64,
-        size_len: c_int,
-        implicit_: c_int,
-    );
-    pub fn atg_expand_as(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_expm1(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_expm1_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_expm1_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_exponential_(out__: *mut *mut C_tensor, self_: *mut C_tensor, lambd_: f64);
-    pub fn atg_eye(out__: *mut *mut C_tensor, n_: i64, options_kind: c_int, options_device: c_int);
-    pub fn atg_eye1(
-        out__: *mut *mut C_tensor,
-        n_: i64,
-        m_: i64,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_eye_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, n_: i64);
-    pub fn atg_eye_out1(out__: *mut *mut C_tensor, out_: *mut C_tensor, n_: i64, m_: i64);
-    pub fn atg_fake_quantize_per_channel_affine(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        scale_: *mut C_tensor,
-        zero_point_: *mut C_tensor,
-        axis_: i64,
-        quant_min_: i64,
-        quant_max_: i64,
-    );
-    pub fn atg_fake_quantize_per_channel_affine_backward(
-        out__: *mut *mut C_tensor,
-        grad_: *mut C_tensor,
-        self_: *mut C_tensor,
-        scale_: *mut C_tensor,
-        zero_point_: *mut C_tensor,
-        axis_: i64,
-        quant_min_: i64,
-        quant_max_: i64,
-    );
-    pub fn atg_fake_quantize_per_tensor_affine(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        scale_: f64,
-        zero_point_: i64,
-        quant_min_: i64,
-        quant_max_: i64,
-    );
-    pub fn atg_fake_quantize_per_tensor_affine_backward(
-        out__: *mut *mut C_tensor,
-        grad_: *mut C_tensor,
-        self_: *mut C_tensor,
-        scale_: f64,
-        zero_point_: i64,
-        quant_min_: i64,
-        quant_max_: i64,
-    );
-    pub fn atg_fbgemm_linear_fp16_weight(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        packed_weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-    );
-    pub fn atg_fbgemm_linear_fp16_weight_fp32_activation(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        packed_weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-    );
-    pub fn atg_fbgemm_linear_int8_weight(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        packed_: *mut C_tensor,
-        col_offsets_: *mut C_tensor,
-        weight_scale_: *mut C_scalar,
-        weight_zero_point_: *mut C_scalar,
-        bias_: *mut C_tensor,
-    );
-    pub fn atg_fbgemm_linear_int8_weight_fp32_activation(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        packed_: *mut C_tensor,
-        col_offsets_: *mut C_tensor,
-        weight_scale_: *mut C_scalar,
-        weight_zero_point_: *mut C_scalar,
-        bias_: *mut C_tensor,
-    );
-    pub fn atg_fbgemm_pack_gemm_matrix_fp16(out__: *mut *mut C_tensor, input_: *mut C_tensor);
-    pub fn atg_fbgemm_pack_quantized_matrix(out__: *mut *mut C_tensor, input_: *mut C_tensor);
-    pub fn atg_fbgemm_pack_quantized_matrix1(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        K_: i64,
-        n_: i64,
-    );
-    pub fn atg_feature_alpha_dropout(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        p_: f64,
-        train_: c_int,
-    );
-    pub fn atg_feature_alpha_dropout_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        p_: f64,
-        train_: c_int,
-    );
-    pub fn atg_feature_dropout(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        p_: f64,
-        train_: c_int,
-    );
-    pub fn atg_feature_dropout_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        p_: f64,
-        train_: c_int,
-    );
-    pub fn atg_fft(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        signal_ndim_: i64,
-        normalized_: c_int,
-    );
-    pub fn atg_fill_(out__: *mut *mut C_tensor, self_: *mut C_tensor, value_: *mut C_scalar);
-    pub fn atg_fill_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, value_: *mut C_tensor);
-    pub fn atg_fill_diagonal_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        fill_value_: *mut C_scalar,
-        wrap_: c_int,
-    );
-    pub fn atg_flatten(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        start_dim_: i64,
-        end_dim_: i64,
-    );
-    pub fn atg_flip(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dims_data: *const i64,
-        dims_len: c_int,
-    );
-    pub fn atg_floor(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_floor_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_floor_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_fmod(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg_fmod1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_fmod_(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg_fmod_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_fmod_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_scalar,
-    );
-    pub fn atg_fmod_out1(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_tensor,
-    );
-    pub fn atg_frac(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_frac_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_frac_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_fractional_max_pool2d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        random_samples_: *mut C_tensor,
-    );
-    pub fn atg_fractional_max_pool2d_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        indices_: *mut C_tensor,
-    );
-    pub fn atg_fractional_max_pool2d_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        indices_: *mut C_tensor,
-    );
-    pub fn atg_fractional_max_pool2d_out(
-        out__: *mut *mut C_tensor,
-        output_: *mut C_tensor,
-        indices_: *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        random_samples_: *mut C_tensor,
-    );
-    pub fn atg_fractional_max_pool3d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        random_samples_: *mut C_tensor,
-    );
-    pub fn atg_fractional_max_pool3d_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        indices_: *mut C_tensor,
-    );
-    pub fn atg_fractional_max_pool3d_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        indices_: *mut C_tensor,
-    );
-    pub fn atg_fractional_max_pool3d_out(
-        out__: *mut *mut C_tensor,
-        output_: *mut C_tensor,
-        indices_: *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        random_samples_: *mut C_tensor,
-    );
-    pub fn atg_frobenius_norm(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_frobenius_norm1(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_data: *const i64,
-        dim_len: c_int,
-        keepdim_: c_int,
-    );
-    pub fn atg_frobenius_norm_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_data: *const i64,
-        dim_len: c_int,
-        keepdim_: c_int,
-    );
-    pub fn atg_full(
-        out__: *mut *mut C_tensor,
-        size_data: *const i64,
-        size_len: c_int,
-        fill_value_: *mut C_scalar,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_full_like(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        fill_value_: *mut C_scalar,
-    );
-    pub fn atg_full_like1(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        fill_value_: *mut C_scalar,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_full_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        size_data: *const i64,
-        size_len: c_int,
-        fill_value_: *mut C_scalar,
-    );
-    pub fn atg_gather(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        index_: *mut C_tensor,
-        sparse_grad_: c_int,
-    );
-    pub fn atg_gather_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        index_: *mut C_tensor,
-        sparse_grad_: c_int,
-    );
-    pub fn atg_ge(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg_ge1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_ge_(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg_ge_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_ge_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_scalar,
-    );
-    pub fn atg_ge_out1(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_tensor,
-    );
-    pub fn atg_gelu(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_gelu_backward(out__: *mut *mut C_tensor, grad_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_geometric_(out__: *mut *mut C_tensor, self_: *mut C_tensor, p_: f64);
-    pub fn atg_geqrf(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_geqrf_out(
-        out__: *mut *mut C_tensor,
-        a_: *mut C_tensor,
-        tau_: *mut C_tensor,
-        self_: *mut C_tensor,
-    );
-    pub fn atg_ger(out__: *mut *mut C_tensor, self_: *mut C_tensor, vec2_: *mut C_tensor);
-    pub fn atg_ger_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        vec2_: *mut C_tensor,
-    );
-    pub fn atg_glu(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64);
-    pub fn atg_glu_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-    );
-    pub fn atg_glu_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-    );
-    pub fn atg_glu_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-    );
-    pub fn atg_grad(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_grid_sampler(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        grid_: *mut C_tensor,
-        interpolation_mode_: i64,
-        padding_mode_: i64,
-        align_corners_: c_int,
-    );
-    pub fn atg_grid_sampler_2d(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        grid_: *mut C_tensor,
-        interpolation_mode_: i64,
-        padding_mode_: i64,
-        align_corners_: c_int,
-    );
-    pub fn atg_grid_sampler_2d_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        input_: *mut C_tensor,
-        grid_: *mut C_tensor,
-        interpolation_mode_: i64,
-        padding_mode_: i64,
-        align_corners_: c_int,
-    );
-    pub fn atg_grid_sampler_3d(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        grid_: *mut C_tensor,
-        interpolation_mode_: i64,
-        padding_mode_: i64,
-        align_corners_: c_int,
-    );
-    pub fn atg_grid_sampler_3d_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        input_: *mut C_tensor,
-        grid_: *mut C_tensor,
-        interpolation_mode_: i64,
-        padding_mode_: i64,
-        align_corners_: c_int,
-    );
-    pub fn atg_group_norm(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        num_groups_: i64,
-        weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-        eps_: f64,
-        cudnn_enabled_: c_int,
-    );
-    pub fn atg_gru(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        hx_: *mut C_tensor,
-        params_data: *const *mut C_tensor,
-        params_len: c_int,
-        has_biases_: c_int,
-        num_layers_: i64,
-        dropout_: f64,
-        train_: c_int,
-        bidirectional_: c_int,
-        batch_first_: c_int,
-    );
-    pub fn atg_gru1(
-        out__: *mut *mut C_tensor,
-        data_: *mut C_tensor,
-        batch_sizes_: *mut C_tensor,
-        hx_: *mut C_tensor,
-        params_data: *const *mut C_tensor,
-        params_len: c_int,
-        has_biases_: c_int,
-        num_layers_: i64,
-        dropout_: f64,
-        train_: c_int,
-        bidirectional_: c_int,
-    );
-    pub fn atg_gru_cell(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        hx_: *mut C_tensor,
-        w_ih_: *mut C_tensor,
-        w_hh_: *mut C_tensor,
-        b_ih_: *mut C_tensor,
-        b_hh_: *mut C_tensor,
-    );
-    pub fn atg_gt(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg_gt1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_gt_(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg_gt_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_gt_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_scalar,
-    );
-    pub fn atg_gt_out1(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_tensor,
-    );
-    pub fn atg_hamming_window(
-        out__: *mut *mut C_tensor,
-        window_length_: i64,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_hamming_window1(
-        out__: *mut *mut C_tensor,
-        window_length_: i64,
-        periodic_: c_int,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_hamming_window2(
-        out__: *mut *mut C_tensor,
-        window_length_: i64,
-        periodic_: c_int,
-        alpha_: f64,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_hamming_window3(
-        out__: *mut *mut C_tensor,
-        window_length_: i64,
-        periodic_: c_int,
-        alpha_: f64,
-        beta_: f64,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_hann_window(
-        out__: *mut *mut C_tensor,
-        window_length_: i64,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_hann_window1(
-        out__: *mut *mut C_tensor,
-        window_length_: i64,
-        periodic_: c_int,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_hardshrink(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_hardshrink_backward(
-        out__: *mut *mut C_tensor,
-        grad_out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        lambd_: *mut C_scalar,
-    );
-    pub fn atg_hardtanh(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_hardtanh_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_hardtanh_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        min_val_: *mut C_scalar,
-        max_val_: *mut C_scalar,
-    );
-    pub fn atg_hardtanh_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        min_val_: *mut C_scalar,
-        max_val_: *mut C_scalar,
-    );
-    pub fn atg_hardtanh_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_hinge_embedding_loss(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        margin_: f64,
-        reduction_: i64,
-    );
-    pub fn atg_histc(out__: *mut *mut C_tensor, self_: *mut C_tensor, bins_: i64);
-    pub fn atg_histc_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        bins_: i64,
-    );
-    pub fn atg_hspmm(out__: *mut *mut C_tensor, mat1_: *mut C_tensor, mat2_: *mut C_tensor);
-    pub fn atg_hspmm_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        mat1_: *mut C_tensor,
-        mat2_: *mut C_tensor,
-    );
-    pub fn atg_ifft(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        signal_ndim_: i64,
-        normalized_: c_int,
-    );
-    pub fn atg_im2col(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-    );
-    pub fn atg_im2col_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        input_size_data: *const i64,
-        input_size_len: c_int,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-    );
-    pub fn atg_im2col_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        input_size_data: *const i64,
-        input_size_len: c_int,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-    );
-    pub fn atg_im2col_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-    );
-    pub fn atg_imag(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_imag_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_index(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        indices_data: *const *mut C_tensor,
-        indices_len: c_int,
-    );
-    pub fn atg_index_add(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        index_: *mut C_tensor,
-        source_: *mut C_tensor,
-    );
-    pub fn atg_index_add_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        index_: *mut C_tensor,
-        source_: *mut C_tensor,
-    );
-    pub fn atg_index_copy(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        index_: *mut C_tensor,
-        source_: *mut C_tensor,
-    );
-    pub fn atg_index_copy_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        index_: *mut C_tensor,
-        source_: *mut C_tensor,
-    );
-    pub fn atg_index_fill(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        index_: *mut C_tensor,
-        value_: *mut C_scalar,
-    );
-    pub fn atg_index_fill1(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        index_: *mut C_tensor,
-        value_: *mut C_tensor,
-    );
-    pub fn atg_index_fill_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        index_: *mut C_tensor,
-        value_: *mut C_scalar,
-    );
-    pub fn atg_index_fill_1(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        index_: *mut C_tensor,
-        value_: *mut C_tensor,
-    );
-    pub fn atg_index_put(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        indices_data: *const *mut C_tensor,
-        indices_len: c_int,
-        values_: *mut C_tensor,
-        accumulate_: c_int,
-    );
-    pub fn atg_index_put_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        indices_data: *const *mut C_tensor,
-        indices_len: c_int,
-        values_: *mut C_tensor,
-        accumulate_: c_int,
-    );
-    pub fn atg_index_select(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        index_: *mut C_tensor,
-    );
-    pub fn atg_index_select_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        index_: *mut C_tensor,
-    );
-    pub fn atg_indices(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_instance_norm(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-        running_mean_: *mut C_tensor,
-        running_var_: *mut C_tensor,
-        use_input_stats_: c_int,
-        momentum_: f64,
-        eps_: f64,
-        cudnn_enabled_: c_int,
-    );
-    pub fn atg_int_repr(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_inverse(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_inverse_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_irfft(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        signal_ndim_: i64,
-        normalized_: c_int,
-        onesided_: c_int,
-        signal_sizes_data: *const i64,
-        signal_sizes_len: c_int,
-    );
-    pub fn atg_isclose(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_tensor,
-        rtol_: f64,
-        atol_: f64,
-        equal_nan_: c_int,
-    );
-    pub fn atg_isfinite(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_isnan(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_kl_div(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        reduction_: i64,
-    );
-    pub fn atg_kl_div_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        reduction_: i64,
-    );
-    pub fn atg_kthvalue(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        k_: i64,
-        dim_: i64,
-        keepdim_: c_int,
-    );
-    pub fn atg_kthvalue_out(
-        out__: *mut *mut C_tensor,
-        values_: *mut C_tensor,
-        indices_: *mut C_tensor,
-        self_: *mut C_tensor,
-        k_: i64,
-        dim_: i64,
-        keepdim_: c_int,
-    );
-    pub fn atg_l1_loss(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        reduction_: i64,
-    );
-    pub fn atg_l1_loss_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        reduction_: i64,
-    );
-    pub fn atg_l1_loss_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        reduction_: i64,
-    );
-    pub fn atg_l1_loss_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        reduction_: i64,
-    );
-    pub fn atg_layer_norm(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        normalized_shape_data: *const i64,
-        normalized_shape_len: c_int,
-        weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-        eps_: f64,
-        cudnn_enable_: c_int,
-    );
-    pub fn atg_le(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg_le1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_le_(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg_le_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_le_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_scalar,
-    );
-    pub fn atg_le_out1(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_tensor,
-    );
-    pub fn atg_leaky_relu(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_leaky_relu_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_leaky_relu_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        negative_slope_: *mut C_scalar,
-    );
-    pub fn atg_leaky_relu_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        negative_slope_: *mut C_scalar,
-    );
-    pub fn atg_leaky_relu_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_lerp(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        end_: *mut C_tensor,
-        weight_: *mut C_scalar,
-    );
-    pub fn atg_lerp1(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        end_: *mut C_tensor,
-        weight_: *mut C_tensor,
-    );
-    pub fn atg_lerp_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        end_: *mut C_tensor,
-        weight_: *mut C_scalar,
-    );
-    pub fn atg_lerp_1(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        end_: *mut C_tensor,
-        weight_: *mut C_tensor,
-    );
-    pub fn atg_lerp_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        end_: *mut C_tensor,
-        weight_: *mut C_scalar,
-    );
-    pub fn atg_lerp_out1(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        end_: *mut C_tensor,
-        weight_: *mut C_tensor,
-    );
-    pub fn atg_lgamma(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_lgamma_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_lgamma_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_linear(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-    );
-    pub fn atg_linspace(
-        out__: *mut *mut C_tensor,
-        start_: *mut C_scalar,
-        end_: *mut C_scalar,
-        steps_: i64,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_linspace_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        start_: *mut C_scalar,
-        end_: *mut C_scalar,
-        steps_: i64,
-    );
-    pub fn atg_log(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_log10(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_log10_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_log10_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_log1p(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_log1p_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_log1p_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_log2(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_log2_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_log2_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_log_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_log_normal_(out__: *mut *mut C_tensor, self_: *mut C_tensor, mean_: f64, std_: f64);
-    pub fn atg_log_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_log_sigmoid(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_log_sigmoid_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        buffer_: *mut C_tensor,
-    );
-    pub fn atg_log_sigmoid_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        buffer_: *mut C_tensor,
-    );
-    pub fn atg_log_sigmoid_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-    );
-    pub fn atg_log_softmax(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        dtype_: c_int,
-    );
-    pub fn atg_logdet(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_logical_not(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_logical_not_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_logical_not_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-    );
-    pub fn atg_logical_xor(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_logical_xor_(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_logical_xor_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_tensor,
-    );
-    pub fn atg_logspace(
-        out__: *mut *mut C_tensor,
-        start_: *mut C_scalar,
-        end_: *mut C_scalar,
-        steps_: i64,
-        base_: f64,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_logspace_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        start_: *mut C_scalar,
-        end_: *mut C_scalar,
-        steps_: i64,
-        base_: f64,
-    );
-    pub fn atg_logsumexp(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_data: *const i64,
-        dim_len: c_int,
-        keepdim_: c_int,
-    );
-    pub fn atg_logsumexp_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_data: *const i64,
-        dim_len: c_int,
-        keepdim_: c_int,
-    );
-    pub fn atg_lstm(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        hx_data: *const *mut C_tensor,
-        hx_len: c_int,
-        params_data: *const *mut C_tensor,
-        params_len: c_int,
-        has_biases_: c_int,
-        num_layers_: i64,
-        dropout_: f64,
-        train_: c_int,
-        bidirectional_: c_int,
-        batch_first_: c_int,
-    );
-    pub fn atg_lstm1(
-        out__: *mut *mut C_tensor,
-        data_: *mut C_tensor,
-        batch_sizes_: *mut C_tensor,
-        hx_data: *const *mut C_tensor,
-        hx_len: c_int,
-        params_data: *const *mut C_tensor,
-        params_len: c_int,
-        has_biases_: c_int,
-        num_layers_: i64,
-        dropout_: f64,
-        train_: c_int,
-        bidirectional_: c_int,
-    );
-    pub fn atg_lstm_cell(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        hx_data: *const *mut C_tensor,
-        hx_len: c_int,
-        w_ih_: *mut C_tensor,
-        w_hh_: *mut C_tensor,
-        b_ih_: *mut C_tensor,
-        b_hh_: *mut C_tensor,
-    );
-    pub fn atg_lstsq(out__: *mut *mut C_tensor, self_: *mut C_tensor, A_: *mut C_tensor);
-    pub fn atg_lstsq_out(
-        out__: *mut *mut C_tensor,
-        X_: *mut C_tensor,
-        qr_: *mut C_tensor,
-        self_: *mut C_tensor,
-        A_: *mut C_tensor,
-    );
-    pub fn atg_lt(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg_lt1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_lt_(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg_lt_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_lt_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_scalar,
-    );
-    pub fn atg_lt_out1(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_tensor,
-    );
-    pub fn atg_lu_solve(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        LU_data_: *mut C_tensor,
-        LU_pivots_: *mut C_tensor,
-    );
-    pub fn atg_lu_solve_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        LU_data_: *mut C_tensor,
-        LU_pivots_: *mut C_tensor,
-    );
-    pub fn atg_margin_ranking_loss(
-        out__: *mut *mut C_tensor,
-        input1_: *mut C_tensor,
-        input2_: *mut C_tensor,
-        target_: *mut C_tensor,
-        margin_: f64,
-        reduction_: i64,
-    );
-    pub fn atg_masked_fill(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        mask_: *mut C_tensor,
-        value_: *mut C_scalar,
-    );
-    pub fn atg_masked_fill1(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        mask_: *mut C_tensor,
-        value_: *mut C_tensor,
-    );
-    pub fn atg_masked_fill_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        mask_: *mut C_tensor,
-        value_: *mut C_scalar,
-    );
-    pub fn atg_masked_fill_1(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        mask_: *mut C_tensor,
-        value_: *mut C_tensor,
-    );
-    pub fn atg_masked_scatter(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        mask_: *mut C_tensor,
-        source_: *mut C_tensor,
-    );
-    pub fn atg_masked_scatter_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        mask_: *mut C_tensor,
-        source_: *mut C_tensor,
-    );
-    pub fn atg_masked_select(out__: *mut *mut C_tensor, self_: *mut C_tensor, mask_: *mut C_tensor);
-    pub fn atg_masked_select_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        mask_: *mut C_tensor,
-    );
-    pub fn atg_matmul(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_matmul_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_tensor,
-    );
-    pub fn atg_matrix_power(out__: *mut *mut C_tensor, self_: *mut C_tensor, n_: i64);
-    pub fn atg_matrix_rank(out__: *mut *mut C_tensor, self_: *mut C_tensor, symmetric_: c_int);
-    pub fn atg_matrix_rank1(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        tol_: f64,
-        symmetric_: c_int,
-    );
-    pub fn atg_max(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_max1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_max2(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int);
-    pub fn atg_max_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_tensor,
-    );
-    pub fn atg_max_out1(
-        out__: *mut *mut C_tensor,
-        max_: *mut C_tensor,
-        max_values_: *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        keepdim_: c_int,
-    );
-    pub fn atg_max_pool1d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        ceil_mode_: c_int,
-    );
-    pub fn atg_max_pool1d_with_indices(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        ceil_mode_: c_int,
-    );
-    pub fn atg_max_pool2d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        ceil_mode_: c_int,
-    );
-    pub fn atg_max_pool2d_with_indices(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        ceil_mode_: c_int,
-    );
-    pub fn atg_max_pool2d_with_indices_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        ceil_mode_: c_int,
-        indices_: *mut C_tensor,
-    );
-    pub fn atg_max_pool2d_with_indices_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        ceil_mode_: c_int,
-        indices_: *mut C_tensor,
-    );
-    pub fn atg_max_pool2d_with_indices_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        indices_: *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        ceil_mode_: c_int,
-    );
-    pub fn atg_max_pool3d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        ceil_mode_: c_int,
-    );
-    pub fn atg_max_pool3d_with_indices(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        ceil_mode_: c_int,
-    );
-    pub fn atg_max_pool3d_with_indices_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        ceil_mode_: c_int,
-        indices_: *mut C_tensor,
-    );
-    pub fn atg_max_pool3d_with_indices_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        ceil_mode_: c_int,
-        indices_: *mut C_tensor,
-    );
-    pub fn atg_max_pool3d_with_indices_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        indices_: *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        ceil_mode_: c_int,
-    );
-    pub fn atg_max_unpool2d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        indices_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-    );
-    pub fn atg_max_unpool2d_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        indices_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-    );
-    pub fn atg_max_unpool2d_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        indices_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-    );
-    pub fn atg_max_unpool2d_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        indices_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-    );
-    pub fn atg_max_unpool3d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        indices_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-    );
-    pub fn atg_max_unpool3d_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        indices_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-    );
-    pub fn atg_max_unpool3d_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        indices_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-    );
-    pub fn atg_max_unpool3d_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        indices_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-    );
-    pub fn atg_max_values(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_data: *const i64,
-        dim_len: c_int,
-        keepdim_: c_int,
-    );
-    pub fn atg_mean(out__: *mut *mut C_tensor, self_: *mut C_tensor, dtype_: c_int);
-    pub fn atg_mean1(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_data: *const i64,
-        dim_len: c_int,
-        keepdim_: c_int,
-        dtype_: c_int,
-    );
-    pub fn atg_mean_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_data: *const i64,
-        dim_len: c_int,
-        keepdim_: c_int,
-        dtype_: c_int,
-    );
-    pub fn atg_median(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_median1(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int);
-    pub fn atg_median_out(
-        out__: *mut *mut C_tensor,
-        values_: *mut C_tensor,
-        indices_: *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        keepdim_: c_int,
-    );
-    pub fn atg_meshgrid(
-        tensors_data: *const *mut C_tensor,
-        tensors_len: c_int,
-    ) -> *mut *mut C_tensor;
-    pub fn atg_min(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_min1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_min2(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int);
-    pub fn atg_min_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_tensor,
-    );
-    pub fn atg_min_out1(
-        out__: *mut *mut C_tensor,
-        min_: *mut C_tensor,
-        min_indices_: *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        keepdim_: c_int,
-    );
-    pub fn atg_min_values(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_data: *const i64,
-        dim_len: c_int,
-        keepdim_: c_int,
-    );
-    pub fn atg_miopen_batch_norm(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-        running_mean_: *mut C_tensor,
-        running_var_: *mut C_tensor,
-        training_: c_int,
-        exponential_average_factor_: f64,
-        epsilon_: f64,
-    );
-    pub fn atg_miopen_batch_norm_backward(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        running_mean_: *mut C_tensor,
-        running_var_: *mut C_tensor,
-        save_mean_: *mut C_tensor,
-        save_var_: *mut C_tensor,
-        epsilon_: f64,
-    );
-    pub fn atg_miopen_convolution(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        groups_: i64,
-        benchmark_: c_int,
-        deterministic_: c_int,
-    );
-    pub fn atg_miopen_convolution_backward_bias(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-    );
-    pub fn atg_miopen_convolution_backward_input(
-        out__: *mut *mut C_tensor,
-        self_size_data: *const i64,
-        self_size_len: c_int,
-        grad_output_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        groups_: i64,
-        benchmark_: c_int,
-        deterministic_: c_int,
-    );
-    pub fn atg_miopen_convolution_backward_weight(
-        out__: *mut *mut C_tensor,
-        weight_size_data: *const i64,
-        weight_size_len: c_int,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        groups_: i64,
-        benchmark_: c_int,
-        deterministic_: c_int,
-    );
-    pub fn atg_miopen_convolution_transpose(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-        output_padding_data: *const i64,
-        output_padding_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        groups_: i64,
-        benchmark_: c_int,
-        deterministic_: c_int,
-    );
-    pub fn atg_miopen_convolution_transpose_backward_input(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        groups_: i64,
-        benchmark_: c_int,
-        deterministic_: c_int,
-    );
-    pub fn atg_miopen_convolution_transpose_backward_weight(
-        out__: *mut *mut C_tensor,
-        weight_size_data: *const i64,
-        weight_size_len: c_int,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        groups_: i64,
-        benchmark_: c_int,
-        deterministic_: c_int,
-    );
-    pub fn atg_miopen_depthwise_convolution(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        groups_: i64,
-        benchmark_: c_int,
-        deterministic_: c_int,
-    );
-    pub fn atg_miopen_depthwise_convolution_backward_input(
-        out__: *mut *mut C_tensor,
-        self_size_data: *const i64,
-        self_size_len: c_int,
-        grad_output_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        groups_: i64,
-        benchmark_: c_int,
-        deterministic_: c_int,
-    );
-    pub fn atg_miopen_depthwise_convolution_backward_weight(
-        out__: *mut *mut C_tensor,
-        weight_size_data: *const i64,
-        weight_size_len: c_int,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        groups_: i64,
-        benchmark_: c_int,
-        deterministic_: c_int,
-    );
-    pub fn atg_miopen_rnn(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        weight_data: *const *mut C_tensor,
-        weight_len: c_int,
-        weight_stride0_: i64,
-        hx_: *mut C_tensor,
-        cx_: *mut C_tensor,
-        mode_: i64,
-        hidden_size_: i64,
-        num_layers_: i64,
-        batch_first_: c_int,
-        dropout_: f64,
-        train_: c_int,
-        bidirectional_: c_int,
-        batch_sizes_data: *const i64,
-        batch_sizes_len: c_int,
-        dropout_state_: *mut C_tensor,
-    );
-    pub fn atg_mkldnn_adaptive_avg_pool2d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-    );
-    pub fn atg_mkldnn_convolution(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        groups_: i64,
-    );
-    pub fn atg_mkldnn_convolution_backward_input(
-        out__: *mut *mut C_tensor,
-        self_size_data: *const i64,
-        self_size_len: c_int,
-        grad_output_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        groups_: i64,
-        bias_defined_: c_int,
-    );
-    pub fn atg_mkldnn_convolution_backward_weights(
-        out__: *mut *mut C_tensor,
-        weight_size_data: *const i64,
-        weight_size_len: c_int,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        groups_: i64,
-        bias_defined_: c_int,
-    );
-    pub fn atg_mkldnn_linear(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-    );
-    pub fn atg_mkldnn_max_pool2d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        ceil_mode_: c_int,
-    );
-    pub fn atg_mkldnn_reorder_conv2d_weight(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        groups_: i64,
-    );
-    pub fn atg_mm(out__: *mut *mut C_tensor, self_: *mut C_tensor, mat2_: *mut C_tensor);
-    pub fn atg_mm_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        mat2_: *mut C_tensor,
-    );
-    pub fn atg_mode(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int);
-    pub fn atg_mode_out(
-        out__: *mut *mut C_tensor,
-        values_: *mut C_tensor,
-        indices_: *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        keepdim_: c_int,
-    );
-    pub fn atg_mse_loss(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        reduction_: i64,
-    );
-    pub fn atg_mse_loss_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        reduction_: i64,
-    );
-    pub fn atg_mse_loss_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        reduction_: i64,
-    );
-    pub fn atg_mse_loss_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        reduction_: i64,
-    );
-    pub fn atg_mul(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_mul1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg_mul_(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_mul_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg_mul_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_tensor,
-    );
-    pub fn atg_multi_margin_loss_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        p_: *mut C_scalar,
-        margin_: *mut C_scalar,
-        weight_: *mut C_tensor,
-        reduction_: i64,
-    );
-    pub fn atg_multi_margin_loss_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        p_: *mut C_scalar,
-        margin_: *mut C_scalar,
-        weight_: *mut C_tensor,
-        reduction_: i64,
-    );
-    pub fn atg_multilabel_margin_loss(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        reduction_: i64,
-    );
-    pub fn atg_multilabel_margin_loss_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        reduction_: i64,
-        is_target_: *mut C_tensor,
-    );
-    pub fn atg_multilabel_margin_loss_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        reduction_: i64,
-        is_target_: *mut C_tensor,
-    );
-    pub fn atg_multilabel_margin_loss_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        reduction_: i64,
-    );
-    pub fn atg_multinomial(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        num_samples_: i64,
-        replacement_: c_int,
-    );
-    pub fn atg_multinomial_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        num_samples_: i64,
-        replacement_: c_int,
-    );
-    pub fn atg_mv(out__: *mut *mut C_tensor, self_: *mut C_tensor, vec_: *mut C_tensor);
-    pub fn atg_mv_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        vec_: *mut C_tensor,
-    );
-    pub fn atg_mvlgamma(out__: *mut *mut C_tensor, self_: *mut C_tensor, p_: i64);
-    pub fn atg_mvlgamma_(out__: *mut *mut C_tensor, self_: *mut C_tensor, p_: i64);
-    pub fn atg_narrow(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        start_: i64,
-        length_: i64,
-    );
-    pub fn atg_narrow_copy(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        start_: i64,
-        length_: i64,
-    );
-    pub fn atg_native_batch_norm(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-        running_mean_: *mut C_tensor,
-        running_var_: *mut C_tensor,
-        training_: c_int,
-        momentum_: f64,
-        eps_: f64,
-    );
-    pub fn atg_native_layer_norm(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        bias_: *mut C_tensor,
-        M_: i64,
-        n_: i64,
-        eps_: f64,
-    );
-    pub fn atg_native_norm(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_ne(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg_ne1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_ne_(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg_ne_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_ne_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_scalar,
-    );
-    pub fn atg_ne_out1(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_tensor,
-    );
-    pub fn atg_neg(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_neg_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_neg_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_new_empty(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        size_data: *const i64,
-        size_len: c_int,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_new_full(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        size_data: *const i64,
-        size_len: c_int,
-        fill_value_: *mut C_scalar,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_new_zeros(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        size_data: *const i64,
-        size_len: c_int,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_nll_loss(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        reduction_: i64,
-        ignore_index_: i64,
-    );
-    pub fn atg_nll_loss2d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        reduction_: i64,
-        ignore_index_: i64,
-    );
-    pub fn atg_nll_loss2d_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        reduction_: i64,
-        ignore_index_: i64,
-        total_weight_: *mut C_tensor,
-    );
-    pub fn atg_nll_loss2d_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        reduction_: i64,
-        ignore_index_: i64,
-        total_weight_: *mut C_tensor,
-    );
-    pub fn atg_nll_loss2d_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        reduction_: i64,
-        ignore_index_: i64,
-    );
-    pub fn atg_nll_loss_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        reduction_: i64,
-        ignore_index_: i64,
-        total_weight_: *mut C_tensor,
-    );
-    pub fn atg_nll_loss_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        reduction_: i64,
-        ignore_index_: i64,
-        total_weight_: *mut C_tensor,
-    );
-    pub fn atg_nll_loss_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        reduction_: i64,
-        ignore_index_: i64,
-    );
-    pub fn atg_nonzero(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_nonzero_numpy(self_: *mut C_tensor) -> *mut *mut C_tensor;
-    pub fn atg_nonzero_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_norm(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_norm1(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        p_: *mut C_scalar,
-        dtype_: c_int,
-    );
-    pub fn atg_norm2(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        p_: *mut C_scalar,
-        dim_data: *const i64,
-        dim_len: c_int,
-        keepdim_: c_int,
-    );
-    pub fn atg_norm3(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        p_: *mut C_scalar,
-        dim_data: *const i64,
-        dim_len: c_int,
-        keepdim_: c_int,
-        dtype_: c_int,
-    );
-    pub fn atg_norm_except_dim(out__: *mut *mut C_tensor, v_: *mut C_tensor, pow_: i64, dim_: i64);
-    pub fn atg_norm_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        p_: *mut C_scalar,
-        dim_data: *const i64,
-        dim_len: c_int,
-        keepdim_: c_int,
-    );
-    pub fn atg_norm_out1(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        p_: *mut C_scalar,
-        dim_data: *const i64,
-        dim_len: c_int,
-        keepdim_: c_int,
-        dtype_: c_int,
-    );
-    pub fn atg_normal_(out__: *mut *mut C_tensor, self_: *mut C_tensor, mean_: f64, std_: f64);
-    pub fn atg_normal_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        mean_: *mut C_tensor,
-        std_: f64,
-    );
-    pub fn atg_normal_out1(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        mean_: f64,
-        std_: *mut C_tensor,
-    );
-    pub fn atg_normal_out2(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        mean_: *mut C_tensor,
-        std_: *mut C_tensor,
-    );
-    pub fn atg_normal_out3(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        mean_: f64,
-        std_: f64,
-        size_data: *const i64,
-        size_len: c_int,
-    );
-    pub fn atg_nuclear_norm(out__: *mut *mut C_tensor, self_: *mut C_tensor, keepdim_: c_int);
-    pub fn atg_nuclear_norm1(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_data: *const i64,
-        dim_len: c_int,
-        keepdim_: c_int,
-    );
-    pub fn atg_nuclear_norm_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        keepdim_: c_int,
-    );
-    pub fn atg_nuclear_norm_out1(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_data: *const i64,
-        dim_len: c_int,
-        keepdim_: c_int,
-    );
-    pub fn atg_numpy_t(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_one_hot(out__: *mut *mut C_tensor, self_: *mut C_tensor, num_classes_: i64);
-    pub fn atg_ones(
-        out__: *mut *mut C_tensor,
-        size_data: *const i64,
-        size_len: c_int,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_ones_like(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_ones_like1(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_ones_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        size_data: *const i64,
-        size_len: c_int,
-    );
-    pub fn atg_orgqr(out__: *mut *mut C_tensor, self_: *mut C_tensor, input2_: *mut C_tensor);
-    pub fn atg_orgqr_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        input2_: *mut C_tensor,
-    );
-    pub fn atg_ormqr(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        input2_: *mut C_tensor,
-        input3_: *mut C_tensor,
-        left_: c_int,
-        transpose_: c_int,
-    );
-    pub fn atg_ormqr_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        input2_: *mut C_tensor,
-        input3_: *mut C_tensor,
-        left_: c_int,
-        transpose_: c_int,
-    );
-    pub fn atg_pairwise_distance(
-        out__: *mut *mut C_tensor,
-        x1_: *mut C_tensor,
-        x2_: *mut C_tensor,
-        p_: f64,
-        eps_: f64,
-        keepdim_: c_int,
-    );
-    pub fn atg_pdist(out__: *mut *mut C_tensor, self_: *mut C_tensor, p_: f64);
-    pub fn atg_permute(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dims_data: *const i64,
-        dims_len: c_int,
-    );
-    pub fn atg_pin_memory(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_pinverse(out__: *mut *mut C_tensor, self_: *mut C_tensor, rcond_: f64);
-    pub fn atg_pixel_shuffle(out__: *mut *mut C_tensor, self_: *mut C_tensor, upscale_factor_: i64);
-    pub fn atg_poisson(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_poisson_nll_loss(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        target_: *mut C_tensor,
-        log_input_: c_int,
-        full_: c_int,
-        eps_: f64,
-        reduction_: i64,
-    );
-    pub fn atg_polygamma(out__: *mut *mut C_tensor, n_: i64, self_: *mut C_tensor);
-    pub fn atg_polygamma_(out__: *mut *mut C_tensor, self_: *mut C_tensor, n_: i64);
-    pub fn atg_polygamma_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        n_: i64,
-        self_: *mut C_tensor,
-    );
-    pub fn atg_pow(out__: *mut *mut C_tensor, self_: *mut C_tensor, exponent_: *mut C_scalar);
-    pub fn atg_pow1(out__: *mut *mut C_tensor, self_: *mut C_tensor, exponent_: *mut C_tensor);
-    pub fn atg_pow2(
-        out__: *mut *mut C_tensor,
-        self_scalar_: *mut C_scalar,
-        exponent_: *mut C_tensor,
-    );
-    pub fn atg_pow_(out__: *mut *mut C_tensor, self_: *mut C_tensor, exponent_: *mut C_scalar);
-    pub fn atg_pow_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, exponent_: *mut C_tensor);
-    pub fn atg_pow_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        exponent_: *mut C_scalar,
-    );
-    pub fn atg_pow_out1(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        exponent_: *mut C_tensor,
-    );
-    pub fn atg_pow_out2(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_scalar_: *mut C_scalar,
-        exponent_: *mut C_tensor,
-    );
-    pub fn atg_prelu(out__: *mut *mut C_tensor, self_: *mut C_tensor, weight_: *mut C_tensor);
-    pub fn atg_prelu_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        weight_: *mut C_tensor,
-    );
-    pub fn atg_prod(out__: *mut *mut C_tensor, self_: *mut C_tensor, dtype_: c_int);
-    pub fn atg_prod1(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        keepdim_: c_int,
-        dtype_: c_int,
-    );
-    pub fn atg_prod_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        keepdim_: c_int,
-        dtype_: c_int,
-    );
-    pub fn atg_put_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        index_: *mut C_tensor,
-        source_: *mut C_tensor,
-        accumulate_: c_int,
-    );
-    pub fn atg_q_per_channel_scales(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_q_per_channel_zero_points(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_qr(out__: *mut *mut C_tensor, self_: *mut C_tensor, some_: c_int);
-    pub fn atg_qr_out(
-        out__: *mut *mut C_tensor,
-        Q_: *mut C_tensor,
-        R_: *mut C_tensor,
-        self_: *mut C_tensor,
-        some_: c_int,
-    );
-    pub fn atg_quantize_per_channel(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        scales_: *mut C_tensor,
-        zero_points_: *mut C_tensor,
-        axis_: i64,
-        dtype_: c_int,
-    );
-    pub fn atg_quantize_per_tensor(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        scale_: f64,
-        zero_point_: i64,
-        dtype_: c_int,
-    );
-    pub fn atg_quantized_gru(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        hx_: *mut C_tensor,
-        params_data: *const *mut C_tensor,
-        params_len: c_int,
-        has_biases_: c_int,
-        num_layers_: i64,
-        dropout_: f64,
-        train_: c_int,
-        bidirectional_: c_int,
-        batch_first_: c_int,
-    );
-    pub fn atg_quantized_gru1(
-        out__: *mut *mut C_tensor,
-        data_: *mut C_tensor,
-        batch_sizes_: *mut C_tensor,
-        hx_: *mut C_tensor,
-        params_data: *const *mut C_tensor,
-        params_len: c_int,
-        has_biases_: c_int,
-        num_layers_: i64,
-        dropout_: f64,
-        train_: c_int,
-        bidirectional_: c_int,
-    );
-    pub fn atg_quantized_gru_cell(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        hx_: *mut C_tensor,
-        w_ih_: *mut C_tensor,
-        w_hh_: *mut C_tensor,
-        b_ih_: *mut C_tensor,
-        b_hh_: *mut C_tensor,
-        packed_ih_: *mut C_tensor,
-        packed_hh_: *mut C_tensor,
-        col_offsets_ih_: *mut C_tensor,
-        col_offsets_hh_: *mut C_tensor,
-        scale_ih_: *mut C_scalar,
-        scale_hh_: *mut C_scalar,
-        zero_point_ih_: *mut C_scalar,
-        zero_point_hh_: *mut C_scalar,
-    );
-    pub fn atg_quantized_lstm(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        hx_data: *const *mut C_tensor,
-        hx_len: c_int,
-        params_data: *const *mut C_tensor,
-        params_len: c_int,
-        has_biases_: c_int,
-        num_layers_: i64,
-        dropout_: f64,
-        train_: c_int,
-        bidirectional_: c_int,
-        batch_first_: c_int,
-        dtype_: c_int,
-        use_dynamic_: c_int,
-    );
-    pub fn atg_quantized_lstm1(
-        out__: *mut *mut C_tensor,
-        data_: *mut C_tensor,
-        batch_sizes_: *mut C_tensor,
-        hx_data: *const *mut C_tensor,
-        hx_len: c_int,
-        params_data: *const *mut C_tensor,
-        params_len: c_int,
-        has_biases_: c_int,
-        num_layers_: i64,
-        dropout_: f64,
-        train_: c_int,
-        bidirectional_: c_int,
-        dtype_: c_int,
-        use_dynamic_: c_int,
-    );
-    pub fn atg_quantized_lstm_cell(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        hx_data: *const *mut C_tensor,
-        hx_len: c_int,
-        w_ih_: *mut C_tensor,
-        w_hh_: *mut C_tensor,
-        b_ih_: *mut C_tensor,
-        b_hh_: *mut C_tensor,
-        packed_ih_: *mut C_tensor,
-        packed_hh_: *mut C_tensor,
-        col_offsets_ih_: *mut C_tensor,
-        col_offsets_hh_: *mut C_tensor,
-        scale_ih_: *mut C_scalar,
-        scale_hh_: *mut C_scalar,
-        zero_point_ih_: *mut C_scalar,
-        zero_point_hh_: *mut C_scalar,
-    );
-    pub fn atg_quantized_max_pool2d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-        ceil_mode_: c_int,
-    );
-    pub fn atg_quantized_rnn_relu_cell(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        hx_: *mut C_tensor,
-        w_ih_: *mut C_tensor,
-        w_hh_: *mut C_tensor,
-        b_ih_: *mut C_tensor,
-        b_hh_: *mut C_tensor,
-        packed_ih_: *mut C_tensor,
-        packed_hh_: *mut C_tensor,
-        col_offsets_ih_: *mut C_tensor,
-        col_offsets_hh_: *mut C_tensor,
-        scale_ih_: *mut C_scalar,
-        scale_hh_: *mut C_scalar,
-        zero_point_ih_: *mut C_scalar,
-        zero_point_hh_: *mut C_scalar,
-    );
-    pub fn atg_quantized_rnn_tanh_cell(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        hx_: *mut C_tensor,
-        w_ih_: *mut C_tensor,
-        w_hh_: *mut C_tensor,
-        b_ih_: *mut C_tensor,
-        b_hh_: *mut C_tensor,
-        packed_ih_: *mut C_tensor,
-        packed_hh_: *mut C_tensor,
-        col_offsets_ih_: *mut C_tensor,
-        col_offsets_hh_: *mut C_tensor,
-        scale_ih_: *mut C_scalar,
-        scale_hh_: *mut C_scalar,
-        zero_point_ih_: *mut C_scalar,
-        zero_point_hh_: *mut C_scalar,
-    );
-    pub fn atg_rand(
-        out__: *mut *mut C_tensor,
-        size_data: *const i64,
-        size_len: c_int,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_rand_like(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_rand_like1(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_rand_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        size_data: *const i64,
-        size_len: c_int,
-    );
-    pub fn atg_randint(
-        out__: *mut *mut C_tensor,
-        high_: i64,
-        size_data: *const i64,
-        size_len: c_int,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_randint1(
-        out__: *mut *mut C_tensor,
-        low_: i64,
-        high_: i64,
-        size_data: *const i64,
-        size_len: c_int,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_randint_like(out__: *mut *mut C_tensor, self_: *mut C_tensor, high_: i64);
-    pub fn atg_randint_like1(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        low_: i64,
-        high_: i64,
-    );
-    pub fn atg_randint_like2(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        high_: i64,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_randint_like3(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        low_: i64,
-        high_: i64,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_randint_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        high_: i64,
-        size_data: *const i64,
-        size_len: c_int,
-    );
-    pub fn atg_randint_out1(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        low_: i64,
-        high_: i64,
-        size_data: *const i64,
-        size_len: c_int,
-    );
-    pub fn atg_randn(
-        out__: *mut *mut C_tensor,
-        size_data: *const i64,
-        size_len: c_int,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_randn_like(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_randn_like1(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_randn_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        size_data: *const i64,
-        size_len: c_int,
-    );
-    pub fn atg_random_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_random_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, to_: i64);
-    pub fn atg_random_2(out__: *mut *mut C_tensor, self_: *mut C_tensor, from_: i64, to_: i64);
-    pub fn atg_randperm(
-        out__: *mut *mut C_tensor,
-        n_: i64,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_randperm_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, n_: i64);
-    pub fn atg_range(
-        out__: *mut *mut C_tensor,
-        start_: *mut C_scalar,
-        end_: *mut C_scalar,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_range1(
-        out__: *mut *mut C_tensor,
-        start_: *mut C_scalar,
-        end_: *mut C_scalar,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_range_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        start_: *mut C_scalar,
-        end_: *mut C_scalar,
-    );
-    pub fn atg_real(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_real_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_reciprocal(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_reciprocal_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_reciprocal_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_reflection_pad1d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-    );
-    pub fn atg_reflection_pad1d_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-    );
-    pub fn atg_reflection_pad1d_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-    );
-    pub fn atg_reflection_pad1d_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-    );
-    pub fn atg_reflection_pad2d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-    );
-    pub fn atg_reflection_pad2d_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-    );
-    pub fn atg_reflection_pad2d_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-    );
-    pub fn atg_reflection_pad2d_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-    );
-    pub fn atg_relu(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_relu_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_remainder(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg_remainder1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_remainder_(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg_remainder_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_remainder_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_scalar,
-    );
-    pub fn atg_remainder_out1(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_tensor,
-    );
-    pub fn atg_renorm(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        p_: *mut C_scalar,
-        dim_: i64,
-        maxnorm_: *mut C_scalar,
-    );
-    pub fn atg_renorm_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        p_: *mut C_scalar,
-        dim_: i64,
-        maxnorm_: *mut C_scalar,
-    );
-    pub fn atg_renorm_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        p_: *mut C_scalar,
-        dim_: i64,
-        maxnorm_: *mut C_scalar,
-    );
-    pub fn atg_repeat(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        repeats_data: *const i64,
-        repeats_len: c_int,
-    );
-    pub fn atg_repeat_interleave(out__: *mut *mut C_tensor, repeats_: *mut C_tensor);
-    pub fn atg_repeat_interleave1(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        repeats_: *mut C_tensor,
-        dim_: i64,
-    );
-    pub fn atg_repeat_interleave2(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        repeats_: i64,
-        dim_: i64,
-    );
-    pub fn atg_replication_pad1d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-    );
-    pub fn atg_replication_pad1d_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-    );
-    pub fn atg_replication_pad1d_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-    );
-    pub fn atg_replication_pad1d_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-    );
-    pub fn atg_replication_pad2d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-    );
-    pub fn atg_replication_pad2d_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-    );
-    pub fn atg_replication_pad2d_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-    );
-    pub fn atg_replication_pad2d_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-    );
-    pub fn atg_replication_pad3d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-    );
-    pub fn atg_replication_pad3d_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-    );
-    pub fn atg_replication_pad3d_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-    );
-    pub fn atg_replication_pad3d_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        padding_data: *const i64,
-        padding_len: c_int,
-    );
-    pub fn atg_requires_grad_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        _requires_grad_: c_int,
-    );
-    pub fn atg_reshape(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        shape_data: *const i64,
-        shape_len: c_int,
-    );
-    pub fn atg_reshape_as(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_resize_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        size_data: *const i64,
-        size_len: c_int,
-    );
-    pub fn atg_resize_as_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        the_template_: *mut C_tensor,
-    );
-    pub fn atg_rfft(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        signal_ndim_: i64,
-        normalized_: c_int,
-        onesided_: c_int,
-    );
-    pub fn atg_rnn_relu(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        hx_: *mut C_tensor,
-        params_data: *const *mut C_tensor,
-        params_len: c_int,
-        has_biases_: c_int,
-        num_layers_: i64,
-        dropout_: f64,
-        train_: c_int,
-        bidirectional_: c_int,
-        batch_first_: c_int,
-    );
-    pub fn atg_rnn_relu1(
-        out__: *mut *mut C_tensor,
-        data_: *mut C_tensor,
-        batch_sizes_: *mut C_tensor,
-        hx_: *mut C_tensor,
-        params_data: *const *mut C_tensor,
-        params_len: c_int,
-        has_biases_: c_int,
-        num_layers_: i64,
-        dropout_: f64,
-        train_: c_int,
-        bidirectional_: c_int,
-    );
-    pub fn atg_rnn_relu_cell(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        hx_: *mut C_tensor,
-        w_ih_: *mut C_tensor,
-        w_hh_: *mut C_tensor,
-        b_ih_: *mut C_tensor,
-        b_hh_: *mut C_tensor,
-    );
-    pub fn atg_rnn_tanh(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        hx_: *mut C_tensor,
-        params_data: *const *mut C_tensor,
-        params_len: c_int,
-        has_biases_: c_int,
-        num_layers_: i64,
-        dropout_: f64,
-        train_: c_int,
-        bidirectional_: c_int,
-        batch_first_: c_int,
-    );
-    pub fn atg_rnn_tanh1(
-        out__: *mut *mut C_tensor,
-        data_: *mut C_tensor,
-        batch_sizes_: *mut C_tensor,
-        hx_: *mut C_tensor,
-        params_data: *const *mut C_tensor,
-        params_len: c_int,
-        has_biases_: c_int,
-        num_layers_: i64,
-        dropout_: f64,
-        train_: c_int,
-        bidirectional_: c_int,
-    );
-    pub fn atg_rnn_tanh_cell(
-        out__: *mut *mut C_tensor,
-        input_: *mut C_tensor,
-        hx_: *mut C_tensor,
-        w_ih_: *mut C_tensor,
-        w_hh_: *mut C_tensor,
-        b_ih_: *mut C_tensor,
-        b_hh_: *mut C_tensor,
-    );
-    pub fn atg_roll(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        shifts_data: *const i64,
-        shifts_len: c_int,
-        dims_data: *const i64,
-        dims_len: c_int,
-    );
-    pub fn atg_rot90(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        k_: i64,
-        dims_data: *const i64,
-        dims_len: c_int,
-    );
-    pub fn atg_round(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_round_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_round_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_rrelu(out__: *mut *mut C_tensor, self_: *mut C_tensor, training_: c_int);
-    pub fn atg_rrelu_(out__: *mut *mut C_tensor, self_: *mut C_tensor, training_: c_int);
-    pub fn atg_rrelu_with_noise(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        noise_: *mut C_tensor,
-        training_: c_int,
-    );
-    pub fn atg_rrelu_with_noise_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        noise_: *mut C_tensor,
-        training_: c_int,
-    );
-    pub fn atg_rrelu_with_noise_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        noise_: *mut C_tensor,
-        lower_: *mut C_scalar,
-        upper_: *mut C_scalar,
-        training_: c_int,
-    );
-    pub fn atg_rrelu_with_noise_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        noise_: *mut C_tensor,
-        lower_: *mut C_scalar,
-        upper_: *mut C_scalar,
-        training_: c_int,
-    );
-    pub fn atg_rrelu_with_noise_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        noise_: *mut C_tensor,
-        training_: c_int,
-    );
-    pub fn atg_rsqrt(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_rsqrt_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_rsqrt_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_rsub(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_rsub1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg_scalar_tensor(
-        out__: *mut *mut C_tensor,
-        s_: *mut C_scalar,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_scatter(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        index_: *mut C_tensor,
-        src_: *mut C_tensor,
-    );
-    pub fn atg_scatter1(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        index_: *mut C_tensor,
-        value_: *mut C_scalar,
-    );
-    pub fn atg_scatter_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        index_: *mut C_tensor,
-        src_: *mut C_tensor,
-    );
-    pub fn atg_scatter_1(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        index_: *mut C_tensor,
-        value_: *mut C_scalar,
-    );
-    pub fn atg_scatter_add(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        index_: *mut C_tensor,
-        src_: *mut C_tensor,
-    );
-    pub fn atg_scatter_add_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        index_: *mut C_tensor,
-        src_: *mut C_tensor,
-    );
-    pub fn atg_select(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, index_: i64);
-    pub fn atg_selu(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_selu_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_set_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_set_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, source_: *mut C_tensor);
-    pub fn atg_set_requires_grad(out__: *mut *mut C_tensor, self_: *mut C_tensor, r_: c_int);
-    pub fn atg_sigmoid(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_sigmoid_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_sigmoid_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        output_: *mut C_tensor,
-    );
-    pub fn atg_sigmoid_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        output_: *mut C_tensor,
-    );
-    pub fn atg_sigmoid_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_sign(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_sign_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_sign_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_sin(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_sin_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_sin_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_sinh(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_sinh_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_sinh_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_slice(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        start_: i64,
-        end_: i64,
-        step_: i64,
-    );
-    pub fn atg_slogdet(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_slow_conv3d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        bias_: *mut C_tensor,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-    );
-    pub fn atg_slow_conv3d_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        bias_: *mut C_tensor,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-    );
-    pub fn atg_slow_conv_dilated2d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        bias_: *mut C_tensor,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-    );
-    pub fn atg_slow_conv_dilated3d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        bias_: *mut C_tensor,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-    );
-    pub fn atg_slow_conv_transpose2d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        bias_: *mut C_tensor,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        output_padding_data: *const i64,
-        output_padding_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-    );
-    pub fn atg_slow_conv_transpose2d_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        bias_: *mut C_tensor,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        output_padding_data: *const i64,
-        output_padding_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-    );
-    pub fn atg_slow_conv_transpose3d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        bias_: *mut C_tensor,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        output_padding_data: *const i64,
-        output_padding_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-    );
-    pub fn atg_slow_conv_transpose3d_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        weight_: *mut C_tensor,
-        kernel_size_data: *const i64,
-        kernel_size_len: c_int,
-        bias_: *mut C_tensor,
-        stride_data: *const i64,
-        stride_len: c_int,
-        padding_data: *const i64,
-        padding_len: c_int,
-        output_padding_data: *const i64,
-        output_padding_len: c_int,
-        dilation_data: *const i64,
-        dilation_len: c_int,
-    );
-    pub fn atg_smm(out__: *mut *mut C_tensor, self_: *mut C_tensor, mat2_: *mut C_tensor);
-    pub fn atg_smooth_l1_loss(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        reduction_: i64,
-    );
-    pub fn atg_smooth_l1_loss_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        reduction_: i64,
-    );
-    pub fn atg_smooth_l1_loss_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        reduction_: i64,
-    );
-    pub fn atg_smooth_l1_loss_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        reduction_: i64,
-    );
-    pub fn atg_soft_margin_loss(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        reduction_: i64,
-    );
-    pub fn atg_soft_margin_loss_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        reduction_: i64,
-    );
-    pub fn atg_soft_margin_loss_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        reduction_: i64,
-    );
-    pub fn atg_soft_margin_loss_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        target_: *mut C_tensor,
-        reduction_: i64,
-    );
-    pub fn atg_softmax(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, dtype_: c_int);
-    pub fn atg_softplus(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_softplus_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        beta_: *mut C_scalar,
-        threshold_: *mut C_scalar,
-        output_: *mut C_tensor,
-    );
-    pub fn atg_softplus_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        beta_: *mut C_scalar,
-        threshold_: *mut C_scalar,
-        output_: *mut C_tensor,
-    );
-    pub fn atg_softplus_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_softshrink(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_softshrink_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        lambd_: *mut C_scalar,
-    );
-    pub fn atg_softshrink_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        lambd_: *mut C_scalar,
-    );
-    pub fn atg_softshrink_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_solve(out__: *mut *mut C_tensor, self_: *mut C_tensor, A_: *mut C_tensor);
-    pub fn atg_solve_out(
-        out__: *mut *mut C_tensor,
-        solution_: *mut C_tensor,
-        lu_: *mut C_tensor,
-        self_: *mut C_tensor,
-        A_: *mut C_tensor,
-    );
-    pub fn atg_sort(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, descending_: c_int);
-    pub fn atg_sort_out(
-        out__: *mut *mut C_tensor,
-        values_: *mut C_tensor,
-        indices_: *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        descending_: c_int,
-    );
-    pub fn atg_sparse_coo_tensor(
-        out__: *mut *mut C_tensor,
-        size_data: *const i64,
-        size_len: c_int,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_sparse_coo_tensor1(
-        out__: *mut *mut C_tensor,
-        indices_: *mut C_tensor,
-        values_: *mut C_tensor,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_sparse_coo_tensor2(
-        out__: *mut *mut C_tensor,
-        indices_: *mut C_tensor,
-        values_: *mut C_tensor,
-        size_data: *const i64,
-        size_len: c_int,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_sparse_mask(out__: *mut *mut C_tensor, self_: *mut C_tensor, mask_: *mut C_tensor);
-    pub fn atg_sparse_resize_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        size_data: *const i64,
-        size_len: c_int,
-        sparse_dim_: i64,
-        dense_dim_: i64,
-    );
-    pub fn atg_sparse_resize_and_clear_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        size_data: *const i64,
-        size_len: c_int,
-        sparse_dim_: i64,
-        dense_dim_: i64,
-    );
-    pub fn atg_split(self_: *mut C_tensor, split_size_: i64, dim_: i64) -> *mut *mut C_tensor;
-    pub fn atg_split_with_sizes(
-        self_: *mut C_tensor,
-        split_sizes_data: *const i64,
-        split_sizes_len: c_int,
-        dim_: i64,
-    ) -> *mut *mut C_tensor;
-    pub fn atg_sqrt(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_sqrt_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_sqrt_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_squeeze(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_squeeze1(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64);
-    pub fn atg_squeeze_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_squeeze_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64);
-    pub fn atg_sspaddmm(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        mat1_: *mut C_tensor,
-        mat2_: *mut C_tensor,
-    );
-    pub fn atg_sspaddmm_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        mat1_: *mut C_tensor,
-        mat2_: *mut C_tensor,
-    );
-    pub fn atg_stack(
-        out__: *mut *mut C_tensor,
-        tensors_data: *const *mut C_tensor,
-        tensors_len: c_int,
-        dim_: i64,
-    );
-    pub fn atg_stack_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        tensors_data: *const *mut C_tensor,
-        tensors_len: c_int,
-        dim_: i64,
-    );
-    pub fn atg_std(out__: *mut *mut C_tensor, self_: *mut C_tensor, unbiased_: c_int);
-    pub fn atg_std1(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_data: *const i64,
-        dim_len: c_int,
-        unbiased_: c_int,
-        keepdim_: c_int,
-    );
-    pub fn atg_std_mean(out__: *mut *mut C_tensor, self_: *mut C_tensor, unbiased_: c_int);
-    pub fn atg_std_mean1(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_data: *const i64,
-        dim_len: c_int,
-        unbiased_: c_int,
-        keepdim_: c_int,
-    );
-    pub fn atg_std_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_data: *const i64,
-        dim_len: c_int,
-        unbiased_: c_int,
-        keepdim_: c_int,
-    );
-    pub fn atg_stft(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        n_fft_: i64,
-        hop_length_: i64,
-        win_length_: i64,
-        window_: *mut C_tensor,
-        normalized_: c_int,
-        onesided_: c_int,
-    );
-    pub fn atg_sub(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_sub1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg_sub_(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_sub_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar);
-    pub fn atg_sub_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_tensor,
-    );
-    pub fn atg_sum(out__: *mut *mut C_tensor, self_: *mut C_tensor, dtype_: c_int);
-    pub fn atg_sum1(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_data: *const i64,
-        dim_len: c_int,
-        keepdim_: c_int,
-        dtype_: c_int,
-    );
-    pub fn atg_sum_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_data: *const i64,
-        dim_len: c_int,
-        keepdim_: c_int,
-        dtype_: c_int,
-    );
-    pub fn atg_sum_to_size(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        size_data: *const i64,
-        size_len: c_int,
-    );
-    pub fn atg_svd(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        some_: c_int,
-        compute_uv_: c_int,
-    );
-    pub fn atg_svd_out(
-        out__: *mut *mut C_tensor,
-        U_: *mut C_tensor,
-        S_: *mut C_tensor,
-        V_: *mut C_tensor,
-        self_: *mut C_tensor,
-        some_: c_int,
-        compute_uv_: c_int,
-    );
-    pub fn atg_symeig(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        eigenvectors_: c_int,
-        upper_: c_int,
-    );
-    pub fn atg_symeig_out(
-        out__: *mut *mut C_tensor,
-        e_: *mut C_tensor,
-        V_: *mut C_tensor,
-        self_: *mut C_tensor,
-        eigenvectors_: c_int,
-        upper_: c_int,
-    );
-    pub fn atg_t(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_t_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_take(out__: *mut *mut C_tensor, self_: *mut C_tensor, index_: *mut C_tensor);
-    pub fn atg_take_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        index_: *mut C_tensor,
-    );
-    pub fn atg_tan(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_tan_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_tan_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_tanh(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_tanh_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_tanh_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        output_: *mut C_tensor,
-    );
-    pub fn atg_tanh_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        output_: *mut C_tensor,
-    );
-    pub fn atg_tanh_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_tensordot(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_tensor,
-        dims_self_data: *const i64,
-        dims_self_len: c_int,
-        dims_other_data: *const i64,
-        dims_other_len: c_int,
-    );
-    pub fn atg_threshold(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        threshold_: *mut C_scalar,
-        value_: *mut C_scalar,
-    );
-    pub fn atg_threshold_(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        threshold_: *mut C_scalar,
-        value_: *mut C_scalar,
-    );
-    pub fn atg_threshold_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        self_: *mut C_tensor,
-        threshold_: *mut C_scalar,
-    );
-    pub fn atg_threshold_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        threshold_: *mut C_scalar,
-        value_: *mut C_scalar,
-    );
-    pub fn atg_to(out__: *mut *mut C_tensor, self_: *mut C_tensor, device_: c_int);
-    pub fn atg_to1(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        options_kind: c_int,
-        options_device: c_int,
-        non_blocking_: c_int,
-        copy_: c_int,
-    );
-    pub fn atg_to2(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dtype_: c_int,
-        non_blocking_: c_int,
-        copy_: c_int,
-    );
-    pub fn atg_to3(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_tensor,
-        non_blocking_: c_int,
-        copy_: c_int,
-    );
-    pub fn atg_to4(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        device_: c_int,
-        dtype_: c_int,
-        non_blocking_: c_int,
-        copy_: c_int,
-    );
-    pub fn atg_to_dense(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_to_dense_backward(
-        out__: *mut *mut C_tensor,
-        grad_: *mut C_tensor,
-        input_: *mut C_tensor,
-    );
-    pub fn atg_to_mkldnn(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_to_mkldnn_backward(
-        out__: *mut *mut C_tensor,
-        grad_: *mut C_tensor,
-        input_: *mut C_tensor,
-    );
-    pub fn atg_to_sparse(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_to_sparse1(out__: *mut *mut C_tensor, self_: *mut C_tensor, sparse_dim_: i64);
-    pub fn atg_topk(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        k_: i64,
-        dim_: i64,
-        largest_: c_int,
-        sorted_: c_int,
-    );
-    pub fn atg_topk_out(
-        out__: *mut *mut C_tensor,
-        values_: *mut C_tensor,
-        indices_: *mut C_tensor,
-        self_: *mut C_tensor,
-        k_: i64,
-        dim_: i64,
-        largest_: c_int,
-        sorted_: c_int,
-    );
-    pub fn atg_totype(out__: *mut *mut C_tensor, self_: *mut C_tensor, scalar_type_: c_int);
-    pub fn atg_trace(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_transpose(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim0_: i64, dim1_: i64);
-    pub fn atg_transpose_(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim0_: i64, dim1_: i64);
-    pub fn atg_trapz(out__: *mut *mut C_tensor, y_: *mut C_tensor, x_: *mut C_tensor, dim_: i64);
-    pub fn atg_trapz1(out__: *mut *mut C_tensor, y_: *mut C_tensor, dx_: f64, dim_: i64);
-    pub fn atg_triangular_solve(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        A_: *mut C_tensor,
-        upper_: c_int,
-        transpose_: c_int,
-        unitriangular_: c_int,
-    );
-    pub fn atg_triangular_solve_out(
-        out__: *mut *mut C_tensor,
-        X_: *mut C_tensor,
-        M_: *mut C_tensor,
-        self_: *mut C_tensor,
-        A_: *mut C_tensor,
-        upper_: c_int,
-        transpose_: c_int,
-        unitriangular_: c_int,
-    );
-    pub fn atg_tril(out__: *mut *mut C_tensor, self_: *mut C_tensor, diagonal_: i64);
-    pub fn atg_tril_(out__: *mut *mut C_tensor, self_: *mut C_tensor, diagonal_: i64);
-    pub fn atg_tril_indices(
-        out__: *mut *mut C_tensor,
-        row_: i64,
-        col_: i64,
-        offset_: i64,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_tril_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        diagonal_: i64,
-    );
-    pub fn atg_triplet_margin_loss(
-        out__: *mut *mut C_tensor,
-        anchor_: *mut C_tensor,
-        positive_: *mut C_tensor,
-        negative_: *mut C_tensor,
-        margin_: f64,
-        p_: f64,
-        eps_: f64,
-        swap_: c_int,
-        reduction_: i64,
-    );
-    pub fn atg_triu(out__: *mut *mut C_tensor, self_: *mut C_tensor, diagonal_: i64);
-    pub fn atg_triu_(out__: *mut *mut C_tensor, self_: *mut C_tensor, diagonal_: i64);
-    pub fn atg_triu_indices(
-        out__: *mut *mut C_tensor,
-        row_: i64,
-        col_: i64,
-        offset_: i64,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_triu_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        diagonal_: i64,
-    );
-    pub fn atg_trunc(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_trunc_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_trunc_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_type_as(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_unbind(self_: *mut C_tensor, dim_: i64) -> *mut *mut C_tensor;
-    pub fn atg_unfold(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dimension_: i64,
-        size_: i64,
-        step_: i64,
-    );
-    pub fn atg_uniform_(out__: *mut *mut C_tensor, self_: *mut C_tensor, from_: f64, to_: f64);
-    pub fn atg_unique_consecutive(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        return_inverse_: c_int,
-        return_counts_: c_int,
-        dim_: i64,
-    );
-    pub fn atg_unique_dim(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        sorted_: c_int,
-        return_inverse_: c_int,
-        return_counts_: c_int,
-    );
-    pub fn atg_unique_dim_consecutive(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_: i64,
-        return_inverse_: c_int,
-        return_counts_: c_int,
-    );
-    pub fn atg_unsqueeze(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64);
-    pub fn atg_unsqueeze_(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64);
-    pub fn atg_upsample_bicubic2d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        align_corners_: c_int,
-    );
-    pub fn atg_upsample_bicubic2d_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        input_size_data: *const i64,
-        input_size_len: c_int,
-        align_corners_: c_int,
-    );
-    pub fn atg_upsample_bicubic2d_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        input_size_data: *const i64,
-        input_size_len: c_int,
-        align_corners_: c_int,
-    );
-    pub fn atg_upsample_bicubic2d_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        align_corners_: c_int,
-    );
-    pub fn atg_upsample_bilinear2d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        align_corners_: c_int,
-    );
-    pub fn atg_upsample_bilinear2d_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        input_size_data: *const i64,
-        input_size_len: c_int,
-        align_corners_: c_int,
-    );
-    pub fn atg_upsample_bilinear2d_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        input_size_data: *const i64,
-        input_size_len: c_int,
-        align_corners_: c_int,
-    );
-    pub fn atg_upsample_bilinear2d_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        align_corners_: c_int,
-    );
-    pub fn atg_upsample_linear1d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        align_corners_: c_int,
-    );
-    pub fn atg_upsample_linear1d_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        input_size_data: *const i64,
-        input_size_len: c_int,
-        align_corners_: c_int,
-    );
-    pub fn atg_upsample_linear1d_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        input_size_data: *const i64,
-        input_size_len: c_int,
-        align_corners_: c_int,
-    );
-    pub fn atg_upsample_linear1d_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        align_corners_: c_int,
-    );
-    pub fn atg_upsample_nearest1d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-    );
-    pub fn atg_upsample_nearest1d_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        input_size_data: *const i64,
-        input_size_len: c_int,
-    );
-    pub fn atg_upsample_nearest1d_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        input_size_data: *const i64,
-        input_size_len: c_int,
-    );
-    pub fn atg_upsample_nearest1d_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-    );
-    pub fn atg_upsample_nearest2d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-    );
-    pub fn atg_upsample_nearest2d_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        input_size_data: *const i64,
-        input_size_len: c_int,
-    );
-    pub fn atg_upsample_nearest2d_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        input_size_data: *const i64,
-        input_size_len: c_int,
-    );
-    pub fn atg_upsample_nearest2d_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-    );
-    pub fn atg_upsample_nearest3d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-    );
-    pub fn atg_upsample_nearest3d_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        input_size_data: *const i64,
-        input_size_len: c_int,
-    );
-    pub fn atg_upsample_nearest3d_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        input_size_data: *const i64,
-        input_size_len: c_int,
-    );
-    pub fn atg_upsample_nearest3d_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-    );
-    pub fn atg_upsample_trilinear3d(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        align_corners_: c_int,
-    );
-    pub fn atg_upsample_trilinear3d_backward(
-        out__: *mut *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        input_size_data: *const i64,
-        input_size_len: c_int,
-        align_corners_: c_int,
-    );
-    pub fn atg_upsample_trilinear3d_backward_out(
-        out__: *mut *mut C_tensor,
-        grad_input_: *mut C_tensor,
-        grad_output_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        input_size_data: *const i64,
-        input_size_len: c_int,
-        align_corners_: c_int,
-    );
-    pub fn atg_upsample_trilinear3d_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        output_size_data: *const i64,
-        output_size_len: c_int,
-        align_corners_: c_int,
-    );
-    pub fn atg_values(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_var(out__: *mut *mut C_tensor, self_: *mut C_tensor, unbiased_: c_int);
-    pub fn atg_var1(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_data: *const i64,
-        dim_len: c_int,
-        unbiased_: c_int,
-        keepdim_: c_int,
-    );
-    pub fn atg_var_mean(out__: *mut *mut C_tensor, self_: *mut C_tensor, unbiased_: c_int);
-    pub fn atg_var_mean1(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_data: *const i64,
-        dim_len: c_int,
-        unbiased_: c_int,
-        keepdim_: c_int,
-    );
-    pub fn atg_var_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        self_: *mut C_tensor,
-        dim_data: *const i64,
-        dim_len: c_int,
-        unbiased_: c_int,
-        keepdim_: c_int,
-    );
-    pub fn atg_view(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        size_data: *const i64,
-        size_len: c_int,
-    );
-    pub fn atg_view_as(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor);
-    pub fn atg_where(condition_: *mut C_tensor) -> *mut *mut C_tensor;
-    pub fn atg_where1(
-        out__: *mut *mut C_tensor,
-        condition_: *mut C_tensor,
-        self_: *mut C_tensor,
-        other_: *mut C_tensor,
-    );
-    pub fn atg_zero_(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_zeros(
-        out__: *mut *mut C_tensor,
-        size_data: *const i64,
-        size_len: c_int,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_zeros_like(out__: *mut *mut C_tensor, self_: *mut C_tensor);
-    pub fn atg_zeros_like1(
-        out__: *mut *mut C_tensor,
-        self_: *mut C_tensor,
-        options_kind: c_int,
-        options_device: c_int,
-    );
-    pub fn atg_zeros_out(
-        out__: *mut *mut C_tensor,
-        out_: *mut C_tensor,
-        size_data: *const i64,
-        size_len: c_int,
-    );
-}
+pub_ffi!(fn atg___and__(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg___and__1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg___iand__(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg___iand__1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg___ilshift__(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg___ilshift__1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg___ior__(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg___ior__1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg___irshift__(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg___irshift__1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg___ixor__(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg___ixor__1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg___lshift__(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg___lshift__1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg___or__(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg___or__1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg___rshift__(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg___rshift__1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg___xor__(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg___xor__1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg__adaptive_avg_pool2d(out__: *mut *mut C_tensor, self_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int));
+pub_ffi!(fn atg__adaptive_avg_pool2d_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg__addr(out__: *mut *mut C_tensor, self_: *mut C_tensor, vec1_: *mut C_tensor, vec2_: *mut C_tensor));
+pub_ffi!(fn atg__addr_(out__: *mut *mut C_tensor, self_: *mut C_tensor, vec1_: *mut C_tensor, vec2_: *mut C_tensor));
+pub_ffi!(fn atg__addr_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, vec1_: *mut C_tensor, vec2_: *mut C_tensor));
+pub_ffi!(fn atg__baddbmm_mkl_(out__: *mut *mut C_tensor, self_: *mut C_tensor, batch1_: *mut C_tensor, batch2_: *mut C_tensor));
+pub_ffi!(fn atg__cast_byte(out__: *mut *mut C_tensor, self_: *mut C_tensor, non_blocking_: c_int));
+pub_ffi!(fn atg__cast_char(out__: *mut *mut C_tensor, self_: *mut C_tensor, non_blocking_: c_int));
+pub_ffi!(fn atg__cast_double(out__: *mut *mut C_tensor, self_: *mut C_tensor, non_blocking_: c_int));
+pub_ffi!(fn atg__cast_float(out__: *mut *mut C_tensor, self_: *mut C_tensor, non_blocking_: c_int));
+pub_ffi!(fn atg__cast_half(out__: *mut *mut C_tensor, self_: *mut C_tensor, non_blocking_: c_int));
+pub_ffi!(fn atg__cast_int(out__: *mut *mut C_tensor, self_: *mut C_tensor, non_blocking_: c_int));
+pub_ffi!(fn atg__cast_long(out__: *mut *mut C_tensor, self_: *mut C_tensor, non_blocking_: c_int));
+pub_ffi!(fn atg__cast_short(out__: *mut *mut C_tensor, self_: *mut C_tensor, non_blocking_: c_int));
+pub_ffi!(fn atg__cat(out__: *mut *mut C_tensor, tensors_data: *const *mut C_tensor, tensors_len: c_int, dim_: i64));
+pub_ffi!(fn atg__cat_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, tensors_data: *const *mut C_tensor, tensors_len: c_int, dim_: i64));
+pub_ffi!(fn atg__cdist_backward(out__: *mut *mut C_tensor, grad_: *mut C_tensor, x1_: *mut C_tensor, x2_: *mut C_tensor, p_: f64, cdist_: *mut C_tensor));
+pub_ffi!(fn atg__cholesky_helper(out__: *mut *mut C_tensor, self_: *mut C_tensor, upper_: c_int));
+pub_ffi!(fn atg__cholesky_solve_helper(out__: *mut *mut C_tensor, self_: *mut C_tensor, A_: *mut C_tensor, upper_: c_int));
+pub_ffi!(fn atg__coalesced_(out__: *mut *mut C_tensor, self_: *mut C_tensor, coalesced_: c_int));
+pub_ffi!(fn atg__convolution(out__: *mut *mut C_tensor, input_: *mut C_tensor, weight_: *mut C_tensor, bias_: *mut C_tensor, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, dilation_data: *const i64, dilation_len: c_int, transposed_: c_int, output_padding_data: *const i64, output_padding_len: c_int, groups_: i64, benchmark_: c_int, deterministic_: c_int, cudnn_enabled_: c_int));
+pub_ffi!(fn atg__convolution_nogroup(out__: *mut *mut C_tensor, input_: *mut C_tensor, weight_: *mut C_tensor, bias_: *mut C_tensor, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, dilation_data: *const i64, dilation_len: c_int, transposed_: c_int, output_padding_data: *const i64, output_padding_len: c_int));
+pub_ffi!(fn atg__copy_from(out__: *mut *mut C_tensor, self_: *mut C_tensor, dst_: *mut C_tensor, non_blocking_: c_int));
+pub_ffi!(fn atg__ctc_loss(out__: *mut *mut C_tensor, log_probs_: *mut C_tensor, targets_: *mut C_tensor, input_lengths_data: *const i64, input_lengths_len: c_int, target_lengths_data: *const i64, target_lengths_len: c_int, blank_: i64, zero_infinity_: c_int));
+pub_ffi!(fn atg__ctc_loss_backward(out__: *mut *mut C_tensor, grad_: *mut C_tensor, log_probs_: *mut C_tensor, targets_: *mut C_tensor, input_lengths_data: *const i64, input_lengths_len: c_int, target_lengths_data: *const i64, target_lengths_len: c_int, neg_log_likelihood_: *mut C_tensor, log_alpha_: *mut C_tensor, blank_: i64, zero_infinity_: c_int));
+pub_ffi!(fn atg__cudnn_ctc_loss(out__: *mut *mut C_tensor, log_probs_: *mut C_tensor, targets_: *mut C_tensor, input_lengths_data: *const i64, input_lengths_len: c_int, target_lengths_data: *const i64, target_lengths_len: c_int, blank_: i64, deterministic_: c_int, zero_infinity_: c_int));
+pub_ffi!(fn atg__cudnn_init_dropout_state(out__: *mut *mut C_tensor, dropout_: f64, train_: c_int, dropout_seed_: i64, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg__cudnn_rnn(out__: *mut *mut C_tensor, input_: *mut C_tensor, weight_data: *const *mut C_tensor, weight_len: c_int, weight_stride0_: i64, weight_buf_: *mut C_tensor, hx_: *mut C_tensor, cx_: *mut C_tensor, mode_: i64, hidden_size_: i64, num_layers_: i64, batch_first_: c_int, dropout_: f64, train_: c_int, bidirectional_: c_int, batch_sizes_data: *const i64, batch_sizes_len: c_int, dropout_state_: *mut C_tensor));
+pub_ffi!(fn atg__cudnn_rnn_flatten_weight(out__: *mut *mut C_tensor, weight_arr_data: *const *mut C_tensor, weight_arr_len: c_int, weight_stride0_: i64, input_size_: i64, mode_: i64, hidden_size_: i64, num_layers_: i64, batch_first_: c_int, bidirectional_: c_int));
+pub_ffi!(fn atg__cumprod(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64));
+pub_ffi!(fn atg__cumprod_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, dim_: i64));
+pub_ffi!(fn atg__cumsum(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64));
+pub_ffi!(fn atg__cumsum_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, dim_: i64));
+pub_ffi!(fn atg__dim_arange(out__: *mut *mut C_tensor, like_: *mut C_tensor, dim_: i64));
+pub_ffi!(fn atg__dirichlet_grad(out__: *mut *mut C_tensor, x_: *mut C_tensor, alpha_: *mut C_tensor, total_: *mut C_tensor));
+pub_ffi!(fn atg__embedding_bag(out__: *mut *mut C_tensor, weight_: *mut C_tensor, indices_: *mut C_tensor, offsets_: *mut C_tensor, scale_grad_by_freq_: c_int, mode_: i64, sparse_: c_int, per_sample_weights_: *mut C_tensor));
+pub_ffi!(fn atg__embedding_bag_backward(out__: *mut *mut C_tensor, grad_: *mut C_tensor, indices_: *mut C_tensor, offsets_: *mut C_tensor, offset2bag_: *mut C_tensor, bag_size_: *mut C_tensor, maximum_indices_: *mut C_tensor, num_weights_: i64, scale_grad_by_freq_: c_int, mode_: i64, sparse_: c_int, per_sample_weights_: *mut C_tensor));
+pub_ffi!(fn atg__embedding_bag_dense_backward(out__: *mut *mut C_tensor, grad_: *mut C_tensor, indices_: *mut C_tensor, offsets_: *mut C_tensor, offset2bag_: *mut C_tensor, bag_size_: *mut C_tensor, maximum_indices_: *mut C_tensor, num_weights_: i64, scale_grad_by_freq_: c_int, mode_: i64, per_sample_weights_: *mut C_tensor));
+pub_ffi!(fn atg__embedding_bag_per_sample_weights_backward(out__: *mut *mut C_tensor, grad_: *mut C_tensor, weight_: *mut C_tensor, indices_: *mut C_tensor, offsets_: *mut C_tensor, offset2bag_: *mut C_tensor, mode_: i64));
+pub_ffi!(fn atg__embedding_bag_sparse_backward(out__: *mut *mut C_tensor, grad_: *mut C_tensor, indices_: *mut C_tensor, offsets_: *mut C_tensor, offset2bag_: *mut C_tensor, bag_size_: *mut C_tensor, num_weights_: i64, scale_grad_by_freq_: c_int, mode_: i64, per_sample_weights_: *mut C_tensor));
+pub_ffi!(fn atg__empty_affine_quantized(out__: *mut *mut C_tensor, size_data: *const i64, size_len: c_int, options_kind: c_int, options_device: c_int, scale_: f64, zero_point_: i64));
+pub_ffi!(fn atg__empty_per_channel_affine_quantized(out__: *mut *mut C_tensor, size_data: *const i64, size_len: c_int, scales_: *mut C_tensor, zero_points_: *mut C_tensor, axis_: i64, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg__fft_with_size(out__: *mut *mut C_tensor, self_: *mut C_tensor, signal_ndim_: i64, complex_input_: c_int, complex_output_: c_int, inverse_: c_int, checked_signal_sizes_data: *const i64, checked_signal_sizes_len: c_int, normalized_: c_int, onesided_: c_int, output_sizes_data: *const i64, output_sizes_len: c_int));
+pub_ffi!(fn atg__fused_dropout(out__: *mut *mut C_tensor, self_: *mut C_tensor, p_: f64));
+pub_ffi!(fn atg__gather_sparse_backward(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, index_: *mut C_tensor, grad_: *mut C_tensor));
+pub_ffi!(fn atg__index_copy_(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, index_: *mut C_tensor, source_: *mut C_tensor));
+pub_ffi!(fn atg__index_put_impl_(out__: *mut *mut C_tensor, self_: *mut C_tensor, indices_data: *const *mut C_tensor, indices_len: c_int, values_: *mut C_tensor, accumulate_: c_int, unsafe_: c_int));
+pub_ffi!(fn atg__indices(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg__inverse_helper(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg__log_softmax(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, half_to_float_: c_int));
+pub_ffi!(fn atg__log_softmax_backward_data(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, output_: *mut C_tensor, dim_: i64, self_: *mut C_tensor));
+pub_ffi!(fn atg__lu_solve_helper(out__: *mut *mut C_tensor, self_: *mut C_tensor, LU_data_: *mut C_tensor, LU_pivots_: *mut C_tensor));
+pub_ffi!(fn atg__lu_with_info(out__: *mut *mut C_tensor, self_: *mut C_tensor, pivot_: c_int, check_errors_: c_int));
+pub_ffi!(fn atg__make_per_channel_quantized_tensor(out__: *mut *mut C_tensor, self_: *mut C_tensor, scale_: *mut C_tensor, zero_point_: *mut C_tensor, axis_: i64));
+pub_ffi!(fn atg__make_per_tensor_quantized_tensor(out__: *mut *mut C_tensor, self_: *mut C_tensor, scale_: f64, zero_point_: i64));
+pub_ffi!(fn atg__masked_scale(out__: *mut *mut C_tensor, self_: *mut C_tensor, mask_: *mut C_tensor, scale_: f64));
+pub_ffi!(fn atg__max(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int));
+pub_ffi!(fn atg__max_out(out__: *mut *mut C_tensor, max_: *mut C_tensor, max_indices_: *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int));
+pub_ffi!(fn atg__min(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int));
+pub_ffi!(fn atg__min_out(out__: *mut *mut C_tensor, min_: *mut C_tensor, min_indices_: *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int));
+pub_ffi!(fn atg__mkldnn_reshape(out__: *mut *mut C_tensor, self_: *mut C_tensor, shape_data: *const i64, shape_len: c_int));
+pub_ffi!(fn atg__mkldnn_transpose(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim0_: i64, dim1_: i64));
+pub_ffi!(fn atg__mkldnn_transpose_(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim0_: i64, dim1_: i64));
+pub_ffi!(fn atg__mode(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int));
+pub_ffi!(fn atg__mode_out(out__: *mut *mut C_tensor, values_: *mut C_tensor, indices_: *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int));
+pub_ffi!(fn atg__multinomial_alias_draw(out__: *mut *mut C_tensor, J_: *mut C_tensor, q_: *mut C_tensor, num_samples_: i64));
+pub_ffi!(fn atg__multinomial_alias_setup(out__: *mut *mut C_tensor, probs_: *mut C_tensor));
+pub_ffi!(fn atg__nnpack_spatial_convolution(out__: *mut *mut C_tensor, input_: *mut C_tensor, weight_: *mut C_tensor, bias_: *mut C_tensor, padding_data: *const i64, padding_len: c_int, stride_data: *const i64, stride_len: c_int));
+pub_ffi!(fn atg__nnpack_spatial_convolution_backward_input(out__: *mut *mut C_tensor, input_: *mut C_tensor, grad_output_: *mut C_tensor, weight_: *mut C_tensor, padding_data: *const i64, padding_len: c_int));
+pub_ffi!(fn atg__nnpack_spatial_convolution_backward_weight(out__: *mut *mut C_tensor, input_: *mut C_tensor, weightsize_data: *const i64, weightsize_len: c_int, grad_output_: *mut C_tensor, padding_data: *const i64, padding_len: c_int));
+pub_ffi!(fn atg__pack_padded_sequence(out__: *mut *mut C_tensor, input_: *mut C_tensor, lengths_: *mut C_tensor, batch_first_: c_int));
+pub_ffi!(fn atg__pack_padded_sequence_backward(out__: *mut *mut C_tensor, grad_: *mut C_tensor, input_size_data: *const i64, input_size_len: c_int, batch_sizes_: *mut C_tensor, batch_first_: c_int));
+pub_ffi!(fn atg__pad_packed_sequence(out__: *mut *mut C_tensor, data_: *mut C_tensor, batch_sizes_: *mut C_tensor, batch_first_: c_int, padding_value_: *mut C_scalar, total_length_: i64));
+pub_ffi!(fn atg__pdist_backward(out__: *mut *mut C_tensor, grad_: *mut C_tensor, self_: *mut C_tensor, p_: f64, pdist_: *mut C_tensor));
+pub_ffi!(fn atg__qr_helper(out__: *mut *mut C_tensor, self_: *mut C_tensor, some_: c_int));
+pub_ffi!(fn atg__reshape_from_tensor(out__: *mut *mut C_tensor, self_: *mut C_tensor, shape_: *mut C_tensor));
+pub_ffi!(fn atg__s_where(out__: *mut *mut C_tensor, condition_: *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg__sample_dirichlet(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg__shape_as_tensor(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg__sobol_engine_draw(out__: *mut *mut C_tensor, quasi_: *mut C_tensor, n_: i64, sobolstate_: *mut C_tensor, dimension_: i64, num_generated_: i64, dtype_: c_int));
+pub_ffi!(fn atg__sobol_engine_ff_(out__: *mut *mut C_tensor, self_: *mut C_tensor, n_: i64, sobolstate_: *mut C_tensor, dimension_: i64, num_generated_: i64));
+pub_ffi!(fn atg__sobol_engine_initialize_state_(out__: *mut *mut C_tensor, self_: *mut C_tensor, dimension_: i64));
+pub_ffi!(fn atg__sobol_engine_scramble_(out__: *mut *mut C_tensor, self_: *mut C_tensor, ltm_: *mut C_tensor, dimension_: i64));
+pub_ffi!(fn atg__softmax(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, half_to_float_: c_int));
+pub_ffi!(fn atg__softmax_backward_data(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, output_: *mut C_tensor, dim_: i64, self_: *mut C_tensor));
+pub_ffi!(fn atg__solve_helper(out__: *mut *mut C_tensor, self_: *mut C_tensor, A_: *mut C_tensor));
+pub_ffi!(fn atg__sparse_addmm(out__: *mut *mut C_tensor, self_: *mut C_tensor, sparse_: *mut C_tensor, dense_: *mut C_tensor));
+pub_ffi!(fn atg__sparse_coo_tensor_unsafe(out__: *mut *mut C_tensor, indices_: *mut C_tensor, values_: *mut C_tensor, size_data: *const i64, size_len: c_int, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg__sparse_coo_tensor_with_dims(out__: *mut *mut C_tensor, sparse_dim_: i64, dense_dim_: i64, size_data: *const i64, size_len: c_int, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg__sparse_coo_tensor_with_dims_and_tensors(out__: *mut *mut C_tensor, sparse_dim_: i64, dense_dim_: i64, size_data: *const i64, size_len: c_int, indices_: *mut C_tensor, values_: *mut C_tensor, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg__sparse_mm(out__: *mut *mut C_tensor, sparse_: *mut C_tensor, dense_: *mut C_tensor));
+pub_ffi!(fn atg__sparse_sum(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg__sparse_sum1(out__: *mut *mut C_tensor, self_: *mut C_tensor, dtype_: c_int));
+pub_ffi!(fn atg__sparse_sum2(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_data: *const i64, dim_len: c_int));
+pub_ffi!(fn atg__sparse_sum3(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_data: *const i64, dim_len: c_int, dtype_: c_int));
+pub_ffi!(fn atg__sparse_sum_backward(out__: *mut *mut C_tensor, grad_: *mut C_tensor, self_: *mut C_tensor, dim_data: *const i64, dim_len: c_int));
+pub_ffi!(fn atg__standard_gamma(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg__standard_gamma_grad(out__: *mut *mut C_tensor, self_: *mut C_tensor, output_: *mut C_tensor));
+pub_ffi!(fn atg__std(out__: *mut *mut C_tensor, self_: *mut C_tensor, unbiased_: c_int));
+pub_ffi!(fn atg__svd_helper(out__: *mut *mut C_tensor, self_: *mut C_tensor, some_: c_int, compute_uv_: c_int));
+pub_ffi!(fn atg__symeig_helper(out__: *mut *mut C_tensor, self_: *mut C_tensor, eigenvectors_: c_int, upper_: c_int));
+pub_ffi!(fn atg__test_optional_float(out__: *mut *mut C_tensor, self_: *mut C_tensor, scale_: f64));
+pub_ffi!(fn atg__triangular_solve_helper(out__: *mut *mut C_tensor, self_: *mut C_tensor, A_: *mut C_tensor, upper_: c_int, transpose_: c_int, unitriangular_: c_int));
+pub_ffi!(fn atg__trilinear(out__: *mut *mut C_tensor, i1_: *mut C_tensor, i2_: *mut C_tensor, i3_: *mut C_tensor, expand1_data: *const i64, expand1_len: c_int, expand2_data: *const i64, expand2_len: c_int, expand3_data: *const i64, expand3_len: c_int, sumdim_data: *const i64, sumdim_len: c_int, unroll_dim_: i64));
+pub_ffi!(fn atg__unique(out__: *mut *mut C_tensor, self_: *mut C_tensor, sorted_: c_int, return_inverse_: c_int));
+pub_ffi!(fn atg__unique2(out__: *mut *mut C_tensor, self_: *mut C_tensor, sorted_: c_int, return_inverse_: c_int, return_counts_: c_int));
+pub_ffi!(fn atg__unsafe_view(out__: *mut *mut C_tensor, self_: *mut C_tensor, size_data: *const i64, size_len: c_int));
+pub_ffi!(fn atg__values(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg__var(out__: *mut *mut C_tensor, self_: *mut C_tensor, unbiased_: c_int));
+pub_ffi!(fn atg__weight_norm(out__: *mut *mut C_tensor, v_: *mut C_tensor, g_: *mut C_tensor, dim_: i64));
+pub_ffi!(fn atg__weight_norm_cuda_interface(out__: *mut *mut C_tensor, v_: *mut C_tensor, g_: *mut C_tensor, dim_: i64));
+pub_ffi!(fn atg__weight_norm_cuda_interface_backward(out__: *mut *mut C_tensor, grad_w_: *mut C_tensor, saved_v_: *mut C_tensor, saved_g_: *mut C_tensor, saved_norms_: *mut C_tensor, dim_: i64));
+pub_ffi!(fn atg__weight_norm_differentiable_backward(out__: *mut *mut C_tensor, grad_w_: *mut C_tensor, saved_v_: *mut C_tensor, saved_g_: *mut C_tensor, saved_norms_: *mut C_tensor, dim_: i64));
+pub_ffi!(fn atg_abs(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_abs_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_abs_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_acos(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_acos_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_acos_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_adaptive_avg_pool1d(out__: *mut *mut C_tensor, self_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int));
+pub_ffi!(fn atg_adaptive_avg_pool2d(out__: *mut *mut C_tensor, self_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int));
+pub_ffi!(fn atg_adaptive_avg_pool2d_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int));
+pub_ffi!(fn atg_adaptive_avg_pool3d(out__: *mut *mut C_tensor, self_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int));
+pub_ffi!(fn atg_adaptive_avg_pool3d_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_adaptive_avg_pool3d_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_adaptive_avg_pool3d_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int));
+pub_ffi!(fn atg_adaptive_max_pool1d(out__: *mut *mut C_tensor, self_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int));
+pub_ffi!(fn atg_adaptive_max_pool2d(out__: *mut *mut C_tensor, self_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int));
+pub_ffi!(fn atg_adaptive_max_pool2d_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, indices_: *mut C_tensor));
+pub_ffi!(fn atg_adaptive_max_pool2d_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, indices_: *mut C_tensor));
+pub_ffi!(fn atg_adaptive_max_pool2d_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, indices_: *mut C_tensor, self_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int));
+pub_ffi!(fn atg_adaptive_max_pool3d(out__: *mut *mut C_tensor, self_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int));
+pub_ffi!(fn atg_adaptive_max_pool3d_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, indices_: *mut C_tensor));
+pub_ffi!(fn atg_adaptive_max_pool3d_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, indices_: *mut C_tensor));
+pub_ffi!(fn atg_adaptive_max_pool3d_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, indices_: *mut C_tensor, self_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int));
+pub_ffi!(fn atg_add(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_add1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_add_(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_add_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_add_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_addbmm(out__: *mut *mut C_tensor, self_: *mut C_tensor, batch1_: *mut C_tensor, batch2_: *mut C_tensor));
+pub_ffi!(fn atg_addbmm_(out__: *mut *mut C_tensor, self_: *mut C_tensor, batch1_: *mut C_tensor, batch2_: *mut C_tensor));
+pub_ffi!(fn atg_addbmm_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, batch1_: *mut C_tensor, batch2_: *mut C_tensor));
+pub_ffi!(fn atg_addcdiv(out__: *mut *mut C_tensor, self_: *mut C_tensor, tensor1_: *mut C_tensor, tensor2_: *mut C_tensor));
+pub_ffi!(fn atg_addcdiv_(out__: *mut *mut C_tensor, self_: *mut C_tensor, tensor1_: *mut C_tensor, tensor2_: *mut C_tensor));
+pub_ffi!(fn atg_addcdiv_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, tensor1_: *mut C_tensor, tensor2_: *mut C_tensor));
+pub_ffi!(fn atg_addcmul(out__: *mut *mut C_tensor, self_: *mut C_tensor, tensor1_: *mut C_tensor, tensor2_: *mut C_tensor));
+pub_ffi!(fn atg_addcmul_(out__: *mut *mut C_tensor, self_: *mut C_tensor, tensor1_: *mut C_tensor, tensor2_: *mut C_tensor));
+pub_ffi!(fn atg_addcmul_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, tensor1_: *mut C_tensor, tensor2_: *mut C_tensor));
+pub_ffi!(fn atg_addmm(out__: *mut *mut C_tensor, self_: *mut C_tensor, mat1_: *mut C_tensor, mat2_: *mut C_tensor));
+pub_ffi!(fn atg_addmm_(out__: *mut *mut C_tensor, self_: *mut C_tensor, mat1_: *mut C_tensor, mat2_: *mut C_tensor));
+pub_ffi!(fn atg_addmm_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, mat1_: *mut C_tensor, mat2_: *mut C_tensor));
+pub_ffi!(fn atg_addmv(out__: *mut *mut C_tensor, self_: *mut C_tensor, mat_: *mut C_tensor, vec_: *mut C_tensor));
+pub_ffi!(fn atg_addmv_(out__: *mut *mut C_tensor, self_: *mut C_tensor, mat_: *mut C_tensor, vec_: *mut C_tensor));
+pub_ffi!(fn atg_addmv_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, mat_: *mut C_tensor, vec_: *mut C_tensor));
+pub_ffi!(fn atg_addr(out__: *mut *mut C_tensor, self_: *mut C_tensor, vec1_: *mut C_tensor, vec2_: *mut C_tensor));
+pub_ffi!(fn atg_addr_(out__: *mut *mut C_tensor, self_: *mut C_tensor, vec1_: *mut C_tensor, vec2_: *mut C_tensor));
+pub_ffi!(fn atg_addr_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, vec1_: *mut C_tensor, vec2_: *mut C_tensor));
+pub_ffi!(fn atg_affine_grid_generator(out__: *mut *mut C_tensor, theta_: *mut C_tensor, size_data: *const i64, size_len: c_int, align_corners_: c_int));
+pub_ffi!(fn atg_affine_grid_generator_backward(out__: *mut *mut C_tensor, grad_: *mut C_tensor, size_data: *const i64, size_len: c_int, align_corners_: c_int));
+pub_ffi!(fn atg_alias(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_align_as(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_align_tensors(tensors_data: *const *mut C_tensor, tensors_len: c_int) -> *mut *mut C_tensor);
+pub_ffi!(fn atg_all(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_all1(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int));
+pub_ffi!(fn atg_all_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int));
+pub_ffi!(fn atg_alpha_dropout(out__: *mut *mut C_tensor, input_: *mut C_tensor, p_: f64, train_: c_int));
+pub_ffi!(fn atg_alpha_dropout_(out__: *mut *mut C_tensor, self_: *mut C_tensor, p_: f64, train_: c_int));
+pub_ffi!(fn atg_angle(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_angle_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_any(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_any1(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int));
+pub_ffi!(fn atg_any_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int));
+pub_ffi!(fn atg_arange(out__: *mut *mut C_tensor, end_: *mut C_scalar, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_arange1(out__: *mut *mut C_tensor, start_: *mut C_scalar, end_: *mut C_scalar, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_arange2(out__: *mut *mut C_tensor, start_: *mut C_scalar, end_: *mut C_scalar, step_: *mut C_scalar, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_arange_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, end_: *mut C_scalar));
+pub_ffi!(fn atg_arange_out1(out__: *mut *mut C_tensor, out_: *mut C_tensor, start_: *mut C_scalar, end_: *mut C_scalar));
+pub_ffi!(fn atg_argmax(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int));
+pub_ffi!(fn atg_argmin(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int));
+pub_ffi!(fn atg_argsort(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, descending_: c_int));
+pub_ffi!(fn atg_as_strided(out__: *mut *mut C_tensor, self_: *mut C_tensor, size_data: *const i64, size_len: c_int, stride_data: *const i64, stride_len: c_int, storage_offset_: i64));
+pub_ffi!(fn atg_as_strided_(out__: *mut *mut C_tensor, self_: *mut C_tensor, size_data: *const i64, size_len: c_int, stride_data: *const i64, stride_len: c_int, storage_offset_: i64));
+pub_ffi!(fn atg_asin(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_asin_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_asin_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_atan(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_atan2(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_atan2_(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_atan2_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_atan_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_atan_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_avg_pool1d(out__: *mut *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, ceil_mode_: c_int, count_include_pad_: c_int));
+pub_ffi!(fn atg_avg_pool2d(out__: *mut *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, ceil_mode_: c_int, count_include_pad_: c_int, divisor_override_: i64));
+pub_ffi!(fn atg_avg_pool2d_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, ceil_mode_: c_int, count_include_pad_: c_int, divisor_override_: i64));
+pub_ffi!(fn atg_avg_pool2d_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, ceil_mode_: c_int, count_include_pad_: c_int, divisor_override_: i64));
+pub_ffi!(fn atg_avg_pool2d_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, ceil_mode_: c_int, count_include_pad_: c_int, divisor_override_: i64));
+pub_ffi!(fn atg_avg_pool3d(out__: *mut *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, ceil_mode_: c_int, count_include_pad_: c_int, divisor_override_: i64));
+pub_ffi!(fn atg_avg_pool3d_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, ceil_mode_: c_int, count_include_pad_: c_int, divisor_override_: i64));
+pub_ffi!(fn atg_avg_pool3d_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, ceil_mode_: c_int, count_include_pad_: c_int, divisor_override_: i64));
+pub_ffi!(fn atg_avg_pool3d_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, ceil_mode_: c_int, count_include_pad_: c_int, divisor_override_: i64));
+pub_ffi!(fn atg_baddbmm(out__: *mut *mut C_tensor, self_: *mut C_tensor, batch1_: *mut C_tensor, batch2_: *mut C_tensor));
+pub_ffi!(fn atg_baddbmm_(out__: *mut *mut C_tensor, self_: *mut C_tensor, batch1_: *mut C_tensor, batch2_: *mut C_tensor));
+pub_ffi!(fn atg_baddbmm_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, batch1_: *mut C_tensor, batch2_: *mut C_tensor));
+pub_ffi!(fn atg_bartlett_window(out__: *mut *mut C_tensor, window_length_: i64, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_bartlett_window1(out__: *mut *mut C_tensor, window_length_: i64, periodic_: c_int, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_batch_norm(out__: *mut *mut C_tensor, input_: *mut C_tensor, weight_: *mut C_tensor, bias_: *mut C_tensor, running_mean_: *mut C_tensor, running_var_: *mut C_tensor, training_: c_int, momentum_: f64, eps_: f64, cudnn_enabled_: c_int));
+pub_ffi!(fn atg_batch_norm_backward_elemt(out__: *mut *mut C_tensor, grad_out_: *mut C_tensor, input_: *mut C_tensor, mean_: *mut C_tensor, invstd_: *mut C_tensor, weight_: *mut C_tensor, mean_dy_: *mut C_tensor, mean_dy_xmu_: *mut C_tensor));
+pub_ffi!(fn atg_batch_norm_backward_reduce(out__: *mut *mut C_tensor, grad_out_: *mut C_tensor, input_: *mut C_tensor, mean_: *mut C_tensor, invstd_: *mut C_tensor, weight_: *mut C_tensor, input_g_: c_int, weight_g_: c_int, bias_g_: c_int));
+pub_ffi!(fn atg_batch_norm_elemt(out__: *mut *mut C_tensor, input_: *mut C_tensor, weight_: *mut C_tensor, bias_: *mut C_tensor, mean_: *mut C_tensor, invstd_: *mut C_tensor, eps_: f64));
+pub_ffi!(fn atg_batch_norm_elemt_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, input_: *mut C_tensor, weight_: *mut C_tensor, bias_: *mut C_tensor, mean_: *mut C_tensor, invstd_: *mut C_tensor, eps_: f64));
+pub_ffi!(fn atg_batch_norm_gather_stats(out__: *mut *mut C_tensor, input_: *mut C_tensor, mean_: *mut C_tensor, invstd_: *mut C_tensor, running_mean_: *mut C_tensor, running_var_: *mut C_tensor, momentum_: f64, eps_: f64, count_: i64));
+pub_ffi!(fn atg_batch_norm_gather_stats_with_counts(out__: *mut *mut C_tensor, input_: *mut C_tensor, mean_: *mut C_tensor, invstd_: *mut C_tensor, running_mean_: *mut C_tensor, running_var_: *mut C_tensor, momentum_: f64, eps_: f64, counts_data: *const i64, counts_len: c_int));
+pub_ffi!(fn atg_batch_norm_stats(out__: *mut *mut C_tensor, input_: *mut C_tensor, eps_: f64));
+pub_ffi!(fn atg_batch_norm_update_stats(out__: *mut *mut C_tensor, input_: *mut C_tensor, running_mean_: *mut C_tensor, running_var_: *mut C_tensor, momentum_: f64));
+pub_ffi!(fn atg_bernoulli(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_bernoulli1(out__: *mut *mut C_tensor, self_: *mut C_tensor, p_: f64));
+pub_ffi!(fn atg_bernoulli_(out__: *mut *mut C_tensor, self_: *mut C_tensor, p_: *mut C_tensor));
+pub_ffi!(fn atg_bernoulli_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, p_: f64));
+pub_ffi!(fn atg_bernoulli_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_bilinear(out__: *mut *mut C_tensor, input1_: *mut C_tensor, input2_: *mut C_tensor, weight_: *mut C_tensor, bias_: *mut C_tensor));
+pub_ffi!(fn atg_binary_cross_entropy(out__: *mut *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, weight_: *mut C_tensor, reduction_: i64));
+pub_ffi!(fn atg_binary_cross_entropy_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, weight_: *mut C_tensor, reduction_: i64));
+pub_ffi!(fn atg_binary_cross_entropy_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, weight_: *mut C_tensor, reduction_: i64));
+pub_ffi!(fn atg_binary_cross_entropy_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, weight_: *mut C_tensor, reduction_: i64));
+pub_ffi!(fn atg_binary_cross_entropy_with_logits(out__: *mut *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, weight_: *mut C_tensor, pos_weight_: *mut C_tensor, reduction_: i64));
+pub_ffi!(fn atg_binary_cross_entropy_with_logits_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, weight_: *mut C_tensor, pos_weight_: *mut C_tensor, reduction_: i64));
+pub_ffi!(fn atg_bincount(out__: *mut *mut C_tensor, self_: *mut C_tensor, weights_: *mut C_tensor, minlength_: i64));
+pub_ffi!(fn atg_bitwise_not(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_bitwise_not_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_bitwise_not_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_bitwise_xor(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_bitwise_xor1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_bitwise_xor_(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_bitwise_xor_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_bitwise_xor_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_bitwise_xor_out1(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_blackman_window(out__: *mut *mut C_tensor, window_length_: i64, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_blackman_window1(out__: *mut *mut C_tensor, window_length_: i64, periodic_: c_int, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_bmm(out__: *mut *mut C_tensor, self_: *mut C_tensor, mat2_: *mut C_tensor));
+pub_ffi!(fn atg_bmm_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, mat2_: *mut C_tensor));
+pub_ffi!(fn atg_broadcast_tensors(tensors_data: *const *mut C_tensor, tensors_len: c_int) -> *mut *mut C_tensor);
+pub_ffi!(fn atg_cartesian_prod(out__: *mut *mut C_tensor, tensors_data: *const *mut C_tensor, tensors_len: c_int));
+pub_ffi!(fn atg_cat(out__: *mut *mut C_tensor, tensors_data: *const *mut C_tensor, tensors_len: c_int, dim_: i64));
+pub_ffi!(fn atg_cat_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, tensors_data: *const *mut C_tensor, tensors_len: c_int, dim_: i64));
+pub_ffi!(fn atg_cauchy_(out__: *mut *mut C_tensor, self_: *mut C_tensor, median_: f64, sigma_: f64));
+pub_ffi!(fn atg_cdist(out__: *mut *mut C_tensor, x1_: *mut C_tensor, x2_: *mut C_tensor, p_: f64, compute_mode_: i64));
+pub_ffi!(fn atg_ceil(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_ceil_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_ceil_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_celu(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_celu_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_chain_matmul(out__: *mut *mut C_tensor, matrices_data: *const *mut C_tensor, matrices_len: c_int));
+pub_ffi!(fn atg_cholesky(out__: *mut *mut C_tensor, self_: *mut C_tensor, upper_: c_int));
+pub_ffi!(fn atg_cholesky_inverse(out__: *mut *mut C_tensor, self_: *mut C_tensor, upper_: c_int));
+pub_ffi!(fn atg_cholesky_inverse_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, upper_: c_int));
+pub_ffi!(fn atg_cholesky_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, upper_: c_int));
+pub_ffi!(fn atg_cholesky_solve(out__: *mut *mut C_tensor, self_: *mut C_tensor, input2_: *mut C_tensor, upper_: c_int));
+pub_ffi!(fn atg_cholesky_solve_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, input2_: *mut C_tensor, upper_: c_int));
+pub_ffi!(fn atg_chunk(self_: *mut C_tensor, chunks_: i64, dim_: i64) -> *mut *mut C_tensor);
+pub_ffi!(fn atg_clamp(out__: *mut *mut C_tensor, self_: *mut C_tensor, min_: *mut C_scalar, max_: *mut C_scalar));
+pub_ffi!(fn atg_clamp_(out__: *mut *mut C_tensor, self_: *mut C_tensor, min_: *mut C_scalar, max_: *mut C_scalar));
+pub_ffi!(fn atg_clamp_max(out__: *mut *mut C_tensor, self_: *mut C_tensor, max_: *mut C_scalar));
+pub_ffi!(fn atg_clamp_max_(out__: *mut *mut C_tensor, self_: *mut C_tensor, max_: *mut C_scalar));
+pub_ffi!(fn atg_clamp_max_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, max_: *mut C_scalar));
+pub_ffi!(fn atg_clamp_min(out__: *mut *mut C_tensor, self_: *mut C_tensor, min_: *mut C_scalar));
+pub_ffi!(fn atg_clamp_min_(out__: *mut *mut C_tensor, self_: *mut C_tensor, min_: *mut C_scalar));
+pub_ffi!(fn atg_clamp_min_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, min_: *mut C_scalar));
+pub_ffi!(fn atg_clamp_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, min_: *mut C_scalar, max_: *mut C_scalar));
+pub_ffi!(fn atg_coalesce(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_col2im(out__: *mut *mut C_tensor, self_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int, kernel_size_data: *const i64, kernel_size_len: c_int, dilation_data: *const i64, dilation_len: c_int, padding_data: *const i64, padding_len: c_int, stride_data: *const i64, stride_len: c_int));
+pub_ffi!(fn atg_col2im_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, dilation_data: *const i64, dilation_len: c_int, padding_data: *const i64, padding_len: c_int, stride_data: *const i64, stride_len: c_int));
+pub_ffi!(fn atg_col2im_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, dilation_data: *const i64, dilation_len: c_int, padding_data: *const i64, padding_len: c_int, stride_data: *const i64, stride_len: c_int));
+pub_ffi!(fn atg_col2im_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int, kernel_size_data: *const i64, kernel_size_len: c_int, dilation_data: *const i64, dilation_len: c_int, padding_data: *const i64, padding_len: c_int, stride_data: *const i64, stride_len: c_int));
+pub_ffi!(fn atg_combinations(out__: *mut *mut C_tensor, self_: *mut C_tensor, r_: i64, with_replacement_: c_int));
+pub_ffi!(fn atg_conj(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_conj_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_constant_pad_nd(out__: *mut *mut C_tensor, self_: *mut C_tensor, pad_data: *const i64, pad_len: c_int));
+pub_ffi!(fn atg_contiguous(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_conv1d(out__: *mut *mut C_tensor, input_: *mut C_tensor, weight_: *mut C_tensor, bias_: *mut C_tensor, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, dilation_data: *const i64, dilation_len: c_int, groups_: i64));
+pub_ffi!(fn atg_conv2d(out__: *mut *mut C_tensor, input_: *mut C_tensor, weight_: *mut C_tensor, bias_: *mut C_tensor, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, dilation_data: *const i64, dilation_len: c_int, groups_: i64));
+pub_ffi!(fn atg_conv3d(out__: *mut *mut C_tensor, input_: *mut C_tensor, weight_: *mut C_tensor, bias_: *mut C_tensor, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, dilation_data: *const i64, dilation_len: c_int, groups_: i64));
+pub_ffi!(fn atg_conv_tbc(out__: *mut *mut C_tensor, self_: *mut C_tensor, weight_: *mut C_tensor, bias_: *mut C_tensor, pad_: i64));
+pub_ffi!(fn atg_conv_tbc_backward(out__: *mut *mut C_tensor, self_: *mut C_tensor, input_: *mut C_tensor, weight_: *mut C_tensor, bias_: *mut C_tensor, pad_: i64));
+pub_ffi!(fn atg_conv_transpose1d(out__: *mut *mut C_tensor, input_: *mut C_tensor, weight_: *mut C_tensor, bias_: *mut C_tensor, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, output_padding_data: *const i64, output_padding_len: c_int, groups_: i64, dilation_data: *const i64, dilation_len: c_int));
+pub_ffi!(fn atg_conv_transpose2d(out__: *mut *mut C_tensor, input_: *mut C_tensor, weight_: *mut C_tensor, bias_: *mut C_tensor, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, output_padding_data: *const i64, output_padding_len: c_int, groups_: i64, dilation_data: *const i64, dilation_len: c_int));
+pub_ffi!(fn atg_conv_transpose3d(out__: *mut *mut C_tensor, input_: *mut C_tensor, weight_: *mut C_tensor, bias_: *mut C_tensor, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, output_padding_data: *const i64, output_padding_len: c_int, groups_: i64, dilation_data: *const i64, dilation_len: c_int));
+pub_ffi!(fn atg_convolution(out__: *mut *mut C_tensor, input_: *mut C_tensor, weight_: *mut C_tensor, bias_: *mut C_tensor, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, dilation_data: *const i64, dilation_len: c_int, transposed_: c_int, output_padding_data: *const i64, output_padding_len: c_int, groups_: i64));
+pub_ffi!(fn atg_convolution_overrideable(out__: *mut *mut C_tensor, input_: *mut C_tensor, weight_: *mut C_tensor, bias_: *mut C_tensor, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, dilation_data: *const i64, dilation_len: c_int, transposed_: c_int, output_padding_data: *const i64, output_padding_len: c_int, groups_: i64));
+pub_ffi!(fn atg_copy_sparse_to_sparse_(out__: *mut *mut C_tensor, self_: *mut C_tensor, src_: *mut C_tensor, non_blocking_: c_int));
+pub_ffi!(fn atg_cos(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_cos_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_cos_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_cosh(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_cosh_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_cosh_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_cosine_embedding_loss(out__: *mut *mut C_tensor, input1_: *mut C_tensor, input2_: *mut C_tensor, target_: *mut C_tensor, margin_: f64, reduction_: i64));
+pub_ffi!(fn atg_cosine_similarity(out__: *mut *mut C_tensor, x1_: *mut C_tensor, x2_: *mut C_tensor, dim_: i64, eps_: f64));
+pub_ffi!(fn atg_cross(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor, dim_: i64));
+pub_ffi!(fn atg_cross_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor, dim_: i64));
+pub_ffi!(fn atg_ctc_loss(out__: *mut *mut C_tensor, log_probs_: *mut C_tensor, targets_: *mut C_tensor, input_lengths_data: *const i64, input_lengths_len: c_int, target_lengths_data: *const i64, target_lengths_len: c_int, blank_: i64, reduction_: i64, zero_infinity_: c_int));
+pub_ffi!(fn atg_ctc_loss1(out__: *mut *mut C_tensor, log_probs_: *mut C_tensor, targets_: *mut C_tensor, input_lengths_: *mut C_tensor, target_lengths_: *mut C_tensor, blank_: i64, reduction_: i64, zero_infinity_: c_int));
+pub_ffi!(fn atg_cudnn_affine_grid_generator(out__: *mut *mut C_tensor, theta_: *mut C_tensor, n_: i64, C_: i64, H_: i64, W_: i64));
+pub_ffi!(fn atg_cudnn_affine_grid_generator_backward(out__: *mut *mut C_tensor, grad_: *mut C_tensor, n_: i64, C_: i64, H_: i64, W_: i64));
+pub_ffi!(fn atg_cudnn_batch_norm(out__: *mut *mut C_tensor, input_: *mut C_tensor, weight_: *mut C_tensor, bias_: *mut C_tensor, running_mean_: *mut C_tensor, running_var_: *mut C_tensor, training_: c_int, exponential_average_factor_: f64, epsilon_: f64));
+pub_ffi!(fn atg_cudnn_batch_norm_backward(out__: *mut *mut C_tensor, input_: *mut C_tensor, grad_output_: *mut C_tensor, weight_: *mut C_tensor, running_mean_: *mut C_tensor, running_var_: *mut C_tensor, save_mean_: *mut C_tensor, save_var_: *mut C_tensor, epsilon_: f64, reserveSpace_: *mut C_tensor));
+pub_ffi!(fn atg_cudnn_convolution(out__: *mut *mut C_tensor, self_: *mut C_tensor, weight_: *mut C_tensor, bias_: *mut C_tensor, padding_data: *const i64, padding_len: c_int, stride_data: *const i64, stride_len: c_int, dilation_data: *const i64, dilation_len: c_int, groups_: i64, benchmark_: c_int, deterministic_: c_int));
+pub_ffi!(fn atg_cudnn_convolution_backward_bias(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor));
+pub_ffi!(fn atg_cudnn_convolution_backward_input(out__: *mut *mut C_tensor, self_size_data: *const i64, self_size_len: c_int, grad_output_: *mut C_tensor, weight_: *mut C_tensor, padding_data: *const i64, padding_len: c_int, stride_data: *const i64, stride_len: c_int, dilation_data: *const i64, dilation_len: c_int, groups_: i64, benchmark_: c_int, deterministic_: c_int));
+pub_ffi!(fn atg_cudnn_convolution_backward_weight(out__: *mut *mut C_tensor, weight_size_data: *const i64, weight_size_len: c_int, grad_output_: *mut C_tensor, self_: *mut C_tensor, padding_data: *const i64, padding_len: c_int, stride_data: *const i64, stride_len: c_int, dilation_data: *const i64, dilation_len: c_int, groups_: i64, benchmark_: c_int, deterministic_: c_int));
+pub_ffi!(fn atg_cudnn_convolution_transpose(out__: *mut *mut C_tensor, self_: *mut C_tensor, weight_: *mut C_tensor, bias_: *mut C_tensor, padding_data: *const i64, padding_len: c_int, output_padding_data: *const i64, output_padding_len: c_int, stride_data: *const i64, stride_len: c_int, dilation_data: *const i64, dilation_len: c_int, groups_: i64, benchmark_: c_int, deterministic_: c_int));
+pub_ffi!(fn atg_cudnn_convolution_transpose_backward_bias(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor));
+pub_ffi!(fn atg_cudnn_convolution_transpose_backward_input(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, weight_: *mut C_tensor, padding_data: *const i64, padding_len: c_int, stride_data: *const i64, stride_len: c_int, dilation_data: *const i64, dilation_len: c_int, groups_: i64, benchmark_: c_int, deterministic_: c_int));
+pub_ffi!(fn atg_cudnn_convolution_transpose_backward_weight(out__: *mut *mut C_tensor, weight_size_data: *const i64, weight_size_len: c_int, grad_output_: *mut C_tensor, self_: *mut C_tensor, padding_data: *const i64, padding_len: c_int, stride_data: *const i64, stride_len: c_int, dilation_data: *const i64, dilation_len: c_int, groups_: i64, benchmark_: c_int, deterministic_: c_int));
+pub_ffi!(fn atg_cudnn_grid_sampler(out__: *mut *mut C_tensor, self_: *mut C_tensor, grid_: *mut C_tensor));
+pub_ffi!(fn atg_cudnn_grid_sampler_backward(out__: *mut *mut C_tensor, self_: *mut C_tensor, grid_: *mut C_tensor, grad_output_: *mut C_tensor));
+pub_ffi!(fn atg_cumprod(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, dtype_: c_int));
+pub_ffi!(fn atg_cumprod_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, dim_: i64, dtype_: c_int));
+pub_ffi!(fn atg_cumsum(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, dtype_: c_int));
+pub_ffi!(fn atg_cumsum_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, dim_: i64, dtype_: c_int));
+pub_ffi!(fn atg_data(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_dequantize(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_det(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_detach(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_detach_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_diag(out__: *mut *mut C_tensor, self_: *mut C_tensor, diagonal_: i64));
+pub_ffi!(fn atg_diag_embed(out__: *mut *mut C_tensor, self_: *mut C_tensor, offset_: i64, dim1_: i64, dim2_: i64));
+pub_ffi!(fn atg_diag_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, diagonal_: i64));
+pub_ffi!(fn atg_diagflat(out__: *mut *mut C_tensor, self_: *mut C_tensor, offset_: i64));
+pub_ffi!(fn atg_diagonal(out__: *mut *mut C_tensor, self_: *mut C_tensor, offset_: i64, dim1_: i64, dim2_: i64));
+pub_ffi!(fn atg_digamma(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_digamma_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_digamma_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_dist(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_div(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_div1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_div_(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_div_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_div_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_dot(out__: *mut *mut C_tensor, self_: *mut C_tensor, tensor_: *mut C_tensor));
+pub_ffi!(fn atg_dot_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, tensor_: *mut C_tensor));
+pub_ffi!(fn atg_dropout(out__: *mut *mut C_tensor, input_: *mut C_tensor, p_: f64, train_: c_int));
+pub_ffi!(fn atg_dropout_(out__: *mut *mut C_tensor, self_: *mut C_tensor, p_: f64, train_: c_int));
+pub_ffi!(fn atg_eig(out__: *mut *mut C_tensor, self_: *mut C_tensor, eigenvectors_: c_int));
+pub_ffi!(fn atg_eig_out(out__: *mut *mut C_tensor, e_: *mut C_tensor, v_: *mut C_tensor, self_: *mut C_tensor, eigenvectors_: c_int));
+pub_ffi!(fn atg_elu(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_elu_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_elu_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, alpha_: *mut C_scalar, scale_: *mut C_scalar, input_scale_: *mut C_scalar, output_: *mut C_tensor));
+pub_ffi!(fn atg_elu_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, alpha_: *mut C_scalar, scale_: *mut C_scalar, input_scale_: *mut C_scalar, output_: *mut C_tensor));
+pub_ffi!(fn atg_elu_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_embedding(out__: *mut *mut C_tensor, weight_: *mut C_tensor, indices_: *mut C_tensor, padding_idx_: i64, scale_grad_by_freq_: c_int, sparse_: c_int));
+pub_ffi!(fn atg_embedding_backward(out__: *mut *mut C_tensor, grad_: *mut C_tensor, indices_: *mut C_tensor, num_weights_: i64, padding_idx_: i64, scale_grad_by_freq_: c_int, sparse_: c_int));
+pub_ffi!(fn atg_embedding_bag(out__: *mut *mut C_tensor, weight_: *mut C_tensor, indices_: *mut C_tensor, offsets_: *mut C_tensor, scale_grad_by_freq_: c_int, mode_: i64, sparse_: c_int, per_sample_weights_: *mut C_tensor));
+pub_ffi!(fn atg_embedding_dense_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, indices_: *mut C_tensor, num_weights_: i64, padding_idx_: i64, scale_grad_by_freq_: c_int));
+pub_ffi!(fn atg_embedding_renorm_(out__: *mut *mut C_tensor, self_: *mut C_tensor, indices_: *mut C_tensor, max_norm_: f64, norm_type_: f64));
+pub_ffi!(fn atg_embedding_sparse_backward(out__: *mut *mut C_tensor, grad_: *mut C_tensor, indices_: *mut C_tensor, num_weights_: i64, padding_idx_: i64, scale_grad_by_freq_: c_int));
+pub_ffi!(fn atg_empty(out__: *mut *mut C_tensor, size_data: *const i64, size_len: c_int, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_empty_like(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_empty_like1(out__: *mut *mut C_tensor, self_: *mut C_tensor, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_empty_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, size_data: *const i64, size_len: c_int));
+pub_ffi!(fn atg_empty_strided(out__: *mut *mut C_tensor, size_data: *const i64, size_len: c_int, stride_data: *const i64, stride_len: c_int, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_eq(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_eq1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_eq_(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_eq_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_eq_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_eq_out1(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_erf(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_erf_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_erf_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_erfc(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_erfc_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_erfc_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_erfinv(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_erfinv_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_erfinv_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_exp(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_exp_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_exp_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_expand(out__: *mut *mut C_tensor, self_: *mut C_tensor, size_data: *const i64, size_len: c_int, implicit_: c_int));
+pub_ffi!(fn atg_expand_as(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_expm1(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_expm1_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_expm1_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_exponential_(out__: *mut *mut C_tensor, self_: *mut C_tensor, lambd_: f64));
+pub_ffi!(fn atg_eye(out__: *mut *mut C_tensor, n_: i64, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_eye1(out__: *mut *mut C_tensor, n_: i64, m_: i64, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_eye_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, n_: i64));
+pub_ffi!(fn atg_eye_out1(out__: *mut *mut C_tensor, out_: *mut C_tensor, n_: i64, m_: i64));
+pub_ffi!(fn atg_fake_quantize_per_channel_affine(out__: *mut *mut C_tensor, self_: *mut C_tensor, scale_: *mut C_tensor, zero_point_: *mut C_tensor, axis_: i64, quant_min_: i64, quant_max_: i64));
+pub_ffi!(fn atg_fake_quantize_per_channel_affine_backward(out__: *mut *mut C_tensor, grad_: *mut C_tensor, self_: *mut C_tensor, scale_: *mut C_tensor, zero_point_: *mut C_tensor, axis_: i64, quant_min_: i64, quant_max_: i64));
+pub_ffi!(fn atg_fake_quantize_per_tensor_affine(out__: *mut *mut C_tensor, self_: *mut C_tensor, scale_: f64, zero_point_: i64, quant_min_: i64, quant_max_: i64));
+pub_ffi!(fn atg_fake_quantize_per_tensor_affine_backward(out__: *mut *mut C_tensor, grad_: *mut C_tensor, self_: *mut C_tensor, scale_: f64, zero_point_: i64, quant_min_: i64, quant_max_: i64));
+pub_ffi!(fn atg_fbgemm_linear_fp16_weight(out__: *mut *mut C_tensor, input_: *mut C_tensor, packed_weight_: *mut C_tensor, bias_: *mut C_tensor));
+pub_ffi!(fn atg_fbgemm_linear_fp16_weight_fp32_activation(out__: *mut *mut C_tensor, input_: *mut C_tensor, packed_weight_: *mut C_tensor, bias_: *mut C_tensor));
+pub_ffi!(fn atg_fbgemm_linear_int8_weight(out__: *mut *mut C_tensor, input_: *mut C_tensor, weight_: *mut C_tensor, packed_: *mut C_tensor, col_offsets_: *mut C_tensor, weight_scale_: *mut C_scalar, weight_zero_point_: *mut C_scalar, bias_: *mut C_tensor));
+pub_ffi!(fn atg_fbgemm_linear_int8_weight_fp32_activation(out__: *mut *mut C_tensor, input_: *mut C_tensor, weight_: *mut C_tensor, packed_: *mut C_tensor, col_offsets_: *mut C_tensor, weight_scale_: *mut C_scalar, weight_zero_point_: *mut C_scalar, bias_: *mut C_tensor));
+pub_ffi!(fn atg_fbgemm_pack_gemm_matrix_fp16(out__: *mut *mut C_tensor, input_: *mut C_tensor));
+pub_ffi!(fn atg_fbgemm_pack_quantized_matrix(out__: *mut *mut C_tensor, input_: *mut C_tensor));
+pub_ffi!(fn atg_fbgemm_pack_quantized_matrix1(out__: *mut *mut C_tensor, input_: *mut C_tensor, K_: i64, n_: i64));
+pub_ffi!(fn atg_feature_alpha_dropout(out__: *mut *mut C_tensor, input_: *mut C_tensor, p_: f64, train_: c_int));
+pub_ffi!(fn atg_feature_alpha_dropout_(out__: *mut *mut C_tensor, self_: *mut C_tensor, p_: f64, train_: c_int));
+pub_ffi!(fn atg_feature_dropout(out__: *mut *mut C_tensor, input_: *mut C_tensor, p_: f64, train_: c_int));
+pub_ffi!(fn atg_feature_dropout_(out__: *mut *mut C_tensor, self_: *mut C_tensor, p_: f64, train_: c_int));
+pub_ffi!(fn atg_fft(out__: *mut *mut C_tensor, self_: *mut C_tensor, signal_ndim_: i64, normalized_: c_int));
+pub_ffi!(fn atg_fill_(out__: *mut *mut C_tensor, self_: *mut C_tensor, value_: *mut C_scalar));
+pub_ffi!(fn atg_fill_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, value_: *mut C_tensor));
+pub_ffi!(fn atg_fill_diagonal_(out__: *mut *mut C_tensor, self_: *mut C_tensor, fill_value_: *mut C_scalar, wrap_: c_int));
+pub_ffi!(fn atg_flatten(out__: *mut *mut C_tensor, self_: *mut C_tensor, start_dim_: i64, end_dim_: i64));
+pub_ffi!(fn atg_flip(out__: *mut *mut C_tensor, self_: *mut C_tensor, dims_data: *const i64, dims_len: c_int));
+pub_ffi!(fn atg_floor(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_floor_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_floor_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_fmod(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_fmod1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_fmod_(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_fmod_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_fmod_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_fmod_out1(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_frac(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_frac_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_frac_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_fractional_max_pool2d(out__: *mut *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, output_size_data: *const i64, output_size_len: c_int, random_samples_: *mut C_tensor));
+pub_ffi!(fn atg_fractional_max_pool2d_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, output_size_data: *const i64, output_size_len: c_int, indices_: *mut C_tensor));
+pub_ffi!(fn atg_fractional_max_pool2d_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, output_size_data: *const i64, output_size_len: c_int, indices_: *mut C_tensor));
+pub_ffi!(fn atg_fractional_max_pool2d_out(out__: *mut *mut C_tensor, output_: *mut C_tensor, indices_: *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, output_size_data: *const i64, output_size_len: c_int, random_samples_: *mut C_tensor));
+pub_ffi!(fn atg_fractional_max_pool3d(out__: *mut *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, output_size_data: *const i64, output_size_len: c_int, random_samples_: *mut C_tensor));
+pub_ffi!(fn atg_fractional_max_pool3d_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, output_size_data: *const i64, output_size_len: c_int, indices_: *mut C_tensor));
+pub_ffi!(fn atg_fractional_max_pool3d_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, output_size_data: *const i64, output_size_len: c_int, indices_: *mut C_tensor));
+pub_ffi!(fn atg_fractional_max_pool3d_out(out__: *mut *mut C_tensor, output_: *mut C_tensor, indices_: *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, output_size_data: *const i64, output_size_len: c_int, random_samples_: *mut C_tensor));
+pub_ffi!(fn atg_frobenius_norm(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_frobenius_norm1(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_data: *const i64, dim_len: c_int, keepdim_: c_int));
+pub_ffi!(fn atg_frobenius_norm_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, dim_data: *const i64, dim_len: c_int, keepdim_: c_int));
+pub_ffi!(fn atg_full(out__: *mut *mut C_tensor, size_data: *const i64, size_len: c_int, fill_value_: *mut C_scalar, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_full_like(out__: *mut *mut C_tensor, self_: *mut C_tensor, fill_value_: *mut C_scalar));
+pub_ffi!(fn atg_full_like1(out__: *mut *mut C_tensor, self_: *mut C_tensor, fill_value_: *mut C_scalar, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_full_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, size_data: *const i64, size_len: c_int, fill_value_: *mut C_scalar));
+pub_ffi!(fn atg_gather(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, index_: *mut C_tensor, sparse_grad_: c_int));
+pub_ffi!(fn atg_gather_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, dim_: i64, index_: *mut C_tensor, sparse_grad_: c_int));
+pub_ffi!(fn atg_ge(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_ge1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_ge_(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_ge_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_ge_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_ge_out1(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_gelu(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_gelu_backward(out__: *mut *mut C_tensor, grad_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_geometric_(out__: *mut *mut C_tensor, self_: *mut C_tensor, p_: f64));
+pub_ffi!(fn atg_geqrf(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_geqrf_out(out__: *mut *mut C_tensor, a_: *mut C_tensor, tau_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_ger(out__: *mut *mut C_tensor, self_: *mut C_tensor, vec2_: *mut C_tensor));
+pub_ffi!(fn atg_ger_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, vec2_: *mut C_tensor));
+pub_ffi!(fn atg_glu(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64));
+pub_ffi!(fn atg_glu_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, dim_: i64));
+pub_ffi!(fn atg_glu_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, dim_: i64));
+pub_ffi!(fn atg_glu_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, dim_: i64));
+pub_ffi!(fn atg_grad(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_grid_sampler(out__: *mut *mut C_tensor, input_: *mut C_tensor, grid_: *mut C_tensor, interpolation_mode_: i64, padding_mode_: i64, align_corners_: c_int));
+pub_ffi!(fn atg_grid_sampler_2d(out__: *mut *mut C_tensor, input_: *mut C_tensor, grid_: *mut C_tensor, interpolation_mode_: i64, padding_mode_: i64, align_corners_: c_int));
+pub_ffi!(fn atg_grid_sampler_2d_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, input_: *mut C_tensor, grid_: *mut C_tensor, interpolation_mode_: i64, padding_mode_: i64, align_corners_: c_int));
+pub_ffi!(fn atg_grid_sampler_3d(out__: *mut *mut C_tensor, input_: *mut C_tensor, grid_: *mut C_tensor, interpolation_mode_: i64, padding_mode_: i64, align_corners_: c_int));
+pub_ffi!(fn atg_grid_sampler_3d_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, input_: *mut C_tensor, grid_: *mut C_tensor, interpolation_mode_: i64, padding_mode_: i64, align_corners_: c_int));
+pub_ffi!(fn atg_group_norm(out__: *mut *mut C_tensor, input_: *mut C_tensor, num_groups_: i64, weight_: *mut C_tensor, bias_: *mut C_tensor, eps_: f64, cudnn_enabled_: c_int));
+pub_ffi!(fn atg_gru(out__: *mut *mut C_tensor, input_: *mut C_tensor, hx_: *mut C_tensor, params_data: *const *mut C_tensor, params_len: c_int, has_biases_: c_int, num_layers_: i64, dropout_: f64, train_: c_int, bidirectional_: c_int, batch_first_: c_int));
+pub_ffi!(fn atg_gru1(out__: *mut *mut C_tensor, data_: *mut C_tensor, batch_sizes_: *mut C_tensor, hx_: *mut C_tensor, params_data: *const *mut C_tensor, params_len: c_int, has_biases_: c_int, num_layers_: i64, dropout_: f64, train_: c_int, bidirectional_: c_int));
+pub_ffi!(fn atg_gru_cell(out__: *mut *mut C_tensor, input_: *mut C_tensor, hx_: *mut C_tensor, w_ih_: *mut C_tensor, w_hh_: *mut C_tensor, b_ih_: *mut C_tensor, b_hh_: *mut C_tensor));
+pub_ffi!(fn atg_gt(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_gt1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_gt_(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_gt_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_gt_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_gt_out1(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_hamming_window(out__: *mut *mut C_tensor, window_length_: i64, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_hamming_window1(out__: *mut *mut C_tensor, window_length_: i64, periodic_: c_int, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_hamming_window2(out__: *mut *mut C_tensor, window_length_: i64, periodic_: c_int, alpha_: f64, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_hamming_window3(out__: *mut *mut C_tensor, window_length_: i64, periodic_: c_int, alpha_: f64, beta_: f64, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_hann_window(out__: *mut *mut C_tensor, window_length_: i64, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_hann_window1(out__: *mut *mut C_tensor, window_length_: i64, periodic_: c_int, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_hardshrink(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_hardshrink_backward(out__: *mut *mut C_tensor, grad_out_: *mut C_tensor, self_: *mut C_tensor, lambd_: *mut C_scalar));
+pub_ffi!(fn atg_hardtanh(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_hardtanh_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_hardtanh_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, min_val_: *mut C_scalar, max_val_: *mut C_scalar));
+pub_ffi!(fn atg_hardtanh_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, min_val_: *mut C_scalar, max_val_: *mut C_scalar));
+pub_ffi!(fn atg_hardtanh_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_hinge_embedding_loss(out__: *mut *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, margin_: f64, reduction_: i64));
+pub_ffi!(fn atg_histc(out__: *mut *mut C_tensor, self_: *mut C_tensor, bins_: i64));
+pub_ffi!(fn atg_histc_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, bins_: i64));
+pub_ffi!(fn atg_hspmm(out__: *mut *mut C_tensor, mat1_: *mut C_tensor, mat2_: *mut C_tensor));
+pub_ffi!(fn atg_hspmm_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, mat1_: *mut C_tensor, mat2_: *mut C_tensor));
+pub_ffi!(fn atg_ifft(out__: *mut *mut C_tensor, self_: *mut C_tensor, signal_ndim_: i64, normalized_: c_int));
+pub_ffi!(fn atg_im2col(out__: *mut *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, dilation_data: *const i64, dilation_len: c_int, padding_data: *const i64, padding_len: c_int, stride_data: *const i64, stride_len: c_int));
+pub_ffi!(fn atg_im2col_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, input_size_data: *const i64, input_size_len: c_int, kernel_size_data: *const i64, kernel_size_len: c_int, dilation_data: *const i64, dilation_len: c_int, padding_data: *const i64, padding_len: c_int, stride_data: *const i64, stride_len: c_int));
+pub_ffi!(fn atg_im2col_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, input_size_data: *const i64, input_size_len: c_int, kernel_size_data: *const i64, kernel_size_len: c_int, dilation_data: *const i64, dilation_len: c_int, padding_data: *const i64, padding_len: c_int, stride_data: *const i64, stride_len: c_int));
+pub_ffi!(fn atg_im2col_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, dilation_data: *const i64, dilation_len: c_int, padding_data: *const i64, padding_len: c_int, stride_data: *const i64, stride_len: c_int));
+pub_ffi!(fn atg_imag(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_imag_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_index(out__: *mut *mut C_tensor, self_: *mut C_tensor, indices_data: *const *mut C_tensor, indices_len: c_int));
+pub_ffi!(fn atg_index_add(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, index_: *mut C_tensor, source_: *mut C_tensor));
+pub_ffi!(fn atg_index_add_(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, index_: *mut C_tensor, source_: *mut C_tensor));
+pub_ffi!(fn atg_index_copy(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, index_: *mut C_tensor, source_: *mut C_tensor));
+pub_ffi!(fn atg_index_copy_(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, index_: *mut C_tensor, source_: *mut C_tensor));
+pub_ffi!(fn atg_index_fill(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, index_: *mut C_tensor, value_: *mut C_scalar));
+pub_ffi!(fn atg_index_fill1(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, index_: *mut C_tensor, value_: *mut C_tensor));
+pub_ffi!(fn atg_index_fill_(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, index_: *mut C_tensor, value_: *mut C_scalar));
+pub_ffi!(fn atg_index_fill_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, index_: *mut C_tensor, value_: *mut C_tensor));
+pub_ffi!(fn atg_index_put(out__: *mut *mut C_tensor, self_: *mut C_tensor, indices_data: *const *mut C_tensor, indices_len: c_int, values_: *mut C_tensor, accumulate_: c_int));
+pub_ffi!(fn atg_index_put_(out__: *mut *mut C_tensor, self_: *mut C_tensor, indices_data: *const *mut C_tensor, indices_len: c_int, values_: *mut C_tensor, accumulate_: c_int));
+pub_ffi!(fn atg_index_select(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, index_: *mut C_tensor));
+pub_ffi!(fn atg_index_select_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, dim_: i64, index_: *mut C_tensor));
+pub_ffi!(fn atg_indices(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_instance_norm(out__: *mut *mut C_tensor, input_: *mut C_tensor, weight_: *mut C_tensor, bias_: *mut C_tensor, running_mean_: *mut C_tensor, running_var_: *mut C_tensor, use_input_stats_: c_int, momentum_: f64, eps_: f64, cudnn_enabled_: c_int));
+pub_ffi!(fn atg_int_repr(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_inverse(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_inverse_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_irfft(out__: *mut *mut C_tensor, self_: *mut C_tensor, signal_ndim_: i64, normalized_: c_int, onesided_: c_int, signal_sizes_data: *const i64, signal_sizes_len: c_int));
+pub_ffi!(fn atg_isclose(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor, rtol_: f64, atol_: f64, equal_nan_: c_int));
+pub_ffi!(fn atg_isfinite(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_isnan(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_kl_div(out__: *mut *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, reduction_: i64));
+pub_ffi!(fn atg_kl_div_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, reduction_: i64));
+pub_ffi!(fn atg_kthvalue(out__: *mut *mut C_tensor, self_: *mut C_tensor, k_: i64, dim_: i64, keepdim_: c_int));
+pub_ffi!(fn atg_kthvalue_out(out__: *mut *mut C_tensor, values_: *mut C_tensor, indices_: *mut C_tensor, self_: *mut C_tensor, k_: i64, dim_: i64, keepdim_: c_int));
+pub_ffi!(fn atg_l1_loss(out__: *mut *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, reduction_: i64));
+pub_ffi!(fn atg_l1_loss_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, reduction_: i64));
+pub_ffi!(fn atg_l1_loss_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, reduction_: i64));
+pub_ffi!(fn atg_l1_loss_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, reduction_: i64));
+pub_ffi!(fn atg_layer_norm(out__: *mut *mut C_tensor, input_: *mut C_tensor, normalized_shape_data: *const i64, normalized_shape_len: c_int, weight_: *mut C_tensor, bias_: *mut C_tensor, eps_: f64, cudnn_enable_: c_int));
+pub_ffi!(fn atg_le(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_le1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_le_(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_le_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_le_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_le_out1(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_leaky_relu(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_leaky_relu_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_leaky_relu_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, negative_slope_: *mut C_scalar));
+pub_ffi!(fn atg_leaky_relu_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, negative_slope_: *mut C_scalar));
+pub_ffi!(fn atg_leaky_relu_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_lerp(out__: *mut *mut C_tensor, self_: *mut C_tensor, end_: *mut C_tensor, weight_: *mut C_scalar));
+pub_ffi!(fn atg_lerp1(out__: *mut *mut C_tensor, self_: *mut C_tensor, end_: *mut C_tensor, weight_: *mut C_tensor));
+pub_ffi!(fn atg_lerp_(out__: *mut *mut C_tensor, self_: *mut C_tensor, end_: *mut C_tensor, weight_: *mut C_scalar));
+pub_ffi!(fn atg_lerp_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, end_: *mut C_tensor, weight_: *mut C_tensor));
+pub_ffi!(fn atg_lerp_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, end_: *mut C_tensor, weight_: *mut C_scalar));
+pub_ffi!(fn atg_lerp_out1(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, end_: *mut C_tensor, weight_: *mut C_tensor));
+pub_ffi!(fn atg_lgamma(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_lgamma_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_lgamma_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_linear(out__: *mut *mut C_tensor, input_: *mut C_tensor, weight_: *mut C_tensor, bias_: *mut C_tensor));
+pub_ffi!(fn atg_linspace(out__: *mut *mut C_tensor, start_: *mut C_scalar, end_: *mut C_scalar, steps_: i64, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_linspace_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, start_: *mut C_scalar, end_: *mut C_scalar, steps_: i64));
+pub_ffi!(fn atg_log(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_log10(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_log10_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_log10_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_log1p(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_log1p_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_log1p_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_log2(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_log2_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_log2_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_log_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_log_normal_(out__: *mut *mut C_tensor, self_: *mut C_tensor, mean_: f64, std_: f64));
+pub_ffi!(fn atg_log_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_log_sigmoid(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_log_sigmoid_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, buffer_: *mut C_tensor));
+pub_ffi!(fn atg_log_sigmoid_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, buffer_: *mut C_tensor));
+pub_ffi!(fn atg_log_sigmoid_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_log_softmax(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, dtype_: c_int));
+pub_ffi!(fn atg_logdet(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_logical_not(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_logical_not_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_logical_not_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_logical_xor(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_logical_xor_(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_logical_xor_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_logspace(out__: *mut *mut C_tensor, start_: *mut C_scalar, end_: *mut C_scalar, steps_: i64, base_: f64, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_logspace_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, start_: *mut C_scalar, end_: *mut C_scalar, steps_: i64, base_: f64));
+pub_ffi!(fn atg_logsumexp(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_data: *const i64, dim_len: c_int, keepdim_: c_int));
+pub_ffi!(fn atg_logsumexp_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, dim_data: *const i64, dim_len: c_int, keepdim_: c_int));
+pub_ffi!(fn atg_lstm(out__: *mut *mut C_tensor, input_: *mut C_tensor, hx_data: *const *mut C_tensor, hx_len: c_int, params_data: *const *mut C_tensor, params_len: c_int, has_biases_: c_int, num_layers_: i64, dropout_: f64, train_: c_int, bidirectional_: c_int, batch_first_: c_int));
+pub_ffi!(fn atg_lstm1(out__: *mut *mut C_tensor, data_: *mut C_tensor, batch_sizes_: *mut C_tensor, hx_data: *const *mut C_tensor, hx_len: c_int, params_data: *const *mut C_tensor, params_len: c_int, has_biases_: c_int, num_layers_: i64, dropout_: f64, train_: c_int, bidirectional_: c_int));
+pub_ffi!(fn atg_lstm_cell(out__: *mut *mut C_tensor, input_: *mut C_tensor, hx_data: *const *mut C_tensor, hx_len: c_int, w_ih_: *mut C_tensor, w_hh_: *mut C_tensor, b_ih_: *mut C_tensor, b_hh_: *mut C_tensor));
+pub_ffi!(fn atg_lstsq(out__: *mut *mut C_tensor, self_: *mut C_tensor, A_: *mut C_tensor));
+pub_ffi!(fn atg_lstsq_out(out__: *mut *mut C_tensor, X_: *mut C_tensor, qr_: *mut C_tensor, self_: *mut C_tensor, A_: *mut C_tensor));
+pub_ffi!(fn atg_lt(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_lt1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_lt_(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_lt_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_lt_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_lt_out1(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_lu_solve(out__: *mut *mut C_tensor, self_: *mut C_tensor, LU_data_: *mut C_tensor, LU_pivots_: *mut C_tensor));
+pub_ffi!(fn atg_lu_solve_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, LU_data_: *mut C_tensor, LU_pivots_: *mut C_tensor));
+pub_ffi!(fn atg_margin_ranking_loss(out__: *mut *mut C_tensor, input1_: *mut C_tensor, input2_: *mut C_tensor, target_: *mut C_tensor, margin_: f64, reduction_: i64));
+pub_ffi!(fn atg_masked_fill(out__: *mut *mut C_tensor, self_: *mut C_tensor, mask_: *mut C_tensor, value_: *mut C_scalar));
+pub_ffi!(fn atg_masked_fill1(out__: *mut *mut C_tensor, self_: *mut C_tensor, mask_: *mut C_tensor, value_: *mut C_tensor));
+pub_ffi!(fn atg_masked_fill_(out__: *mut *mut C_tensor, self_: *mut C_tensor, mask_: *mut C_tensor, value_: *mut C_scalar));
+pub_ffi!(fn atg_masked_fill_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, mask_: *mut C_tensor, value_: *mut C_tensor));
+pub_ffi!(fn atg_masked_scatter(out__: *mut *mut C_tensor, self_: *mut C_tensor, mask_: *mut C_tensor, source_: *mut C_tensor));
+pub_ffi!(fn atg_masked_scatter_(out__: *mut *mut C_tensor, self_: *mut C_tensor, mask_: *mut C_tensor, source_: *mut C_tensor));
+pub_ffi!(fn atg_masked_select(out__: *mut *mut C_tensor, self_: *mut C_tensor, mask_: *mut C_tensor));
+pub_ffi!(fn atg_masked_select_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, mask_: *mut C_tensor));
+pub_ffi!(fn atg_matmul(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_matmul_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_matrix_power(out__: *mut *mut C_tensor, self_: *mut C_tensor, n_: i64));
+pub_ffi!(fn atg_matrix_rank(out__: *mut *mut C_tensor, self_: *mut C_tensor, symmetric_: c_int));
+pub_ffi!(fn atg_matrix_rank1(out__: *mut *mut C_tensor, self_: *mut C_tensor, tol_: f64, symmetric_: c_int));
+pub_ffi!(fn atg_max(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_max1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_max2(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int));
+pub_ffi!(fn atg_max_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_max_out1(out__: *mut *mut C_tensor, max_: *mut C_tensor, max_values_: *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int));
+pub_ffi!(fn atg_max_pool1d(out__: *mut *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, dilation_data: *const i64, dilation_len: c_int, ceil_mode_: c_int));
+pub_ffi!(fn atg_max_pool1d_with_indices(out__: *mut *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, dilation_data: *const i64, dilation_len: c_int, ceil_mode_: c_int));
+pub_ffi!(fn atg_max_pool2d(out__: *mut *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, dilation_data: *const i64, dilation_len: c_int, ceil_mode_: c_int));
+pub_ffi!(fn atg_max_pool2d_with_indices(out__: *mut *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, dilation_data: *const i64, dilation_len: c_int, ceil_mode_: c_int));
+pub_ffi!(fn atg_max_pool2d_with_indices_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, dilation_data: *const i64, dilation_len: c_int, ceil_mode_: c_int, indices_: *mut C_tensor));
+pub_ffi!(fn atg_max_pool2d_with_indices_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, dilation_data: *const i64, dilation_len: c_int, ceil_mode_: c_int, indices_: *mut C_tensor));
+pub_ffi!(fn atg_max_pool2d_with_indices_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, indices_: *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, dilation_data: *const i64, dilation_len: c_int, ceil_mode_: c_int));
+pub_ffi!(fn atg_max_pool3d(out__: *mut *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, dilation_data: *const i64, dilation_len: c_int, ceil_mode_: c_int));
+pub_ffi!(fn atg_max_pool3d_with_indices(out__: *mut *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, dilation_data: *const i64, dilation_len: c_int, ceil_mode_: c_int));
+pub_ffi!(fn atg_max_pool3d_with_indices_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, dilation_data: *const i64, dilation_len: c_int, ceil_mode_: c_int, indices_: *mut C_tensor));
+pub_ffi!(fn atg_max_pool3d_with_indices_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, dilation_data: *const i64, dilation_len: c_int, ceil_mode_: c_int, indices_: *mut C_tensor));
+pub_ffi!(fn atg_max_pool3d_with_indices_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, indices_: *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, dilation_data: *const i64, dilation_len: c_int, ceil_mode_: c_int));
+pub_ffi!(fn atg_max_unpool2d(out__: *mut *mut C_tensor, self_: *mut C_tensor, indices_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int));
+pub_ffi!(fn atg_max_unpool2d_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, indices_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int));
+pub_ffi!(fn atg_max_unpool2d_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, indices_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int));
+pub_ffi!(fn atg_max_unpool2d_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, indices_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int));
+pub_ffi!(fn atg_max_unpool3d(out__: *mut *mut C_tensor, self_: *mut C_tensor, indices_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int));
+pub_ffi!(fn atg_max_unpool3d_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, indices_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int));
+pub_ffi!(fn atg_max_unpool3d_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, indices_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int));
+pub_ffi!(fn atg_max_unpool3d_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, indices_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int));
+pub_ffi!(fn atg_max_values(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_data: *const i64, dim_len: c_int, keepdim_: c_int));
+pub_ffi!(fn atg_mean(out__: *mut *mut C_tensor, self_: *mut C_tensor, dtype_: c_int));
+pub_ffi!(fn atg_mean1(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_data: *const i64, dim_len: c_int, keepdim_: c_int, dtype_: c_int));
+pub_ffi!(fn atg_mean_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, dim_data: *const i64, dim_len: c_int, keepdim_: c_int, dtype_: c_int));
+pub_ffi!(fn atg_median(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_median1(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int));
+pub_ffi!(fn atg_median_out(out__: *mut *mut C_tensor, values_: *mut C_tensor, indices_: *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int));
+pub_ffi!(fn atg_meshgrid(tensors_data: *const *mut C_tensor, tensors_len: c_int) -> *mut *mut C_tensor);
+pub_ffi!(fn atg_min(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_min1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_min2(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int));
+pub_ffi!(fn atg_min_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_min_out1(out__: *mut *mut C_tensor, min_: *mut C_tensor, min_indices_: *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int));
+pub_ffi!(fn atg_min_values(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_data: *const i64, dim_len: c_int, keepdim_: c_int));
+pub_ffi!(fn atg_miopen_batch_norm(out__: *mut *mut C_tensor, input_: *mut C_tensor, weight_: *mut C_tensor, bias_: *mut C_tensor, running_mean_: *mut C_tensor, running_var_: *mut C_tensor, training_: c_int, exponential_average_factor_: f64, epsilon_: f64));
+pub_ffi!(fn atg_miopen_batch_norm_backward(out__: *mut *mut C_tensor, input_: *mut C_tensor, grad_output_: *mut C_tensor, weight_: *mut C_tensor, running_mean_: *mut C_tensor, running_var_: *mut C_tensor, save_mean_: *mut C_tensor, save_var_: *mut C_tensor, epsilon_: f64));
+pub_ffi!(fn atg_miopen_convolution(out__: *mut *mut C_tensor, self_: *mut C_tensor, weight_: *mut C_tensor, bias_: *mut C_tensor, padding_data: *const i64, padding_len: c_int, stride_data: *const i64, stride_len: c_int, dilation_data: *const i64, dilation_len: c_int, groups_: i64, benchmark_: c_int, deterministic_: c_int));
+pub_ffi!(fn atg_miopen_convolution_backward_bias(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor));
+pub_ffi!(fn atg_miopen_convolution_backward_input(out__: *mut *mut C_tensor, self_size_data: *const i64, self_size_len: c_int, grad_output_: *mut C_tensor, weight_: *mut C_tensor, padding_data: *const i64, padding_len: c_int, stride_data: *const i64, stride_len: c_int, dilation_data: *const i64, dilation_len: c_int, groups_: i64, benchmark_: c_int, deterministic_: c_int));
+pub_ffi!(fn atg_miopen_convolution_backward_weight(out__: *mut *mut C_tensor, weight_size_data: *const i64, weight_size_len: c_int, grad_output_: *mut C_tensor, self_: *mut C_tensor, padding_data: *const i64, padding_len: c_int, stride_data: *const i64, stride_len: c_int, dilation_data: *const i64, dilation_len: c_int, groups_: i64, benchmark_: c_int, deterministic_: c_int));
+pub_ffi!(fn atg_miopen_convolution_transpose(out__: *mut *mut C_tensor, self_: *mut C_tensor, weight_: *mut C_tensor, bias_: *mut C_tensor, padding_data: *const i64, padding_len: c_int, output_padding_data: *const i64, output_padding_len: c_int, stride_data: *const i64, stride_len: c_int, dilation_data: *const i64, dilation_len: c_int, groups_: i64, benchmark_: c_int, deterministic_: c_int));
+pub_ffi!(fn atg_miopen_convolution_transpose_backward_input(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, weight_: *mut C_tensor, padding_data: *const i64, padding_len: c_int, stride_data: *const i64, stride_len: c_int, dilation_data: *const i64, dilation_len: c_int, groups_: i64, benchmark_: c_int, deterministic_: c_int));
+pub_ffi!(fn atg_miopen_convolution_transpose_backward_weight(out__: *mut *mut C_tensor, weight_size_data: *const i64, weight_size_len: c_int, grad_output_: *mut C_tensor, self_: *mut C_tensor, padding_data: *const i64, padding_len: c_int, stride_data: *const i64, stride_len: c_int, dilation_data: *const i64, dilation_len: c_int, groups_: i64, benchmark_: c_int, deterministic_: c_int));
+pub_ffi!(fn atg_miopen_depthwise_convolution(out__: *mut *mut C_tensor, self_: *mut C_tensor, weight_: *mut C_tensor, bias_: *mut C_tensor, padding_data: *const i64, padding_len: c_int, stride_data: *const i64, stride_len: c_int, dilation_data: *const i64, dilation_len: c_int, groups_: i64, benchmark_: c_int, deterministic_: c_int));
+pub_ffi!(fn atg_miopen_depthwise_convolution_backward_input(out__: *mut *mut C_tensor, self_size_data: *const i64, self_size_len: c_int, grad_output_: *mut C_tensor, weight_: *mut C_tensor, padding_data: *const i64, padding_len: c_int, stride_data: *const i64, stride_len: c_int, dilation_data: *const i64, dilation_len: c_int, groups_: i64, benchmark_: c_int, deterministic_: c_int));
+pub_ffi!(fn atg_miopen_depthwise_convolution_backward_weight(out__: *mut *mut C_tensor, weight_size_data: *const i64, weight_size_len: c_int, grad_output_: *mut C_tensor, self_: *mut C_tensor, padding_data: *const i64, padding_len: c_int, stride_data: *const i64, stride_len: c_int, dilation_data: *const i64, dilation_len: c_int, groups_: i64, benchmark_: c_int, deterministic_: c_int));
+pub_ffi!(fn atg_miopen_rnn(out__: *mut *mut C_tensor, input_: *mut C_tensor, weight_data: *const *mut C_tensor, weight_len: c_int, weight_stride0_: i64, hx_: *mut C_tensor, cx_: *mut C_tensor, mode_: i64, hidden_size_: i64, num_layers_: i64, batch_first_: c_int, dropout_: f64, train_: c_int, bidirectional_: c_int, batch_sizes_data: *const i64, batch_sizes_len: c_int, dropout_state_: *mut C_tensor));
+pub_ffi!(fn atg_mkldnn_adaptive_avg_pool2d(out__: *mut *mut C_tensor, self_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int));
+pub_ffi!(fn atg_mkldnn_convolution(out__: *mut *mut C_tensor, self_: *mut C_tensor, weight_: *mut C_tensor, bias_: *mut C_tensor, padding_data: *const i64, padding_len: c_int, stride_data: *const i64, stride_len: c_int, dilation_data: *const i64, dilation_len: c_int, groups_: i64));
+pub_ffi!(fn atg_mkldnn_convolution_backward_input(out__: *mut *mut C_tensor, self_size_data: *const i64, self_size_len: c_int, grad_output_: *mut C_tensor, weight_: *mut C_tensor, padding_data: *const i64, padding_len: c_int, stride_data: *const i64, stride_len: c_int, dilation_data: *const i64, dilation_len: c_int, groups_: i64, bias_defined_: c_int));
+pub_ffi!(fn atg_mkldnn_convolution_backward_weights(out__: *mut *mut C_tensor, weight_size_data: *const i64, weight_size_len: c_int, grad_output_: *mut C_tensor, self_: *mut C_tensor, padding_data: *const i64, padding_len: c_int, stride_data: *const i64, stride_len: c_int, dilation_data: *const i64, dilation_len: c_int, groups_: i64, bias_defined_: c_int));
+pub_ffi!(fn atg_mkldnn_linear(out__: *mut *mut C_tensor, input_: *mut C_tensor, weight_: *mut C_tensor, bias_: *mut C_tensor));
+pub_ffi!(fn atg_mkldnn_max_pool2d(out__: *mut *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, dilation_data: *const i64, dilation_len: c_int, ceil_mode_: c_int));
+pub_ffi!(fn atg_mkldnn_reorder_conv2d_weight(out__: *mut *mut C_tensor, self_: *mut C_tensor, padding_data: *const i64, padding_len: c_int, stride_data: *const i64, stride_len: c_int, dilation_data: *const i64, dilation_len: c_int, groups_: i64));
+pub_ffi!(fn atg_mm(out__: *mut *mut C_tensor, self_: *mut C_tensor, mat2_: *mut C_tensor));
+pub_ffi!(fn atg_mm_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, mat2_: *mut C_tensor));
+pub_ffi!(fn atg_mode(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int));
+pub_ffi!(fn atg_mode_out(out__: *mut *mut C_tensor, values_: *mut C_tensor, indices_: *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int));
+pub_ffi!(fn atg_mse_loss(out__: *mut *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, reduction_: i64));
+pub_ffi!(fn atg_mse_loss_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, reduction_: i64));
+pub_ffi!(fn atg_mse_loss_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, reduction_: i64));
+pub_ffi!(fn atg_mse_loss_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, reduction_: i64));
+pub_ffi!(fn atg_mul(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_mul1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_mul_(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_mul_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_mul_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_multi_margin_loss_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, p_: *mut C_scalar, margin_: *mut C_scalar, weight_: *mut C_tensor, reduction_: i64));
+pub_ffi!(fn atg_multi_margin_loss_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, p_: *mut C_scalar, margin_: *mut C_scalar, weight_: *mut C_tensor, reduction_: i64));
+pub_ffi!(fn atg_multilabel_margin_loss(out__: *mut *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, reduction_: i64));
+pub_ffi!(fn atg_multilabel_margin_loss_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, reduction_: i64, is_target_: *mut C_tensor));
+pub_ffi!(fn atg_multilabel_margin_loss_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, reduction_: i64, is_target_: *mut C_tensor));
+pub_ffi!(fn atg_multilabel_margin_loss_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, reduction_: i64));
+pub_ffi!(fn atg_multinomial(out__: *mut *mut C_tensor, self_: *mut C_tensor, num_samples_: i64, replacement_: c_int));
+pub_ffi!(fn atg_multinomial_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, num_samples_: i64, replacement_: c_int));
+pub_ffi!(fn atg_mv(out__: *mut *mut C_tensor, self_: *mut C_tensor, vec_: *mut C_tensor));
+pub_ffi!(fn atg_mv_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, vec_: *mut C_tensor));
+pub_ffi!(fn atg_mvlgamma(out__: *mut *mut C_tensor, self_: *mut C_tensor, p_: i64));
+pub_ffi!(fn atg_mvlgamma_(out__: *mut *mut C_tensor, self_: *mut C_tensor, p_: i64));
+pub_ffi!(fn atg_narrow(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, start_: i64, length_: i64));
+pub_ffi!(fn atg_narrow_copy(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, start_: i64, length_: i64));
+pub_ffi!(fn atg_native_batch_norm(out__: *mut *mut C_tensor, input_: *mut C_tensor, weight_: *mut C_tensor, bias_: *mut C_tensor, running_mean_: *mut C_tensor, running_var_: *mut C_tensor, training_: c_int, momentum_: f64, eps_: f64));
+pub_ffi!(fn atg_native_layer_norm(out__: *mut *mut C_tensor, input_: *mut C_tensor, weight_: *mut C_tensor, bias_: *mut C_tensor, M_: i64, n_: i64, eps_: f64));
+pub_ffi!(fn atg_native_norm(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_ne(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_ne1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_ne_(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_ne_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_ne_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_ne_out1(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_neg(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_neg_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_neg_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_new_empty(out__: *mut *mut C_tensor, self_: *mut C_tensor, size_data: *const i64, size_len: c_int, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_new_full(out__: *mut *mut C_tensor, self_: *mut C_tensor, size_data: *const i64, size_len: c_int, fill_value_: *mut C_scalar, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_new_zeros(out__: *mut *mut C_tensor, self_: *mut C_tensor, size_data: *const i64, size_len: c_int, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_nll_loss(out__: *mut *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, weight_: *mut C_tensor, reduction_: i64, ignore_index_: i64));
+pub_ffi!(fn atg_nll_loss2d(out__: *mut *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, weight_: *mut C_tensor, reduction_: i64, ignore_index_: i64));
+pub_ffi!(fn atg_nll_loss2d_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, weight_: *mut C_tensor, reduction_: i64, ignore_index_: i64, total_weight_: *mut C_tensor));
+pub_ffi!(fn atg_nll_loss2d_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, weight_: *mut C_tensor, reduction_: i64, ignore_index_: i64, total_weight_: *mut C_tensor));
+pub_ffi!(fn atg_nll_loss2d_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, weight_: *mut C_tensor, reduction_: i64, ignore_index_: i64));
+pub_ffi!(fn atg_nll_loss_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, weight_: *mut C_tensor, reduction_: i64, ignore_index_: i64, total_weight_: *mut C_tensor));
+pub_ffi!(fn atg_nll_loss_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, weight_: *mut C_tensor, reduction_: i64, ignore_index_: i64, total_weight_: *mut C_tensor));
+pub_ffi!(fn atg_nll_loss_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, weight_: *mut C_tensor, reduction_: i64, ignore_index_: i64));
+pub_ffi!(fn atg_nonzero(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_nonzero_numpy(self_: *mut C_tensor) -> *mut *mut C_tensor);
+pub_ffi!(fn atg_nonzero_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_norm(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_norm1(out__: *mut *mut C_tensor, self_: *mut C_tensor, p_: *mut C_scalar, dtype_: c_int));
+pub_ffi!(fn atg_norm2(out__: *mut *mut C_tensor, self_: *mut C_tensor, p_: *mut C_scalar, dim_data: *const i64, dim_len: c_int, keepdim_: c_int));
+pub_ffi!(fn atg_norm3(out__: *mut *mut C_tensor, self_: *mut C_tensor, p_: *mut C_scalar, dim_data: *const i64, dim_len: c_int, keepdim_: c_int, dtype_: c_int));
+pub_ffi!(fn atg_norm_except_dim(out__: *mut *mut C_tensor, v_: *mut C_tensor, pow_: i64, dim_: i64));
+pub_ffi!(fn atg_norm_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, p_: *mut C_scalar, dim_data: *const i64, dim_len: c_int, keepdim_: c_int));
+pub_ffi!(fn atg_norm_out1(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, p_: *mut C_scalar, dim_data: *const i64, dim_len: c_int, keepdim_: c_int, dtype_: c_int));
+pub_ffi!(fn atg_normal_(out__: *mut *mut C_tensor, self_: *mut C_tensor, mean_: f64, std_: f64));
+pub_ffi!(fn atg_normal_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, mean_: *mut C_tensor, std_: f64));
+pub_ffi!(fn atg_normal_out1(out__: *mut *mut C_tensor, out_: *mut C_tensor, mean_: f64, std_: *mut C_tensor));
+pub_ffi!(fn atg_normal_out2(out__: *mut *mut C_tensor, out_: *mut C_tensor, mean_: *mut C_tensor, std_: *mut C_tensor));
+pub_ffi!(fn atg_normal_out3(out__: *mut *mut C_tensor, out_: *mut C_tensor, mean_: f64, std_: f64, size_data: *const i64, size_len: c_int));
+pub_ffi!(fn atg_nuclear_norm(out__: *mut *mut C_tensor, self_: *mut C_tensor, keepdim_: c_int));
+pub_ffi!(fn atg_nuclear_norm1(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_data: *const i64, dim_len: c_int, keepdim_: c_int));
+pub_ffi!(fn atg_nuclear_norm_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, keepdim_: c_int));
+pub_ffi!(fn atg_nuclear_norm_out1(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, dim_data: *const i64, dim_len: c_int, keepdim_: c_int));
+pub_ffi!(fn atg_numpy_t(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_one_hot(out__: *mut *mut C_tensor, self_: *mut C_tensor, num_classes_: i64));
+pub_ffi!(fn atg_ones(out__: *mut *mut C_tensor, size_data: *const i64, size_len: c_int, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_ones_like(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_ones_like1(out__: *mut *mut C_tensor, self_: *mut C_tensor, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_ones_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, size_data: *const i64, size_len: c_int));
+pub_ffi!(fn atg_orgqr(out__: *mut *mut C_tensor, self_: *mut C_tensor, input2_: *mut C_tensor));
+pub_ffi!(fn atg_orgqr_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, input2_: *mut C_tensor));
+pub_ffi!(fn atg_ormqr(out__: *mut *mut C_tensor, self_: *mut C_tensor, input2_: *mut C_tensor, input3_: *mut C_tensor, left_: c_int, transpose_: c_int));
+pub_ffi!(fn atg_ormqr_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, input2_: *mut C_tensor, input3_: *mut C_tensor, left_: c_int, transpose_: c_int));
+pub_ffi!(fn atg_pairwise_distance(out__: *mut *mut C_tensor, x1_: *mut C_tensor, x2_: *mut C_tensor, p_: f64, eps_: f64, keepdim_: c_int));
+pub_ffi!(fn atg_pdist(out__: *mut *mut C_tensor, self_: *mut C_tensor, p_: f64));
+pub_ffi!(fn atg_permute(out__: *mut *mut C_tensor, self_: *mut C_tensor, dims_data: *const i64, dims_len: c_int));
+pub_ffi!(fn atg_pin_memory(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_pinverse(out__: *mut *mut C_tensor, self_: *mut C_tensor, rcond_: f64));
+pub_ffi!(fn atg_pixel_shuffle(out__: *mut *mut C_tensor, self_: *mut C_tensor, upscale_factor_: i64));
+pub_ffi!(fn atg_poisson(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_poisson_nll_loss(out__: *mut *mut C_tensor, input_: *mut C_tensor, target_: *mut C_tensor, log_input_: c_int, full_: c_int, eps_: f64, reduction_: i64));
+pub_ffi!(fn atg_polygamma(out__: *mut *mut C_tensor, n_: i64, self_: *mut C_tensor));
+pub_ffi!(fn atg_polygamma_(out__: *mut *mut C_tensor, self_: *mut C_tensor, n_: i64));
+pub_ffi!(fn atg_polygamma_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, n_: i64, self_: *mut C_tensor));
+pub_ffi!(fn atg_pow(out__: *mut *mut C_tensor, self_: *mut C_tensor, exponent_: *mut C_scalar));
+pub_ffi!(fn atg_pow1(out__: *mut *mut C_tensor, self_: *mut C_tensor, exponent_: *mut C_tensor));
+pub_ffi!(fn atg_pow2(out__: *mut *mut C_tensor, self_scalar_: *mut C_scalar, exponent_: *mut C_tensor));
+pub_ffi!(fn atg_pow_(out__: *mut *mut C_tensor, self_: *mut C_tensor, exponent_: *mut C_scalar));
+pub_ffi!(fn atg_pow_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, exponent_: *mut C_tensor));
+pub_ffi!(fn atg_pow_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, exponent_: *mut C_scalar));
+pub_ffi!(fn atg_pow_out1(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, exponent_: *mut C_tensor));
+pub_ffi!(fn atg_pow_out2(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_scalar_: *mut C_scalar, exponent_: *mut C_tensor));
+pub_ffi!(fn atg_prelu(out__: *mut *mut C_tensor, self_: *mut C_tensor, weight_: *mut C_tensor));
+pub_ffi!(fn atg_prelu_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, weight_: *mut C_tensor));
+pub_ffi!(fn atg_prod(out__: *mut *mut C_tensor, self_: *mut C_tensor, dtype_: c_int));
+pub_ffi!(fn atg_prod1(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int, dtype_: c_int));
+pub_ffi!(fn atg_prod_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, dim_: i64, keepdim_: c_int, dtype_: c_int));
+pub_ffi!(fn atg_put_(out__: *mut *mut C_tensor, self_: *mut C_tensor, index_: *mut C_tensor, source_: *mut C_tensor, accumulate_: c_int));
+pub_ffi!(fn atg_q_per_channel_scales(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_q_per_channel_zero_points(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_qr(out__: *mut *mut C_tensor, self_: *mut C_tensor, some_: c_int));
+pub_ffi!(fn atg_qr_out(out__: *mut *mut C_tensor, Q_: *mut C_tensor, R_: *mut C_tensor, self_: *mut C_tensor, some_: c_int));
+pub_ffi!(fn atg_quantize_per_channel(out__: *mut *mut C_tensor, self_: *mut C_tensor, scales_: *mut C_tensor, zero_points_: *mut C_tensor, axis_: i64, dtype_: c_int));
+pub_ffi!(fn atg_quantize_per_tensor(out__: *mut *mut C_tensor, self_: *mut C_tensor, scale_: f64, zero_point_: i64, dtype_: c_int));
+pub_ffi!(fn atg_quantized_gru(out__: *mut *mut C_tensor, input_: *mut C_tensor, hx_: *mut C_tensor, params_data: *const *mut C_tensor, params_len: c_int, has_biases_: c_int, num_layers_: i64, dropout_: f64, train_: c_int, bidirectional_: c_int, batch_first_: c_int));
+pub_ffi!(fn atg_quantized_gru1(out__: *mut *mut C_tensor, data_: *mut C_tensor, batch_sizes_: *mut C_tensor, hx_: *mut C_tensor, params_data: *const *mut C_tensor, params_len: c_int, has_biases_: c_int, num_layers_: i64, dropout_: f64, train_: c_int, bidirectional_: c_int));
+pub_ffi!(fn atg_quantized_gru_cell(out__: *mut *mut C_tensor, input_: *mut C_tensor, hx_: *mut C_tensor, w_ih_: *mut C_tensor, w_hh_: *mut C_tensor, b_ih_: *mut C_tensor, b_hh_: *mut C_tensor, packed_ih_: *mut C_tensor, packed_hh_: *mut C_tensor, col_offsets_ih_: *mut C_tensor, col_offsets_hh_: *mut C_tensor, scale_ih_: *mut C_scalar, scale_hh_: *mut C_scalar, zero_point_ih_: *mut C_scalar, zero_point_hh_: *mut C_scalar));
+pub_ffi!(fn atg_quantized_lstm(out__: *mut *mut C_tensor, input_: *mut C_tensor, hx_data: *const *mut C_tensor, hx_len: c_int, params_data: *const *mut C_tensor, params_len: c_int, has_biases_: c_int, num_layers_: i64, dropout_: f64, train_: c_int, bidirectional_: c_int, batch_first_: c_int, dtype_: c_int, use_dynamic_: c_int));
+pub_ffi!(fn atg_quantized_lstm1(out__: *mut *mut C_tensor, data_: *mut C_tensor, batch_sizes_: *mut C_tensor, hx_data: *const *mut C_tensor, hx_len: c_int, params_data: *const *mut C_tensor, params_len: c_int, has_biases_: c_int, num_layers_: i64, dropout_: f64, train_: c_int, bidirectional_: c_int, dtype_: c_int, use_dynamic_: c_int));
+pub_ffi!(fn atg_quantized_lstm_cell(out__: *mut *mut C_tensor, input_: *mut C_tensor, hx_data: *const *mut C_tensor, hx_len: c_int, w_ih_: *mut C_tensor, w_hh_: *mut C_tensor, b_ih_: *mut C_tensor, b_hh_: *mut C_tensor, packed_ih_: *mut C_tensor, packed_hh_: *mut C_tensor, col_offsets_ih_: *mut C_tensor, col_offsets_hh_: *mut C_tensor, scale_ih_: *mut C_scalar, scale_hh_: *mut C_scalar, zero_point_ih_: *mut C_scalar, zero_point_hh_: *mut C_scalar));
+pub_ffi!(fn atg_quantized_max_pool2d(out__: *mut *mut C_tensor, self_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, dilation_data: *const i64, dilation_len: c_int, ceil_mode_: c_int));
+pub_ffi!(fn atg_quantized_rnn_relu_cell(out__: *mut *mut C_tensor, input_: *mut C_tensor, hx_: *mut C_tensor, w_ih_: *mut C_tensor, w_hh_: *mut C_tensor, b_ih_: *mut C_tensor, b_hh_: *mut C_tensor, packed_ih_: *mut C_tensor, packed_hh_: *mut C_tensor, col_offsets_ih_: *mut C_tensor, col_offsets_hh_: *mut C_tensor, scale_ih_: *mut C_scalar, scale_hh_: *mut C_scalar, zero_point_ih_: *mut C_scalar, zero_point_hh_: *mut C_scalar));
+pub_ffi!(fn atg_quantized_rnn_tanh_cell(out__: *mut *mut C_tensor, input_: *mut C_tensor, hx_: *mut C_tensor, w_ih_: *mut C_tensor, w_hh_: *mut C_tensor, b_ih_: *mut C_tensor, b_hh_: *mut C_tensor, packed_ih_: *mut C_tensor, packed_hh_: *mut C_tensor, col_offsets_ih_: *mut C_tensor, col_offsets_hh_: *mut C_tensor, scale_ih_: *mut C_scalar, scale_hh_: *mut C_scalar, zero_point_ih_: *mut C_scalar, zero_point_hh_: *mut C_scalar));
+pub_ffi!(fn atg_rand(out__: *mut *mut C_tensor, size_data: *const i64, size_len: c_int, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_rand_like(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_rand_like1(out__: *mut *mut C_tensor, self_: *mut C_tensor, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_rand_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, size_data: *const i64, size_len: c_int));
+pub_ffi!(fn atg_randint(out__: *mut *mut C_tensor, high_: i64, size_data: *const i64, size_len: c_int, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_randint1(out__: *mut *mut C_tensor, low_: i64, high_: i64, size_data: *const i64, size_len: c_int, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_randint_like(out__: *mut *mut C_tensor, self_: *mut C_tensor, high_: i64));
+pub_ffi!(fn atg_randint_like1(out__: *mut *mut C_tensor, self_: *mut C_tensor, low_: i64, high_: i64));
+pub_ffi!(fn atg_randint_like2(out__: *mut *mut C_tensor, self_: *mut C_tensor, high_: i64, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_randint_like3(out__: *mut *mut C_tensor, self_: *mut C_tensor, low_: i64, high_: i64, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_randint_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, high_: i64, size_data: *const i64, size_len: c_int));
+pub_ffi!(fn atg_randint_out1(out__: *mut *mut C_tensor, out_: *mut C_tensor, low_: i64, high_: i64, size_data: *const i64, size_len: c_int));
+pub_ffi!(fn atg_randn(out__: *mut *mut C_tensor, size_data: *const i64, size_len: c_int, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_randn_like(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_randn_like1(out__: *mut *mut C_tensor, self_: *mut C_tensor, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_randn_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, size_data: *const i64, size_len: c_int));
+pub_ffi!(fn atg_random_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_random_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, to_: i64));
+pub_ffi!(fn atg_random_2(out__: *mut *mut C_tensor, self_: *mut C_tensor, from_: i64, to_: i64));
+pub_ffi!(fn atg_randperm(out__: *mut *mut C_tensor, n_: i64, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_randperm_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, n_: i64));
+pub_ffi!(fn atg_range(out__: *mut *mut C_tensor, start_: *mut C_scalar, end_: *mut C_scalar, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_range1(out__: *mut *mut C_tensor, start_: *mut C_scalar, end_: *mut C_scalar, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_range_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, start_: *mut C_scalar, end_: *mut C_scalar));
+pub_ffi!(fn atg_real(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_real_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_reciprocal(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_reciprocal_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_reciprocal_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_reflection_pad1d(out__: *mut *mut C_tensor, self_: *mut C_tensor, padding_data: *const i64, padding_len: c_int));
+pub_ffi!(fn atg_reflection_pad1d_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, padding_data: *const i64, padding_len: c_int));
+pub_ffi!(fn atg_reflection_pad1d_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, padding_data: *const i64, padding_len: c_int));
+pub_ffi!(fn atg_reflection_pad1d_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, padding_data: *const i64, padding_len: c_int));
+pub_ffi!(fn atg_reflection_pad2d(out__: *mut *mut C_tensor, self_: *mut C_tensor, padding_data: *const i64, padding_len: c_int));
+pub_ffi!(fn atg_reflection_pad2d_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, padding_data: *const i64, padding_len: c_int));
+pub_ffi!(fn atg_reflection_pad2d_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, padding_data: *const i64, padding_len: c_int));
+pub_ffi!(fn atg_reflection_pad2d_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, padding_data: *const i64, padding_len: c_int));
+pub_ffi!(fn atg_relu(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_relu_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_remainder(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_remainder1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_remainder_(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_remainder_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_remainder_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_remainder_out1(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_renorm(out__: *mut *mut C_tensor, self_: *mut C_tensor, p_: *mut C_scalar, dim_: i64, maxnorm_: *mut C_scalar));
+pub_ffi!(fn atg_renorm_(out__: *mut *mut C_tensor, self_: *mut C_tensor, p_: *mut C_scalar, dim_: i64, maxnorm_: *mut C_scalar));
+pub_ffi!(fn atg_renorm_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, p_: *mut C_scalar, dim_: i64, maxnorm_: *mut C_scalar));
+pub_ffi!(fn atg_repeat(out__: *mut *mut C_tensor, self_: *mut C_tensor, repeats_data: *const i64, repeats_len: c_int));
+pub_ffi!(fn atg_repeat_interleave(out__: *mut *mut C_tensor, repeats_: *mut C_tensor));
+pub_ffi!(fn atg_repeat_interleave1(out__: *mut *mut C_tensor, self_: *mut C_tensor, repeats_: *mut C_tensor, dim_: i64));
+pub_ffi!(fn atg_repeat_interleave2(out__: *mut *mut C_tensor, self_: *mut C_tensor, repeats_: i64, dim_: i64));
+pub_ffi!(fn atg_replication_pad1d(out__: *mut *mut C_tensor, self_: *mut C_tensor, padding_data: *const i64, padding_len: c_int));
+pub_ffi!(fn atg_replication_pad1d_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, padding_data: *const i64, padding_len: c_int));
+pub_ffi!(fn atg_replication_pad1d_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, padding_data: *const i64, padding_len: c_int));
+pub_ffi!(fn atg_replication_pad1d_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, padding_data: *const i64, padding_len: c_int));
+pub_ffi!(fn atg_replication_pad2d(out__: *mut *mut C_tensor, self_: *mut C_tensor, padding_data: *const i64, padding_len: c_int));
+pub_ffi!(fn atg_replication_pad2d_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, padding_data: *const i64, padding_len: c_int));
+pub_ffi!(fn atg_replication_pad2d_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, padding_data: *const i64, padding_len: c_int));
+pub_ffi!(fn atg_replication_pad2d_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, padding_data: *const i64, padding_len: c_int));
+pub_ffi!(fn atg_replication_pad3d(out__: *mut *mut C_tensor, self_: *mut C_tensor, padding_data: *const i64, padding_len: c_int));
+pub_ffi!(fn atg_replication_pad3d_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, padding_data: *const i64, padding_len: c_int));
+pub_ffi!(fn atg_replication_pad3d_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, padding_data: *const i64, padding_len: c_int));
+pub_ffi!(fn atg_replication_pad3d_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, padding_data: *const i64, padding_len: c_int));
+pub_ffi!(fn atg_requires_grad_(out__: *mut *mut C_tensor, self_: *mut C_tensor, _requires_grad_: c_int));
+pub_ffi!(fn atg_reshape(out__: *mut *mut C_tensor, self_: *mut C_tensor, shape_data: *const i64, shape_len: c_int));
+pub_ffi!(fn atg_reshape_as(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_resize_(out__: *mut *mut C_tensor, self_: *mut C_tensor, size_data: *const i64, size_len: c_int));
+pub_ffi!(fn atg_resize_as_(out__: *mut *mut C_tensor, self_: *mut C_tensor, the_template_: *mut C_tensor));
+pub_ffi!(fn atg_rfft(out__: *mut *mut C_tensor, self_: *mut C_tensor, signal_ndim_: i64, normalized_: c_int, onesided_: c_int));
+pub_ffi!(fn atg_rnn_relu(out__: *mut *mut C_tensor, input_: *mut C_tensor, hx_: *mut C_tensor, params_data: *const *mut C_tensor, params_len: c_int, has_biases_: c_int, num_layers_: i64, dropout_: f64, train_: c_int, bidirectional_: c_int, batch_first_: c_int));
+pub_ffi!(fn atg_rnn_relu1(out__: *mut *mut C_tensor, data_: *mut C_tensor, batch_sizes_: *mut C_tensor, hx_: *mut C_tensor, params_data: *const *mut C_tensor, params_len: c_int, has_biases_: c_int, num_layers_: i64, dropout_: f64, train_: c_int, bidirectional_: c_int));
+pub_ffi!(fn atg_rnn_relu_cell(out__: *mut *mut C_tensor, input_: *mut C_tensor, hx_: *mut C_tensor, w_ih_: *mut C_tensor, w_hh_: *mut C_tensor, b_ih_: *mut C_tensor, b_hh_: *mut C_tensor));
+pub_ffi!(fn atg_rnn_tanh(out__: *mut *mut C_tensor, input_: *mut C_tensor, hx_: *mut C_tensor, params_data: *const *mut C_tensor, params_len: c_int, has_biases_: c_int, num_layers_: i64, dropout_: f64, train_: c_int, bidirectional_: c_int, batch_first_: c_int));
+pub_ffi!(fn atg_rnn_tanh1(out__: *mut *mut C_tensor, data_: *mut C_tensor, batch_sizes_: *mut C_tensor, hx_: *mut C_tensor, params_data: *const *mut C_tensor, params_len: c_int, has_biases_: c_int, num_layers_: i64, dropout_: f64, train_: c_int, bidirectional_: c_int));
+pub_ffi!(fn atg_rnn_tanh_cell(out__: *mut *mut C_tensor, input_: *mut C_tensor, hx_: *mut C_tensor, w_ih_: *mut C_tensor, w_hh_: *mut C_tensor, b_ih_: *mut C_tensor, b_hh_: *mut C_tensor));
+pub_ffi!(fn atg_roll(out__: *mut *mut C_tensor, self_: *mut C_tensor, shifts_data: *const i64, shifts_len: c_int, dims_data: *const i64, dims_len: c_int));
+pub_ffi!(fn atg_rot90(out__: *mut *mut C_tensor, self_: *mut C_tensor, k_: i64, dims_data: *const i64, dims_len: c_int));
+pub_ffi!(fn atg_round(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_round_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_round_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_rrelu(out__: *mut *mut C_tensor, self_: *mut C_tensor, training_: c_int));
+pub_ffi!(fn atg_rrelu_(out__: *mut *mut C_tensor, self_: *mut C_tensor, training_: c_int));
+pub_ffi!(fn atg_rrelu_with_noise(out__: *mut *mut C_tensor, self_: *mut C_tensor, noise_: *mut C_tensor, training_: c_int));
+pub_ffi!(fn atg_rrelu_with_noise_(out__: *mut *mut C_tensor, self_: *mut C_tensor, noise_: *mut C_tensor, training_: c_int));
+pub_ffi!(fn atg_rrelu_with_noise_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, noise_: *mut C_tensor, lower_: *mut C_scalar, upper_: *mut C_scalar, training_: c_int));
+pub_ffi!(fn atg_rrelu_with_noise_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, noise_: *mut C_tensor, lower_: *mut C_scalar, upper_: *mut C_scalar, training_: c_int));
+pub_ffi!(fn atg_rrelu_with_noise_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, noise_: *mut C_tensor, training_: c_int));
+pub_ffi!(fn atg_rsqrt(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_rsqrt_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_rsqrt_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_rsub(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_rsub1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_scalar_tensor(out__: *mut *mut C_tensor, s_: *mut C_scalar, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_scatter(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, index_: *mut C_tensor, src_: *mut C_tensor));
+pub_ffi!(fn atg_scatter1(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, index_: *mut C_tensor, value_: *mut C_scalar));
+pub_ffi!(fn atg_scatter_(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, index_: *mut C_tensor, src_: *mut C_tensor));
+pub_ffi!(fn atg_scatter_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, index_: *mut C_tensor, value_: *mut C_scalar));
+pub_ffi!(fn atg_scatter_add(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, index_: *mut C_tensor, src_: *mut C_tensor));
+pub_ffi!(fn atg_scatter_add_(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, index_: *mut C_tensor, src_: *mut C_tensor));
+pub_ffi!(fn atg_select(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, index_: i64));
+pub_ffi!(fn atg_selu(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_selu_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_set_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_set_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, source_: *mut C_tensor));
+pub_ffi!(fn atg_set_requires_grad(out__: *mut *mut C_tensor, self_: *mut C_tensor, r_: c_int));
+pub_ffi!(fn atg_sigmoid(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_sigmoid_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_sigmoid_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, output_: *mut C_tensor));
+pub_ffi!(fn atg_sigmoid_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, output_: *mut C_tensor));
+pub_ffi!(fn atg_sigmoid_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_sign(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_sign_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_sign_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_sin(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_sin_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_sin_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_sinh(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_sinh_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_sinh_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_slice(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, start_: i64, end_: i64, step_: i64));
+pub_ffi!(fn atg_slogdet(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_slow_conv3d(out__: *mut *mut C_tensor, self_: *mut C_tensor, weight_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, bias_: *mut C_tensor, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int));
+pub_ffi!(fn atg_slow_conv3d_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, weight_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, bias_: *mut C_tensor, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int));
+pub_ffi!(fn atg_slow_conv_dilated2d(out__: *mut *mut C_tensor, self_: *mut C_tensor, weight_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, bias_: *mut C_tensor, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, dilation_data: *const i64, dilation_len: c_int));
+pub_ffi!(fn atg_slow_conv_dilated3d(out__: *mut *mut C_tensor, self_: *mut C_tensor, weight_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, bias_: *mut C_tensor, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, dilation_data: *const i64, dilation_len: c_int));
+pub_ffi!(fn atg_slow_conv_transpose2d(out__: *mut *mut C_tensor, self_: *mut C_tensor, weight_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, bias_: *mut C_tensor, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, output_padding_data: *const i64, output_padding_len: c_int, dilation_data: *const i64, dilation_len: c_int));
+pub_ffi!(fn atg_slow_conv_transpose2d_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, weight_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, bias_: *mut C_tensor, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, output_padding_data: *const i64, output_padding_len: c_int, dilation_data: *const i64, dilation_len: c_int));
+pub_ffi!(fn atg_slow_conv_transpose3d(out__: *mut *mut C_tensor, self_: *mut C_tensor, weight_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, bias_: *mut C_tensor, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, output_padding_data: *const i64, output_padding_len: c_int, dilation_data: *const i64, dilation_len: c_int));
+pub_ffi!(fn atg_slow_conv_transpose3d_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, weight_: *mut C_tensor, kernel_size_data: *const i64, kernel_size_len: c_int, bias_: *mut C_tensor, stride_data: *const i64, stride_len: c_int, padding_data: *const i64, padding_len: c_int, output_padding_data: *const i64, output_padding_len: c_int, dilation_data: *const i64, dilation_len: c_int));
+pub_ffi!(fn atg_smm(out__: *mut *mut C_tensor, self_: *mut C_tensor, mat2_: *mut C_tensor));
+pub_ffi!(fn atg_smooth_l1_loss(out__: *mut *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, reduction_: i64));
+pub_ffi!(fn atg_smooth_l1_loss_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, reduction_: i64));
+pub_ffi!(fn atg_smooth_l1_loss_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, reduction_: i64));
+pub_ffi!(fn atg_smooth_l1_loss_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, reduction_: i64));
+pub_ffi!(fn atg_soft_margin_loss(out__: *mut *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, reduction_: i64));
+pub_ffi!(fn atg_soft_margin_loss_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, reduction_: i64));
+pub_ffi!(fn atg_soft_margin_loss_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, reduction_: i64));
+pub_ffi!(fn atg_soft_margin_loss_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, target_: *mut C_tensor, reduction_: i64));
+pub_ffi!(fn atg_softmax(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, dtype_: c_int));
+pub_ffi!(fn atg_softplus(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_softplus_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, beta_: *mut C_scalar, threshold_: *mut C_scalar, output_: *mut C_tensor));
+pub_ffi!(fn atg_softplus_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, beta_: *mut C_scalar, threshold_: *mut C_scalar, output_: *mut C_tensor));
+pub_ffi!(fn atg_softplus_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_softshrink(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_softshrink_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, lambd_: *mut C_scalar));
+pub_ffi!(fn atg_softshrink_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, lambd_: *mut C_scalar));
+pub_ffi!(fn atg_softshrink_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_solve(out__: *mut *mut C_tensor, self_: *mut C_tensor, A_: *mut C_tensor));
+pub_ffi!(fn atg_solve_out(out__: *mut *mut C_tensor, solution_: *mut C_tensor, lu_: *mut C_tensor, self_: *mut C_tensor, A_: *mut C_tensor));
+pub_ffi!(fn atg_sort(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, descending_: c_int));
+pub_ffi!(fn atg_sort_out(out__: *mut *mut C_tensor, values_: *mut C_tensor, indices_: *mut C_tensor, self_: *mut C_tensor, dim_: i64, descending_: c_int));
+pub_ffi!(fn atg_sparse_coo_tensor(out__: *mut *mut C_tensor, size_data: *const i64, size_len: c_int, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_sparse_coo_tensor1(out__: *mut *mut C_tensor, indices_: *mut C_tensor, values_: *mut C_tensor, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_sparse_coo_tensor2(out__: *mut *mut C_tensor, indices_: *mut C_tensor, values_: *mut C_tensor, size_data: *const i64, size_len: c_int, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_sparse_mask(out__: *mut *mut C_tensor, self_: *mut C_tensor, mask_: *mut C_tensor));
+pub_ffi!(fn atg_sparse_resize_(out__: *mut *mut C_tensor, self_: *mut C_tensor, size_data: *const i64, size_len: c_int, sparse_dim_: i64, dense_dim_: i64));
+pub_ffi!(fn atg_sparse_resize_and_clear_(out__: *mut *mut C_tensor, self_: *mut C_tensor, size_data: *const i64, size_len: c_int, sparse_dim_: i64, dense_dim_: i64));
+pub_ffi!(fn atg_split(self_: *mut C_tensor, split_size_: i64, dim_: i64) -> *mut *mut C_tensor);
+pub_ffi!(fn atg_split_with_sizes(self_: *mut C_tensor, split_sizes_data: *const i64, split_sizes_len: c_int, dim_: i64) -> *mut *mut C_tensor);
+pub_ffi!(fn atg_sqrt(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_sqrt_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_sqrt_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_squeeze(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_squeeze1(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64));
+pub_ffi!(fn atg_squeeze_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_squeeze_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64));
+pub_ffi!(fn atg_sspaddmm(out__: *mut *mut C_tensor, self_: *mut C_tensor, mat1_: *mut C_tensor, mat2_: *mut C_tensor));
+pub_ffi!(fn atg_sspaddmm_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, mat1_: *mut C_tensor, mat2_: *mut C_tensor));
+pub_ffi!(fn atg_stack(out__: *mut *mut C_tensor, tensors_data: *const *mut C_tensor, tensors_len: c_int, dim_: i64));
+pub_ffi!(fn atg_stack_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, tensors_data: *const *mut C_tensor, tensors_len: c_int, dim_: i64));
+pub_ffi!(fn atg_std(out__: *mut *mut C_tensor, self_: *mut C_tensor, unbiased_: c_int));
+pub_ffi!(fn atg_std1(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_data: *const i64, dim_len: c_int, unbiased_: c_int, keepdim_: c_int));
+pub_ffi!(fn atg_std_mean(out__: *mut *mut C_tensor, self_: *mut C_tensor, unbiased_: c_int));
+pub_ffi!(fn atg_std_mean1(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_data: *const i64, dim_len: c_int, unbiased_: c_int, keepdim_: c_int));
+pub_ffi!(fn atg_std_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, dim_data: *const i64, dim_len: c_int, unbiased_: c_int, keepdim_: c_int));
+pub_ffi!(fn atg_stft(out__: *mut *mut C_tensor, self_: *mut C_tensor, n_fft_: i64, hop_length_: i64, win_length_: i64, window_: *mut C_tensor, normalized_: c_int, onesided_: c_int));
+pub_ffi!(fn atg_sub(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_sub1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_sub_(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_sub_1(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_scalar));
+pub_ffi!(fn atg_sub_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_sum(out__: *mut *mut C_tensor, self_: *mut C_tensor, dtype_: c_int));
+pub_ffi!(fn atg_sum1(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_data: *const i64, dim_len: c_int, keepdim_: c_int, dtype_: c_int));
+pub_ffi!(fn atg_sum_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, dim_data: *const i64, dim_len: c_int, keepdim_: c_int, dtype_: c_int));
+pub_ffi!(fn atg_sum_to_size(out__: *mut *mut C_tensor, self_: *mut C_tensor, size_data: *const i64, size_len: c_int));
+pub_ffi!(fn atg_svd(out__: *mut *mut C_tensor, self_: *mut C_tensor, some_: c_int, compute_uv_: c_int));
+pub_ffi!(fn atg_svd_out(out__: *mut *mut C_tensor, U_: *mut C_tensor, S_: *mut C_tensor, V_: *mut C_tensor, self_: *mut C_tensor, some_: c_int, compute_uv_: c_int));
+pub_ffi!(fn atg_symeig(out__: *mut *mut C_tensor, self_: *mut C_tensor, eigenvectors_: c_int, upper_: c_int));
+pub_ffi!(fn atg_symeig_out(out__: *mut *mut C_tensor, e_: *mut C_tensor, V_: *mut C_tensor, self_: *mut C_tensor, eigenvectors_: c_int, upper_: c_int));
+pub_ffi!(fn atg_t(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_t_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_take(out__: *mut *mut C_tensor, self_: *mut C_tensor, index_: *mut C_tensor));
+pub_ffi!(fn atg_take_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, index_: *mut C_tensor));
+pub_ffi!(fn atg_tan(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_tan_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_tan_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_tanh(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_tanh_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_tanh_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, output_: *mut C_tensor));
+pub_ffi!(fn atg_tanh_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, output_: *mut C_tensor));
+pub_ffi!(fn atg_tanh_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_tensordot(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor, dims_self_data: *const i64, dims_self_len: c_int, dims_other_data: *const i64, dims_other_len: c_int));
+pub_ffi!(fn atg_threshold(out__: *mut *mut C_tensor, self_: *mut C_tensor, threshold_: *mut C_scalar, value_: *mut C_scalar));
+pub_ffi!(fn atg_threshold_(out__: *mut *mut C_tensor, self_: *mut C_tensor, threshold_: *mut C_scalar, value_: *mut C_scalar));
+pub_ffi!(fn atg_threshold_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, self_: *mut C_tensor, threshold_: *mut C_scalar));
+pub_ffi!(fn atg_threshold_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, threshold_: *mut C_scalar, value_: *mut C_scalar));
+pub_ffi!(fn atg_to(out__: *mut *mut C_tensor, self_: *mut C_tensor, device_: c_int));
+pub_ffi!(fn atg_to1(out__: *mut *mut C_tensor, self_: *mut C_tensor, options_kind: c_int, options_device: c_int, non_blocking_: c_int, copy_: c_int));
+pub_ffi!(fn atg_to2(out__: *mut *mut C_tensor, self_: *mut C_tensor, dtype_: c_int, non_blocking_: c_int, copy_: c_int));
+pub_ffi!(fn atg_to3(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor, non_blocking_: c_int, copy_: c_int));
+pub_ffi!(fn atg_to4(out__: *mut *mut C_tensor, self_: *mut C_tensor, device_: c_int, dtype_: c_int, non_blocking_: c_int, copy_: c_int));
+pub_ffi!(fn atg_to_dense(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_to_dense_backward(out__: *mut *mut C_tensor, grad_: *mut C_tensor, input_: *mut C_tensor));
+pub_ffi!(fn atg_to_mkldnn(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_to_mkldnn_backward(out__: *mut *mut C_tensor, grad_: *mut C_tensor, input_: *mut C_tensor));
+pub_ffi!(fn atg_to_sparse(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_to_sparse1(out__: *mut *mut C_tensor, self_: *mut C_tensor, sparse_dim_: i64));
+pub_ffi!(fn atg_topk(out__: *mut *mut C_tensor, self_: *mut C_tensor, k_: i64, dim_: i64, largest_: c_int, sorted_: c_int));
+pub_ffi!(fn atg_topk_out(out__: *mut *mut C_tensor, values_: *mut C_tensor, indices_: *mut C_tensor, self_: *mut C_tensor, k_: i64, dim_: i64, largest_: c_int, sorted_: c_int));
+pub_ffi!(fn atg_totype(out__: *mut *mut C_tensor, self_: *mut C_tensor, scalar_type_: c_int));
+pub_ffi!(fn atg_trace(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_transpose(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim0_: i64, dim1_: i64));
+pub_ffi!(fn atg_transpose_(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim0_: i64, dim1_: i64));
+pub_ffi!(fn atg_trapz(out__: *mut *mut C_tensor, y_: *mut C_tensor, x_: *mut C_tensor, dim_: i64));
+pub_ffi!(fn atg_trapz1(out__: *mut *mut C_tensor, y_: *mut C_tensor, dx_: f64, dim_: i64));
+pub_ffi!(fn atg_triangular_solve(out__: *mut *mut C_tensor, self_: *mut C_tensor, A_: *mut C_tensor, upper_: c_int, transpose_: c_int, unitriangular_: c_int));
+pub_ffi!(fn atg_triangular_solve_out(out__: *mut *mut C_tensor, X_: *mut C_tensor, M_: *mut C_tensor, self_: *mut C_tensor, A_: *mut C_tensor, upper_: c_int, transpose_: c_int, unitriangular_: c_int));
+pub_ffi!(fn atg_tril(out__: *mut *mut C_tensor, self_: *mut C_tensor, diagonal_: i64));
+pub_ffi!(fn atg_tril_(out__: *mut *mut C_tensor, self_: *mut C_tensor, diagonal_: i64));
+pub_ffi!(fn atg_tril_indices(out__: *mut *mut C_tensor, row_: i64, col_: i64, offset_: i64, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_tril_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, diagonal_: i64));
+pub_ffi!(fn atg_triplet_margin_loss(out__: *mut *mut C_tensor, anchor_: *mut C_tensor, positive_: *mut C_tensor, negative_: *mut C_tensor, margin_: f64, p_: f64, eps_: f64, swap_: c_int, reduction_: i64));
+pub_ffi!(fn atg_triu(out__: *mut *mut C_tensor, self_: *mut C_tensor, diagonal_: i64));
+pub_ffi!(fn atg_triu_(out__: *mut *mut C_tensor, self_: *mut C_tensor, diagonal_: i64));
+pub_ffi!(fn atg_triu_indices(out__: *mut *mut C_tensor, row_: i64, col_: i64, offset_: i64, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_triu_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, diagonal_: i64));
+pub_ffi!(fn atg_trunc(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_trunc_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_trunc_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_type_as(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_unbind(self_: *mut C_tensor, dim_: i64) -> *mut *mut C_tensor);
+pub_ffi!(fn atg_unfold(out__: *mut *mut C_tensor, self_: *mut C_tensor, dimension_: i64, size_: i64, step_: i64));
+pub_ffi!(fn atg_uniform_(out__: *mut *mut C_tensor, self_: *mut C_tensor, from_: f64, to_: f64));
+pub_ffi!(fn atg_unique_consecutive(out__: *mut *mut C_tensor, self_: *mut C_tensor, return_inverse_: c_int, return_counts_: c_int, dim_: i64));
+pub_ffi!(fn atg_unique_dim(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, sorted_: c_int, return_inverse_: c_int, return_counts_: c_int));
+pub_ffi!(fn atg_unique_dim_consecutive(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64, return_inverse_: c_int, return_counts_: c_int));
+pub_ffi!(fn atg_unsqueeze(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64));
+pub_ffi!(fn atg_unsqueeze_(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_: i64));
+pub_ffi!(fn atg_upsample_bicubic2d(out__: *mut *mut C_tensor, self_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int, align_corners_: c_int));
+pub_ffi!(fn atg_upsample_bicubic2d_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int, input_size_data: *const i64, input_size_len: c_int, align_corners_: c_int));
+pub_ffi!(fn atg_upsample_bicubic2d_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int, input_size_data: *const i64, input_size_len: c_int, align_corners_: c_int));
+pub_ffi!(fn atg_upsample_bicubic2d_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int, align_corners_: c_int));
+pub_ffi!(fn atg_upsample_bilinear2d(out__: *mut *mut C_tensor, self_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int, align_corners_: c_int));
+pub_ffi!(fn atg_upsample_bilinear2d_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int, input_size_data: *const i64, input_size_len: c_int, align_corners_: c_int));
+pub_ffi!(fn atg_upsample_bilinear2d_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int, input_size_data: *const i64, input_size_len: c_int, align_corners_: c_int));
+pub_ffi!(fn atg_upsample_bilinear2d_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int, align_corners_: c_int));
+pub_ffi!(fn atg_upsample_linear1d(out__: *mut *mut C_tensor, self_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int, align_corners_: c_int));
+pub_ffi!(fn atg_upsample_linear1d_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int, input_size_data: *const i64, input_size_len: c_int, align_corners_: c_int));
+pub_ffi!(fn atg_upsample_linear1d_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int, input_size_data: *const i64, input_size_len: c_int, align_corners_: c_int));
+pub_ffi!(fn atg_upsample_linear1d_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int, align_corners_: c_int));
+pub_ffi!(fn atg_upsample_nearest1d(out__: *mut *mut C_tensor, self_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int));
+pub_ffi!(fn atg_upsample_nearest1d_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int, input_size_data: *const i64, input_size_len: c_int));
+pub_ffi!(fn atg_upsample_nearest1d_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int, input_size_data: *const i64, input_size_len: c_int));
+pub_ffi!(fn atg_upsample_nearest1d_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int));
+pub_ffi!(fn atg_upsample_nearest2d(out__: *mut *mut C_tensor, self_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int));
+pub_ffi!(fn atg_upsample_nearest2d_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int, input_size_data: *const i64, input_size_len: c_int));
+pub_ffi!(fn atg_upsample_nearest2d_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int, input_size_data: *const i64, input_size_len: c_int));
+pub_ffi!(fn atg_upsample_nearest2d_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int));
+pub_ffi!(fn atg_upsample_nearest3d(out__: *mut *mut C_tensor, self_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int));
+pub_ffi!(fn atg_upsample_nearest3d_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int, input_size_data: *const i64, input_size_len: c_int));
+pub_ffi!(fn atg_upsample_nearest3d_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int, input_size_data: *const i64, input_size_len: c_int));
+pub_ffi!(fn atg_upsample_nearest3d_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int));
+pub_ffi!(fn atg_upsample_trilinear3d(out__: *mut *mut C_tensor, self_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int, align_corners_: c_int));
+pub_ffi!(fn atg_upsample_trilinear3d_backward(out__: *mut *mut C_tensor, grad_output_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int, input_size_data: *const i64, input_size_len: c_int, align_corners_: c_int));
+pub_ffi!(fn atg_upsample_trilinear3d_backward_out(out__: *mut *mut C_tensor, grad_input_: *mut C_tensor, grad_output_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int, input_size_data: *const i64, input_size_len: c_int, align_corners_: c_int));
+pub_ffi!(fn atg_upsample_trilinear3d_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, output_size_data: *const i64, output_size_len: c_int, align_corners_: c_int));
+pub_ffi!(fn atg_values(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_var(out__: *mut *mut C_tensor, self_: *mut C_tensor, unbiased_: c_int));
+pub_ffi!(fn atg_var1(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_data: *const i64, dim_len: c_int, unbiased_: c_int, keepdim_: c_int));
+pub_ffi!(fn atg_var_mean(out__: *mut *mut C_tensor, self_: *mut C_tensor, unbiased_: c_int));
+pub_ffi!(fn atg_var_mean1(out__: *mut *mut C_tensor, self_: *mut C_tensor, dim_data: *const i64, dim_len: c_int, unbiased_: c_int, keepdim_: c_int));
+pub_ffi!(fn atg_var_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, self_: *mut C_tensor, dim_data: *const i64, dim_len: c_int, unbiased_: c_int, keepdim_: c_int));
+pub_ffi!(fn atg_view(out__: *mut *mut C_tensor, self_: *mut C_tensor, size_data: *const i64, size_len: c_int));
+pub_ffi!(fn atg_view_as(out__: *mut *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_where(condition_: *mut C_tensor) -> *mut *mut C_tensor);
+pub_ffi!(fn atg_where1(out__: *mut *mut C_tensor, condition_: *mut C_tensor, self_: *mut C_tensor, other_: *mut C_tensor));
+pub_ffi!(fn atg_zero_(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_zeros(out__: *mut *mut C_tensor, size_data: *const i64, size_len: c_int, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_zeros_like(out__: *mut *mut C_tensor, self_: *mut C_tensor));
+pub_ffi!(fn atg_zeros_like1(out__: *mut *mut C_tensor, self_: *mut C_tensor, options_kind: c_int, options_device: c_int));
+pub_ffi!(fn atg_zeros_out(out__: *mut *mut C_tensor, out_: *mut C_tensor, size_data: *const i64, size_len: c_int));

--- a/torch-sys/src/lib.rs
+++ b/torch-sys/src/lib.rs
@@ -1,136 +1,149 @@
+#![cfg_attr(not(feature = "real-ffi"), allow(unused_variables, non_snake_case))]
+
 use libc::{c_char, c_int, c_void, size_t};
+
+#[cfg(feature = "real-ffi")]
+macro_rules! pub_ffi {
+    (fn $($tokens:tt)*) => {
+        extern "C" {
+            pub fn $($tokens)*;
+        }
+    }
+}
+
+#[cfg(not(feature = "real-ffi"))]
+macro_rules! pub_ffi {
+    (fn $($tokens:tt)*) => {
+        pub extern "C" fn $($tokens)* {
+            unimplemented!("\
+                This crate was built without the \"real-ffi\" feature, \
+                which means that all functions have been replaced by stubs. \
+                This configuration is only intended for building documentation. \
+                Enable the \"real-ffi\" feature to use the crate at runtime.\
+            ");
+        }
+    }
+}
 
 #[repr(C)]
 pub struct C_scalar {
     _private: [u8; 0],
 }
 
-extern "C" {
-    pub fn ats_int(v: i64) -> *mut C_scalar;
-    pub fn ats_float(v: f64) -> *mut C_scalar;
-    pub fn ats_to_int(arg: *mut C_scalar) -> i64;
-    pub fn ats_to_float(arg: *mut C_scalar) -> f64;
-    pub fn ats_to_string(arg: *mut C_scalar) -> *mut c_char;
-    pub fn ats_free(arg: *mut C_scalar);
-}
+pub_ffi!(fn ats_int(v: i64) -> *mut C_scalar);
+pub_ffi!(fn ats_float(v: f64) -> *mut C_scalar);
+pub_ffi!(fn ats_to_int(arg: *mut C_scalar) -> i64);
+pub_ffi!(fn ats_to_float(arg: *mut C_scalar) -> f64);
+pub_ffi!(fn ats_to_string(arg: *mut C_scalar) -> *mut c_char);
+pub_ffi!(fn ats_free(arg: *mut C_scalar));
 
 #[repr(C)]
 pub struct C_tensor {
     _private: [u8; 0],
 }
 
-extern "C" {
-    pub fn at_new_tensor() -> *mut C_tensor;
-    pub fn at_shallow_clone(arg: *mut C_tensor) -> *mut C_tensor;
-    pub fn at_copy_(dst: *mut C_tensor, src: *mut C_tensor);
-    pub fn at_defined(arg: *mut C_tensor) -> c_int;
-    pub fn at_is_sparse(arg: *mut C_tensor) -> c_int;
-    pub fn at_backward(arg: *mut C_tensor, keep_graph: c_int, create_graph: c_int);
-    pub fn at_print(arg: *mut C_tensor);
-    pub fn at_to_string(arg: *mut C_tensor, line_size: c_int) -> *mut c_char;
-    pub fn at_dim(arg: *mut C_tensor) -> size_t;
-    pub fn at_get(arg: *mut C_tensor, index: c_int) -> *mut C_tensor;
-    pub fn at_requires_grad(arg: *mut C_tensor) -> c_int;
-    pub fn at_shape(arg: *mut C_tensor, sz: *mut i64);
-    pub fn at_double_value_at_indexes(arg: *mut C_tensor, idx: *const i64, idx_len: c_int) -> f64;
-    pub fn at_int64_value_at_indexes(arg: *mut C_tensor, idx: *const i64, idx_len: c_int) -> i64;
-    pub fn at_free(arg: *mut C_tensor);
-    pub fn at_run_backward(
-        arg: *const *mut C_tensor,
-        ntensors: c_int,
-        inputs: *const *mut C_tensor,
-        ninputs: c_int,
-        outputs: *mut *mut C_tensor,
-        keep_graph: c_int,
-        create_graph: c_int,
-    );
-    pub fn at_copy_data(
-        arg: *mut C_tensor,
-        vs: *const c_void,
-        numel: size_t,
-        elt_size_in_bytes: size_t,
-    );
-    pub fn at_scalar_type(arg: *mut C_tensor) -> c_int;
-    pub fn at_device(arg: *mut C_tensor) -> c_int;
-    pub fn at_tensor_of_data(
-        vs: *const c_void,
-        dims: *const i64,
-        ndims: size_t,
-        elt_size_in_bytes: size_t,
-        kind: c_int,
-    ) -> *mut C_tensor;
-    pub fn at_grad_set_enabled(b: c_int) -> c_int;
-    pub fn at_save(arg: *mut C_tensor, filename: *const c_char);
-    pub fn at_load(filename: *const c_char) -> *mut C_tensor;
-    pub fn at_save_multi(
-        args: *const *mut C_tensor,
-        names: *const *const c_char,
-        n: c_int,
-        filename: *const c_char,
-    );
-    pub fn at_load_callback(
-        filename: *const c_char,
-        data: *mut c_void,
-        f: extern "C" fn(*mut c_void, name: *const c_char, t: *mut C_tensor),
-    );
-    pub fn at_load_callback_with_device(
-        filename: *const c_char,
-        data: *mut c_void,
-        f: extern "C" fn(*mut c_void, name: *const c_char, t: *mut C_tensor),
-        device_id: c_int,
-    );
+pub_ffi!(fn at_new_tensor() -> *mut C_tensor);
+pub_ffi!(fn at_shallow_clone(arg: *mut C_tensor) -> *mut C_tensor);
+pub_ffi!(fn at_copy_(dst: *mut C_tensor, src: *mut C_tensor));
+pub_ffi!(fn at_defined(arg: *mut C_tensor) -> c_int);
+pub_ffi!(fn at_is_sparse(arg: *mut C_tensor) -> c_int);
+pub_ffi!(fn at_backward(arg: *mut C_tensor, keep_graph: c_int, create_graph: c_int));
+pub_ffi!(fn at_print(arg: *mut C_tensor));
+pub_ffi!(fn at_to_string(arg: *mut C_tensor, line_size: c_int) -> *mut c_char);
+pub_ffi!(fn at_dim(arg: *mut C_tensor) -> size_t);
+pub_ffi!(fn at_get(arg: *mut C_tensor, index: c_int) -> *mut C_tensor);
+pub_ffi!(fn at_requires_grad(arg: *mut C_tensor) -> c_int);
+pub_ffi!(fn at_shape(arg: *mut C_tensor, sz: *mut i64));
+pub_ffi!(fn at_double_value_at_indexes(arg: *mut C_tensor, idx: *const i64, idx_len: c_int) -> f64);
+pub_ffi!(fn at_int64_value_at_indexes(arg: *mut C_tensor, idx: *const i64, idx_len: c_int) -> i64);
+pub_ffi!(fn at_free(arg: *mut C_tensor));
+pub_ffi!(fn at_run_backward(
+    arg: *const *mut C_tensor,
+    ntensors: c_int,
+    inputs: *const *mut C_tensor,
+    ninputs: c_int,
+    outputs: *mut *mut C_tensor,
+    keep_graph: c_int,
+    create_graph: c_int,
+));
+pub_ffi!(fn at_copy_data(
+    arg: *mut C_tensor,
+    vs: *const c_void,
+    numel: size_t,
+    elt_size_in_bytes: size_t,
+));
+pub_ffi!(fn at_scalar_type(arg: *mut C_tensor) -> c_int);
+pub_ffi!(fn at_device(arg: *mut C_tensor) -> c_int);
+pub_ffi!(fn at_tensor_of_data(
+    vs: *const c_void,
+    dims: *const i64,
+    ndims: size_t,
+    elt_size_in_bytes: size_t,
+    kind: c_int,
+) -> *mut C_tensor);
+pub_ffi!(fn at_grad_set_enabled(b: c_int) -> c_int);
+pub_ffi!(fn at_save(arg: *mut C_tensor, filename: *const c_char));
+pub_ffi!(fn at_load(filename: *const c_char) -> *mut C_tensor);
+pub_ffi!(fn at_save_multi(
+    args: *const *mut C_tensor,
+    names: *const *const c_char,
+    n: c_int,
+    filename: *const c_char,
+));
+pub_ffi!(fn at_load_callback(
+    filename: *const c_char,
+    data: *mut c_void,
+    f: extern "C" fn(*mut c_void, name: *const c_char, t: *mut C_tensor),
+));
+pub_ffi!(fn at_load_callback_with_device(
+    filename: *const c_char,
+    data: *mut c_void,
+    f: extern "C" fn(*mut c_void, name: *const c_char, t: *mut C_tensor),
+    device_id: c_int,
+));
 
-    pub fn at_manual_seed(seed: i64);
-}
+pub_ffi!(fn at_manual_seed(seed: i64));
 
 pub mod c_generated;
 
-extern "C" {
-    pub fn atc_cuda_device_count() -> c_int;
-    pub fn atc_cuda_is_available() -> c_int;
-    pub fn atc_cudnn_is_available() -> c_int;
-    pub fn atc_set_benchmark_cudnn(b: c_int);
-}
+pub_ffi!(fn atc_cuda_device_count() -> c_int);
+pub_ffi!(fn atc_cuda_is_available() -> c_int);
+pub_ffi!(fn atc_cudnn_is_available() -> c_int);
+pub_ffi!(fn atc_set_benchmark_cudnn(b: c_int));
 
-extern "C" {
-    pub fn get_and_reset_last_err() -> *mut c_char;
-}
+pub_ffi!(fn get_and_reset_last_err() -> *mut c_char);
 
 #[repr(C)]
 pub struct C_optimizer {
     _private: [u8; 0],
 }
 
-extern "C" {
-    pub fn ato_adam(lr: f64, beta1: f64, beta2: f64, wd: f64) -> *mut C_optimizer;
-    pub fn ato_rms_prop(
-        lr: f64,
-        alpha: f64,
-        eps: f64,
-        wd: f64,
-        momentum: f64,
-        centered: c_int,
-    ) -> *mut C_optimizer;
-    pub fn ato_sgd(
-        lr: f64,
-        momentum: f64,
-        dampening: f64,
-        wd: f64,
-        nesterov: c_int,
-    ) -> *mut C_optimizer;
-    pub fn ato_add_parameters(arg: *mut C_optimizer, ts: *const *mut C_tensor, n: c_int);
-    pub fn ato_set_learning_rate(arg: *mut C_optimizer, lr: f64);
-    pub fn ato_set_momentum(arg: *mut C_optimizer, momentum: f64);
-    pub fn ato_zero_grad(arg: *mut C_optimizer);
-    pub fn ato_step(arg: *mut C_optimizer);
-    pub fn ato_free(arg: *mut C_optimizer);
-}
+pub_ffi!(fn ato_adam(lr: f64, beta1: f64, beta2: f64, wd: f64) -> *mut C_optimizer);
+pub_ffi!(fn ato_rms_prop(
+    lr: f64,
+    alpha: f64,
+    eps: f64,
+    wd: f64,
+    momentum: f64,
+    centered: c_int,
+) -> *mut C_optimizer);
+pub_ffi!(fn ato_sgd(
+    lr: f64,
+    momentum: f64,
+    dampening: f64,
+    wd: f64,
+    nesterov: c_int,
+) -> *mut C_optimizer);
+pub_ffi!(fn ato_add_parameters(arg: *mut C_optimizer, ts: *const *mut C_tensor, n: c_int));
+pub_ffi!(fn ato_set_learning_rate(arg: *mut C_optimizer, lr: f64));
+pub_ffi!(fn ato_set_momentum(arg: *mut C_optimizer, momentum: f64));
+pub_ffi!(fn ato_zero_grad(arg: *mut C_optimizer));
+pub_ffi!(fn ato_step(arg: *mut C_optimizer));
+pub_ffi!(fn ato_free(arg: *mut C_optimizer));
 
-extern "C" {
-    pub fn at_save_image(arg: *mut C_tensor, filename: *const c_char) -> c_int;
-    pub fn at_load_image(filename: *const c_char) -> *mut C_tensor;
-    pub fn at_resize_image(arg: *mut C_tensor, out_w: c_int, out_h: c_int) -> *mut C_tensor;
-}
+pub_ffi!(fn at_save_image(arg: *mut C_tensor, filename: *const c_char) -> c_int);
+pub_ffi!(fn at_load_image(filename: *const c_char) -> *mut C_tensor);
+pub_ffi!(fn at_resize_image(arg: *mut C_tensor, out_w: c_int, out_h: c_int) -> *mut C_tensor);
 
 #[repr(C)]
 pub struct CIValue {
@@ -142,46 +155,44 @@ pub struct CModule_ {
     _private: [u8; 0],
 }
 
-extern "C" {
-    // Constructors
-    pub fn ati_none() -> *mut CIValue;
-    pub fn ati_bool(b: c_int) -> *mut CIValue;
-    pub fn ati_int(v: i64) -> *mut CIValue;
-    pub fn ati_double(v: f64) -> *mut CIValue;
-    pub fn ati_tensor(v: *mut C_tensor) -> *mut CIValue;
-    pub fn ati_string(s: *const c_char) -> *mut CIValue;
-    pub fn ati_tuple(v: *const *mut CIValue, n: c_int) -> *mut CIValue;
-    pub fn ati_generic_list(v: *const *mut CIValue, n: c_int) -> *mut CIValue;
-    pub fn ati_generic_dict(v: *const *mut CIValue, n: c_int) -> *mut CIValue;
-    pub fn ati_int_list(v: *const i64, n: c_int) -> *mut CIValue;
-    pub fn ati_double_list(v: *const f64, n: c_int) -> *mut CIValue;
-    pub fn ati_bool_list(v: *const c_char, n: c_int) -> *mut CIValue;
-    pub fn ati_tensor_list(v: *const *mut C_tensor, n: c_int) -> *mut CIValue;
+// Constructors
+pub_ffi!(fn ati_none() -> *mut CIValue);
+pub_ffi!(fn ati_bool(b: c_int) -> *mut CIValue);
+pub_ffi!(fn ati_int(v: i64) -> *mut CIValue);
+pub_ffi!(fn ati_double(v: f64) -> *mut CIValue);
+pub_ffi!(fn ati_tensor(v: *mut C_tensor) -> *mut CIValue);
+pub_ffi!(fn ati_string(s: *const c_char) -> *mut CIValue);
+pub_ffi!(fn ati_tuple(v: *const *mut CIValue, n: c_int) -> *mut CIValue);
+pub_ffi!(fn ati_generic_list(v: *const *mut CIValue, n: c_int) -> *mut CIValue);
+pub_ffi!(fn ati_generic_dict(v: *const *mut CIValue, n: c_int) -> *mut CIValue);
+pub_ffi!(fn ati_int_list(v: *const i64, n: c_int) -> *mut CIValue);
+pub_ffi!(fn ati_double_list(v: *const f64, n: c_int) -> *mut CIValue);
+pub_ffi!(fn ati_bool_list(v: *const c_char, n: c_int) -> *mut CIValue);
+pub_ffi!(fn ati_tensor_list(v: *const *mut C_tensor, n: c_int) -> *mut CIValue);
 
-    // Type query
-    pub fn ati_tag(arg: *mut CIValue) -> c_int;
+// Type query
+pub_ffi!(fn ati_tag(arg: *mut CIValue) -> c_int);
 
-    // Getters
-    pub fn ati_to_int(arg: *mut CIValue) -> i64;
-    pub fn ati_to_bool(arg: *mut CIValue) -> c_int;
-    pub fn ati_to_double(arg: *mut CIValue) -> f64;
-    pub fn ati_to_tensor(arg: *mut CIValue) -> *mut C_tensor;
-    pub fn ati_length(arg: *mut CIValue) -> c_int;
-    pub fn ati_tuple_length(arg: *mut CIValue) -> c_int;
-    pub fn ati_to_tuple(arg: *mut CIValue, outputs: *mut *mut CIValue, n: c_int);
-    pub fn ati_to_generic_list(arg: *mut CIValue, outputs: *mut *mut CIValue, n: c_int);
-    pub fn ati_to_generic_dict(arg: *mut CIValue, outputs: *mut *mut CIValue, n: c_int);
-    pub fn ati_to_int_list(arg: *mut CIValue, outputs: *mut i64, n: c_int);
-    pub fn ati_to_double_list(arg: *mut CIValue, outputs: *mut f64, n: c_int);
-    pub fn ati_to_bool_list(arg: *mut CIValue, outputs: *mut c_char, n: c_int);
-    pub fn ati_to_tensor_list(arg: *mut CIValue, outputs: *mut *mut C_tensor, n: c_int);
-    pub fn ati_to_string(arg: *mut CIValue) -> *mut c_char;
+// Getters
+pub_ffi!(fn ati_to_int(arg: *mut CIValue) -> i64);
+pub_ffi!(fn ati_to_bool(arg: *mut CIValue) -> c_int);
+pub_ffi!(fn ati_to_double(arg: *mut CIValue) -> f64);
+pub_ffi!(fn ati_to_tensor(arg: *mut CIValue) -> *mut C_tensor);
+pub_ffi!(fn ati_length(arg: *mut CIValue) -> c_int);
+pub_ffi!(fn ati_tuple_length(arg: *mut CIValue) -> c_int);
+pub_ffi!(fn ati_to_tuple(arg: *mut CIValue, outputs: *mut *mut CIValue, n: c_int));
+pub_ffi!(fn ati_to_generic_list(arg: *mut CIValue, outputs: *mut *mut CIValue, n: c_int));
+pub_ffi!(fn ati_to_generic_dict(arg: *mut CIValue, outputs: *mut *mut CIValue, n: c_int));
+pub_ffi!(fn ati_to_int_list(arg: *mut CIValue, outputs: *mut i64, n: c_int));
+pub_ffi!(fn ati_to_double_list(arg: *mut CIValue, outputs: *mut f64, n: c_int));
+pub_ffi!(fn ati_to_bool_list(arg: *mut CIValue, outputs: *mut c_char, n: c_int));
+pub_ffi!(fn ati_to_tensor_list(arg: *mut CIValue, outputs: *mut *mut C_tensor, n: c_int));
+pub_ffi!(fn ati_to_string(arg: *mut CIValue) -> *mut c_char);
 
-    pub fn ati_free(arg: *mut CIValue);
+pub_ffi!(fn ati_free(arg: *mut CIValue));
 
-    pub fn atm_load(filename: *const c_char) -> *mut CModule_;
-    pub fn atm_load_str(data: *const c_char, sz: size_t) -> *mut CModule_;
-    pub fn atm_forward(m: *mut CModule_, args: *const *mut C_tensor, n: c_int) -> *mut C_tensor;
-    pub fn atm_forward_(m: *mut CModule_, args: *const *mut CIValue, n: c_int) -> *mut CIValue;
-    pub fn atm_free(m: *mut CModule_);
-}
+pub_ffi!(fn atm_load(filename: *const c_char) -> *mut CModule_);
+pub_ffi!(fn atm_load_str(data: *const c_char, sz: size_t) -> *mut CModule_);
+pub_ffi!(fn atm_forward(m: *mut CModule_, args: *const *mut C_tensor, n: c_int) -> *mut C_tensor);
+pub_ffi!(fn atm_forward_(m: *mut CModule_, args: *const *mut CIValue, n: c_int) -> *mut CIValue);
+pub_ffi!(fn atm_free(m: *mut CModule_));


### PR DESCRIPTION
This PR makes it possible to build the `tch-sys` crate with stubs that don't link against `libtorch`. It is mainly intended for building the documentation without `libtorch`. This PR should fix #146.

The stubs are used when the `real-ffi` feature is disabled, which is enabled by default. The stubs simply panic with a descriptive message when called.

I think enabling the real FFI functions with a default feature is better than disabling them with a non-default feature. This allows us to avoid downloading dev dependencies when `real-ffi` is disabled, and it means that `--all-features` doesn't produce an unusable library. Instead, `--no-default-features` produces an unusable library, but I think that's better than vice-versa.