### PR TITLE
Remove as_variable_ref.

### DIFF
--- a/torch-sys/libtch/torch_api.cpp
+++ b/torch-sys/libtch/torch_api.cpp
@@ -381,13 +381,13 @@ void at_run_backward(tensor *tensors,
   PROTECT(
     vector<torch::autograd::Edge> roots;
     for (int i = 0; i < ntensors; ++i)
-      roots.push_back(torch::autograd::impl::gradient_edge(torch::autograd::as_variable_ref(*tensors[i])));
+      roots.push_back(torch::autograd::impl::gradient_edge(*tensors[i]));
 
     vector<torch::autograd::Edge> inputs_;
     for (int i = 0; i < ninputs; ++i) {
       if (!inputs[i]->requires_grad())
         throw std::invalid_argument("one of the input tensor does not use set_requires_grad");
-      inputs_.push_back(torch::autograd::impl::gradient_edge(torch::autograd::as_variable_ref(*inputs[i])));
+      inputs_.push_back(torch::autograd::impl::gradient_edge(*inputs[i]));
     }
 
     vector<torch::autograd::Variable> grads;


### PR DESCRIPTION
Apparently this is no longer needed and the function has been removed in [`master`](https://github.com/pytorch/pytorch/pull/36096/files).