### PR TITLE
Configure rustfmt to tidy doc comments

### DIFF
--- a/examples/pretrained-models/main.rs
+++ b/examples/pretrained-models/main.rs
@@ -59,7 +59,7 @@ pub fn main() -> Result<()> {
 
     // Apply the forward pass of the model to get the logits.
     let output = net
-        .forward_t(&image.unsqueeze(0), /*train=*/ false)
+        .forward_t(&image.unsqueeze(0), /* train= */ false)
         .softmax(-1, tch::Kind::Float); // Convert to probability.
 
     // Print the top 5 categories for this image.

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+format_code_in_doc_comments = true

--- a/src/tensor/index.rs
+++ b/src/tensor/index.rs
@@ -8,7 +8,7 @@
 //! be used to get all the indexes from a given dimension.
 //!
 //! ```
-//! use crate::tch::{Tensor,IndexOp};
+//! use crate::tch::{IndexOp, Tensor};
 //! let tensor = Tensor::of_slice(&[1, 2, 3, 4, 5, 6]).view((2, 3));
 //! let t = tensor.i(1);
 //! let t = tensor.i((.., -2));
@@ -17,7 +17,7 @@
 //! Indexes like `1..`, `..1`, or `1..2`, can be used to narrow a dimension.
 //!
 //! ```
-//! use crate::tch::{Tensor,IndexOp};
+//! use crate::tch::{IndexOp, Tensor};
 //! let tensor = Tensor::of_slice(&[1, 2, 3, 4, 5, 6]).view((2, 3));
 //! let t = tensor.i((.., 1..));
 //! assert_eq!(t.size(), [2, 2]);
@@ -36,11 +36,11 @@
 //! The `NewAxis` index can be used to insert a dimension.
 //!
 //! ```
-//! use crate::tch::{Tensor, IndexOp, NewAxis};
+//! use crate::tch::{IndexOp, NewAxis, Tensor};
 //! let tensor = Tensor::of_slice(&[1, 2, 3, 4, 5, 6]).view((2, 3));
 //! let t = tensor.i((NewAxis,));
 //! assert_eq!(t.size(), &[1, 2, 3]);
-//! let t = tensor.i((..,..,NewAxis));
+//! let t = tensor.i((.., .., NewAxis));
 //! assert_eq!(t.size(), &[2, 3, 1]);
 //! ```
 //!


### PR DESCRIPTION
Add a `rustfmt.toml` to tidy code blocks in doc comments.