### PR TITLE
Add functions to load a JIT module directly on a specific device.

### DIFF
--- a/src/wrappers/jit.rs
+++ b/src/wrappers/jit.rs
@@ -260,12 +260,34 @@ impl CModule {
         Ok(CModule { c_module })
     }
 
+    /// Loads a PyTorch saved JIT model from a file onto the given device.
+    ///
+    /// This function loads the model directly on the specified device,
+    /// which means it also allows loading a GPU model on the CPU without having a CUDA enabled GPU.
+    pub fn load_on_device<T: AsRef<std::path::Path>>(path: T, device: Device) -> Fallible<CModule> {
+        let path = path_to_cstring(path)?;
+        let c_module = unsafe_torch_err!({ atm_load_on_device(path.as_ptr(), device.c_int()) });
+        Ok(CModule { c_module })
+    }
+
     /// Loads a PyTorch saved JIT model from a read instance.
     pub fn load_data<T: std::io::Read>(f: &mut T) -> Fallible<CModule> {
         let mut buffer = Vec::new();
         f.read_to_end(&mut buffer)?;
         let buffer_ptr = buffer.as_ptr() as *const libc::c_char;
         let c_module = unsafe_torch_err!({ atm_load_str(buffer_ptr, buffer.len()) });
+        Ok(CModule { c_module })
+    }
+
+    /// Loads a PyTorch saved JIT model from a read instance.
+    ///
+    /// This function loads the model directly on the specified device,
+    /// which means it also allows loading a GPU model on the CPU without having a CUDA enabled GPU.
+    pub fn load_data_on_device<T: std::io::Read>(f: &mut T, device: Device) -> Fallible<CModule> {
+        let mut buffer = Vec::new();
+        f.read_to_end(&mut buffer)?;
+        let buffer_ptr = buffer.as_ptr() as *const i8;
+        let c_module = unsafe_torch_err!({ atm_load_str_on_device(buffer_ptr, buffer.len(), device.c_int()) });
         Ok(CModule { c_module })
     }
 

--- a/torch-sys/libtch/torch_api.cpp
+++ b/torch-sys/libtch/torch_api.cpp
@@ -562,10 +562,25 @@ module atm_load(char *filename) {
   return nullptr;
 }
 
+module atm_load_on_device(char *filename, int device) {
+  PROTECT(
+    return new torch::jit::script::Module(torch::jit::load(filename, device_of_int(device)));
+  )
+  return nullptr;
+}
+
 module atm_load_str(char *data, size_t sz) {
   PROTECT(
     std::istringstream stream(std::string(data, sz));
     return new torch::jit::script::Module(torch::jit::load(stream));
+  )
+  return nullptr;
+}
+
+module atm_load_str_on_device(char *data, size_t sz, int device) {
+  PROTECT(
+    std::istringstream stream(std::string(data, sz));
+    return new torch::jit::script::Module(torch::jit::load(stream, device_of_int(device)));
   )
   return nullptr;
 }

--- a/torch-sys/libtch/torch_api.h
+++ b/torch-sys/libtch/torch_api.h
@@ -125,7 +125,9 @@ int atc_cudnn_is_available();
 void atc_set_benchmark_cudnn(int b);
 
 module atm_load(char *);
+module atm_load_on_device(char *, int device);
 module atm_load_str(char *, size_t sz);
+module atm_load_str_on_device(char *, size_t sz, int device);
 tensor atm_forward(module, tensor *tensors, int ntensors);
 ivalue atm_forward_(module,
                     ivalue *ivalues,

--- a/torch-sys/src/lib.rs
+++ b/torch-sys/src/lib.rs
@@ -185,7 +185,9 @@ extern "C" {
     pub fn ati_free(arg: *mut CIValue);
 
     pub fn atm_load(filename: *const c_char) -> *mut CModule_;
+    pub fn atm_load_on_device(filename: *const c_char, device: c_int) -> *mut CModule_;
     pub fn atm_load_str(data: *const c_char, sz: size_t) -> *mut CModule_;
+    pub fn atm_load_str_on_device(data: *const c_char, sz: size_t, device: c_int) -> *mut CModule_;
     pub fn atm_forward(m: *mut CModule_, args: *const *mut C_tensor, n: c_int) -> *mut C_tensor;
     pub fn atm_forward_(m: *mut CModule_, args: *const *mut CIValue, n: c_int) -> *mut CIValue;
     pub fn atm_free(m: *mut CModule_);


### PR DESCRIPTION
This PR adds functions to load a JIT module directly on a specified device.

This can be important, since it may otherwise be impossible to load a GPU module on a CPU when you don't have a CUDA enabled GPU. In that scenario, loading the GPU module already fails, so you can not move it to the CPU afterwards.

By exposing the device parameter of `torch::jit::load`, we can successfully load the model anyway :)