### PR TITLE
added constructor for linear layer without bias

### DIFF
--- a/src/nn/linear.rs
+++ b/src/nn/linear.rs
@@ -8,6 +8,7 @@ use std::borrow::Borrow;
 pub struct LinearConfig {
     pub ws_init: super::Init,
     pub bs_init: Option<super::Init>,
+    pub bias: bool,
 }
 
 impl Default for LinearConfig {
@@ -15,6 +16,7 @@ impl Default for LinearConfig {
         LinearConfig {
             ws_init: super::Init::KaimingUniform,
             bs_init: None,
+            bias: true,
         }
     }
 }
@@ -34,29 +36,7 @@ pub fn linear<'a, T: Borrow<super::Path<'a>>>(
     c: LinearConfig,
 ) -> Linear {
     let vs = vs.borrow();
-    let bs_init = c.bs_init.unwrap_or_else(|| {
-        let bound = 1.0 / (in_dim as f64).sqrt();
-        super::Init::Uniform {
-            lo: -bound,
-            up: bound,
-        }
-    });
-    Linear {
-        ws: vs.var("weight", &[out_dim, in_dim], c.ws_init),
-        bs: vs.var("bias", &[out_dim], bs_init),
-    }
-}
-
-/// Creates a new linear layer.
-pub fn linear2<'a, T: Borrow<super::Path<'a>>>(
-    vs: T,
-    in_dim: i64,
-    out_dim: i64,
-    bias: bool,
-    c: LinearConfig,
-) -> Linear {
-    let vs = vs.borrow();
-    let bs = match bias {
+    let bs = match c.bias {
         true => {
             let bs_init = c.bs_init.unwrap_or_else(|| {
                 let bound = 1.0 / (in_dim as f64).sqrt();
@@ -72,7 +52,7 @@ pub fn linear2<'a, T: Borrow<super::Path<'a>>>(
 
     Linear {
         ws: vs.var("weight", &[out_dim, in_dim], c.ws_init),
-        bs,
+        bs: bs,
     }
 }
 

--- a/tests/nn_tests.rs
+++ b/tests/nn_tests.rs
@@ -17,6 +17,7 @@ fn optimizer_test() {
     let cfg = nn::LinearConfig {
         ws_init: nn::Init::Const(0.),
         bs_init: Some(nn::Init::Const(0.)),
+        bias: true,
     };
     let mut linear = nn::linear(vs.root(), 1, 1, cfg);
 
@@ -255,26 +256,11 @@ fn linear_test(linear_config: nn::LinearConfig) {
 
     // forward test
     let input = Tensor::randint(10, &[batch_dim, input_dim], kind::FLOAT_CPU);
+    let expected_var_store_size = if linear_config.bias { 2 } else { 1 };
+    let bias_in_var_store = if linear_config.bias { true } else { false };
+
     let output = linear.forward(&input);
     assert_eq!(output.size(), [batch_dim, output_dim]);
-    assert_eq!(vs.variables().len(), 2);
-    assert!(vs.variables().contains_key("weight"));
-    assert!(vs.variables().contains_key("bias"));
-}
-
-fn linear2_test(linear_config: nn::LinearConfig, bias: bool) {
-    let batch_dim = 5;
-    let input_dim = 10;
-    let output_dim = 4;
-    let vs = nn::VarStore::new(tch::Device::Cpu);
-    let linear = nn::linear2(&vs.root(), input_dim, output_dim, bias, linear_config);
-
-    // forward test
-    let input = Tensor::randint(10, &[batch_dim, input_dim], kind::FLOAT_CPU);
-    let output = linear.forward(&input);
-
-    let expected_var_store_size = if bias { 2 } else { 1 };
-    let bias_in_var_store = if bias { true } else { false };
 
     assert_eq!(output.size(), [batch_dim, output_dim]);
     assert_eq!(vs.variables().len(), expected_var_store_size);
@@ -285,6 +271,12 @@ fn linear2_test(linear_config: nn::LinearConfig, bias: bool) {
 #[test]
 fn linear() {
     linear_test(Default::default());
-    linear2_test(Default::default(), true);
-    linear2_test(Default::default(), false);
+    linear_test(nn::LinearConfig {
+        bias: true,
+        ..Default::default()
+    });
+    linear_test(nn::LinearConfig {
+        bias: false,
+        ..Default::default()
+    });
 }


### PR DESCRIPTION
The bias in the original Linear layer from Pytorch is optional and may be skipped (https://pytorch.org/docs/stable/_modules/torch/nn/modules/linear.html#Linear)

A few architectures do not use a bias for specific linear layer. For example are the linear layers with weight tied to the input embeddings for encoder/decoder architectures or masked language models need to be equivalent to a reverse embedding layer and therefore do not use a bias (e.g. GPT2).

The current API forces the bias to be register to the varstore. This PR proposes a constructor for the linear layer that would allow creating linear layers without bias.
- adds a `bias` boolean parameter
- when set to false, the Linear layer bias is a tensor of zeros not registered to the var store

This is meant to maximize compatibility with current code and use a single Linear layer. Alternatives would be :
- set the bias in the linear layer to be of type Option<Tensor>, potentially breaking existing code accessing the bias Tensor directly
- create a new LinearWithoutBias module that would duplicate a significant amount of code from the Linear layer