### PR TITLE
Update rand to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ failure = "0.1"
 lazy_static = "1.3.0"
 libc = "0.2.0"
 ndarray = "0.13"
-rand = "0.6.5"
+rand = "0.7"
 torch-sys = { version = "0.1.7", path = "torch-sys" }
 zip = "0.5"
 


### PR DESCRIPTION
A bit of a boring PR, but this deduplicates transitive dependencies (with the current version `rand_core` and `autocfg` are duplicates). It also reduces the number of transitive dependencies, since rand 0.7 depends on fewer rng implementations.