### PR TITLE
Support tensor ops with i32 and f32 types along with improvements

### DIFF
--- a/examples/vae/main.rs
+++ b/examples/vae/main.rs
@@ -57,7 +57,7 @@ fn loss(recon_x: &Tensor, x: &Tensor, mu: &Tensor, logvar: &Tensor) -> Tensor {
     //     Kingma and Welling. Auto-Encoding Variational Bayes. ICLR, 2014
     // https://arxiv.org/abs/1312.6114
     // 0.5 * sum(1 + log(sigma^2) - mu^2 - sigma^2)
-    let kld = -0.5 * (1 + logvar - mu.pow(2) - logvar.exp()).sum(Kind::Float);
+    let kld = -0.5 * (1i64 + logvar - mu.pow(2) - logvar.exp()).sum(Kind::Float);
     bce + kld
 }
 

--- a/src/wrappers/scalar.rs
+++ b/src/wrappers/scalar.rs
@@ -73,13 +73,13 @@ impl From<f64> for Scalar {
 
 impl From<Scalar> for i64 {
     fn from(s: Scalar) -> i64 {
-        s.to_int().unwrap()
+        Self::from(&s)
     }
 }
 
 impl From<Scalar> for f64 {
     fn from(s: Scalar) -> f64 {
-        s.to_float().unwrap()
+        Self::from(&s)
     }
 }
 


### PR DESCRIPTION
Changes:
- Define {Add,Sub,Mul,Div}{,Assign} on i32 and f32 with tensor
- Replace macros with generic impl
- Reuse existing code and remove duplicated parts

It could somewhat solves #100. However, with this PR, the `1 + tensor` should be more verbose `1i64 + tensor`, otherwise it won't compile.