### PR TITLE
Expose (get|set)_num(_interop)?_threads

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,10 @@ mod wrappers;
 pub use wrappers::device::{Cuda, Device};
 pub use wrappers::jit::{CModule, IValue};
 pub use wrappers::kind::Kind;
-pub use wrappers::manual_seed;
 pub use wrappers::scalar::Scalar;
+pub use wrappers::{
+    get_num_interop_threads, get_num_threads, manual_seed, set_num_interop_threads, set_num_threads,
+};
 
 mod tensor;
 pub use tensor::{

--- a/src/wrappers/mod.rs
+++ b/src/wrappers/mod.rs
@@ -1,6 +1,8 @@
 #[macro_use]
 mod utils;
-pub use utils::manual_seed;
+pub use utils::{
+    get_num_interop_threads, get_num_threads, manual_seed, set_num_interop_threads, set_num_threads,
+};
 
 pub(crate) mod device;
 pub(crate) mod image;

--- a/src/wrappers/utils.rs
+++ b/src/wrappers/utils.rs
@@ -69,3 +69,23 @@ pub(super) fn path_to_cstring<T: AsRef<std::path::Path>>(path: T) -> Fallible<st
 pub fn manual_seed(seed: i64) {
     unsafe_torch!({ torch_sys::at_manual_seed(seed) })
 }
+
+/// Get the number of threads used by torch for inter-op parallelism.
+pub fn get_num_interop_threads() -> i32 {
+    unsafe_torch!({ torch_sys::at_get_num_interop_threads() })
+}
+
+/// Get the number of threads used by torch in parallel regions.
+pub fn get_num_threads() -> i32 {
+    unsafe_torch!({ torch_sys::at_get_num_threads() })
+}
+
+/// Set the number of threads used by torch for inter-op parallelism.
+pub fn set_num_interop_threads(n_threads: i32) {
+    unsafe_torch!({ torch_sys::at_set_num_interop_threads(n_threads) })
+}
+
+/// Set the number of threads used by torch in parallel regions.
+pub fn set_num_threads(n_threads: i32) {
+    unsafe_torch!({ torch_sys::at_set_num_threads(n_threads) })
+}

--- a/torch-sys/libtch/torch_api.cpp
+++ b/torch-sys/libtch/torch_api.cpp
@@ -328,6 +328,22 @@ int at_save_image(tensor tensor, char *filename) {
   return -1;
 }
 
+int at_get_num_interop_threads() {
+  PROTECT(return at::get_num_interop_threads();)
+}
+
+int at_get_num_threads() {
+  PROTECT(return at::get_num_threads();)
+}
+
+void at_set_num_interop_threads(int n_threads) {
+  PROTECT(at::set_num_interop_threads(n_threads);)
+}
+
+void at_set_num_threads(int n_threads) {
+  PROTECT(at::set_num_threads(n_threads);)
+}
+
 tensor at_resize_image(tensor tensor, int out_w, int out_h) {
   PROTECT(
     auto sizes = tensor->sizes();

--- a/torch-sys/libtch/torch_api.h
+++ b/torch-sys/libtch/torch_api.h
@@ -71,6 +71,14 @@ void at_load_multi_(tensor *tensors, char **tensor_names, int ntensors, char *fi
 void at_load_callback(char *filename, void *data, void (*f)(void *, char *, tensor));
 void at_load_callback_with_device(char *filename, void *data, void (*f)(void *, char *, tensor), int device_id);
 
+int at_get_num_interop_threads();
+
+int at_get_num_threads();
+
+void at_set_num_interop_threads(int n_threads);
+
+void at_set_num_threads(int n_threads);
+
 void at_free(tensor);
 
 void at_run_backward(tensor *tensors,

--- a/torch-sys/src/lib.rs
+++ b/torch-sys/src/lib.rs
@@ -34,6 +34,10 @@ extern "C" {
     pub fn at_shape(arg: *mut C_tensor, sz: *mut i64);
     pub fn at_double_value_at_indexes(arg: *mut C_tensor, idx: *const i64, idx_len: c_int) -> f64;
     pub fn at_int64_value_at_indexes(arg: *mut C_tensor, idx: *const i64, idx_len: c_int) -> i64;
+    pub fn at_get_num_interop_threads() -> c_int;
+    pub fn at_get_num_threads() -> c_int;
+    pub fn at_set_num_interop_threads(n_threads: c_int);
+    pub fn at_set_num_threads(n_threads: c_int);
     pub fn at_free(arg: *mut C_tensor);
     pub fn at_run_backward(
         arg: *const *mut C_tensor,


### PR DESCRIPTION
I need to set the number of threads in (as a command-line option) of an application, rather than through the `OMP_NUM_THREADS` environment variable. So, I thought it might be useful to expose ATen's functions for getting/setting the number of threads.