### PR TITLE
Require Send on Module{,T} traits

### DIFF
--- a/src/nn/func.rs
+++ b/src/nn/func.rs
@@ -3,7 +3,7 @@ use crate::Tensor;
 
 /// A layer defined by a simple closure.
 pub struct Func<'a> {
-    f: Box<dyn Fn(&Tensor) -> Tensor + 'a>,
+    f: Box<dyn 'a + Fn(&Tensor) -> Tensor + Send>,
 }
 
 impl<'a> std::fmt::Debug for Func<'a> {
@@ -14,8 +14,7 @@ impl<'a> std::fmt::Debug for Func<'a> {
 
 pub fn func<'a, F>(f: F) -> Func<'a>
 where
-    F: 'a,
-    F: Fn(&Tensor) -> Tensor,
+    F: 'a + Fn(&Tensor) -> Tensor + Send,
 {
     Func { f: Box::new(f) }
 }
@@ -28,7 +27,7 @@ impl<'a> super::module::Module for Func<'a> {
 
 /// A layer defined by a closure with an additional training parameter.
 pub struct FuncT<'a> {
-    f: Box<dyn Fn(&Tensor, bool) -> Tensor + 'a>,
+    f: Box<dyn 'a + Fn(&Tensor, bool) -> Tensor + Send>,
 }
 
 impl<'a> std::fmt::Debug for FuncT<'a> {
@@ -39,8 +38,7 @@ impl<'a> std::fmt::Debug for FuncT<'a> {
 
 pub fn func_t<'a, F>(f: F) -> FuncT<'a>
 where
-    F: 'a,
-    F: Fn(&Tensor, bool) -> Tensor,
+    F: 'a + Fn(&Tensor, bool) -> Tensor + Send,
 {
     FuncT { f: Box::new(f) }
 }

--- a/src/nn/module.rs
+++ b/src/nn/module.rs
@@ -2,7 +2,7 @@
 use crate::{data::Iter2, Device, Tensor};
 
 /// The simplest module trait, defining a forward function.
-pub trait Module: std::fmt::Debug {
+pub trait Module: std::fmt::Debug + Send {
     fn forward(&self, xs: &Tensor) -> Tensor;
 }
 
@@ -10,7 +10,7 @@ pub trait Module: std::fmt::Debug {
 ///
 /// The train parameter is commonly used to have different behavior between training
 /// and evaluation, e.g. when using dropout or batch-normalization.
-pub trait ModuleT: std::fmt::Debug {
+pub trait ModuleT: std::fmt::Debug + Send {
     fn forward_t(&self, xs: &Tensor, train: bool) -> Tensor;
 
     fn batch_accuracy_for_logits(

--- a/src/nn/sequential.rs
+++ b/src/nn/sequential.rs
@@ -50,8 +50,7 @@ impl Sequential {
     /// Appends a closure after all the current layers.
     pub fn add_fn<F>(self, f: F) -> Self
     where
-        F: 'static,
-        F: Fn(&Tensor) -> Tensor,
+        F: 'static + Fn(&Tensor) -> Tensor + Send,
     {
         self.add(super::func(f))
     }
@@ -123,8 +122,7 @@ impl SequentialT {
     /// Appends a closure after all the current layers.
     pub fn add_fn<F>(self, f: F) -> Self
     where
-        F: 'static,
-        F: Fn(&Tensor) -> Tensor,
+        F: 'static + Fn(&Tensor) -> Tensor + Send,
     {
         self.add(super::func(f))
     }
@@ -132,8 +130,7 @@ impl SequentialT {
     /// Appends a closure after all the current layers.
     pub fn add_fn_t<F>(self, f: F) -> Self
     where
-        F: 'static,
-        F: Fn(&Tensor, bool) -> Tensor,
+        F: 'static + Fn(&Tensor, bool) -> Tensor + Send,
     {
         self.add(super::func_t(f))
     }


### PR DESCRIPTION
This patch adds additional trait bound `Module{,T}: Send` and changes `Func{,T}` and `Sequential{,T}` accordingly to satisfy the bound. It aims to ease the hassle to work with multi-threading.

It needs rigorous review on the `Func{,T}` type that it wraps around the `Box<dyn 'a + Fn(...) -> ... + Send>` type. It assumes the underlying closure or fn pointer could be moved among threads. I would be more specific that whether we can eliminate the case the closure can modify outer variables like `FnMut`.

I made a [playground](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2018&gist=82100a4074af0c93c3ea920ff2bd2f6f) to simulate the outcome of this patch. It verifies that closures (w/ or w/o capturing) and fn pointers compile.