### PR TITLE
Public `tensor::Shape` and convert from `&[i64]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,8 @@ pub use wrappers::{
 
 mod tensor;
 pub use tensor::{
-    index, no_grad, no_grad_guard, IndexOp, NewAxis, NoGradGuard, Reduction, Shape, Tensor, TensorIndexer,
+    index, no_grad, no_grad_guard, IndexOp, NewAxis, NoGradGuard, Reduction, Shape, Tensor,
+    TensorIndexer,
 };
 
 pub mod nn;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub use wrappers::{
 
 mod tensor;
 pub use tensor::{
-    index, no_grad, no_grad_guard, IndexOp, NewAxis, NoGradGuard, Reduction, Tensor, TensorIndexer,
+    index, no_grad, no_grad_guard, IndexOp, NewAxis, NoGradGuard, Reduction, Shape, Tensor, TensorIndexer,
 };
 
 pub mod nn;

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -207,6 +207,12 @@ impl Shape for () {
     }
 }
 
+impl Shape for &[i64] {
+    fn to_shape(&self) -> Box<[i64]> {
+        self.into()
+    }
+}
+
 impl Shape for i64 {
     fn to_shape(&self) -> Box<[i64]> {
         Box::new([*self])

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -209,7 +209,7 @@ impl Shape for () {
 
 impl Shape for &[i64] {
     fn to_shape(&self) -> Box<[i64]> {
-        self.into()
+        (*self).into()
     }
 }
 


### PR DESCRIPTION
I think it would be useful to make `tch::tensor::Shape` public, because it is part of the public API already through `Tensor::view()`. I also implemented `impl Shape for &[i64]` so that `Tensor::view()` has a similar API to `Tensor::reshape()`.