### PR TITLE
Update example to use friendly error messages

### DIFF
--- a/examples/neural-style-transfer/main.rs
+++ b/examples/neural-style-transfer/main.rs
@@ -34,7 +34,9 @@ pub fn main() -> Result<()> {
 
     let mut net_vs = tch::nn::VarStore::new(device);
     let net = vgg::vgg16(&net_vs.root(), imagenet::CLASS_COUNT);
-    net_vs.load(weights).expect("Could not load weights file please check the path");
+    net_vs
+        .load(weights)
+        .expect("Could not load weights file please check the path");
     net_vs.freeze();
 
     let style_img = imagenet::load_image(style_img)

--- a/examples/neural-style-transfer/main.rs
+++ b/examples/neural-style-transfer/main.rs
@@ -34,13 +34,15 @@ pub fn main() -> Result<()> {
 
     let mut net_vs = tch::nn::VarStore::new(device);
     let net = vgg::vgg16(&net_vs.root(), imagenet::CLASS_COUNT);
-    net_vs.load(weights)?;
+    net_vs.load(weights).expect("Could not load weights file please check the path");
     net_vs.freeze();
 
-    let style_img = imagenet::load_image(style_img)?
+    let style_img = imagenet::load_image(style_img)
+        .expect("Could not load the style file please check the path")
         .unsqueeze(0)
         .to_device(device);
-    let content_img = imagenet::load_image(content_img)?
+    let content_img = imagenet::load_image(content_img)
+        .expect("Could not load the content file please check the path")
         .unsqueeze(0)
         .to_device(device);
     let max_layer = STYLE_INDEXES.iter().max().unwrap() + 1;


### PR DESCRIPTION
Dearest Reviewer,

Right now if you can not load a file it says something like fopen failed. Adding an expects with which file failed would help a beginner out. 

I have also personally changed the output file name to be the {base name of the source}-{base name of the content}-{step_id} to help me save all my amazing images. That can be another change or an exercise for the reader.

Thanks again for the amazing example.

Becker

Changes:
Moved from `?` to `expect` with a message when loading the inputted files.