### PR TITLE
Added support for f16 serialization

### DIFF
--- a/src/tensor/npy.rs
+++ b/src/tensor/npy.rs
@@ -57,6 +57,7 @@ impl Header {
             .collect::<Vec<_>>()
             .join(",");
         let descr = match self.descr {
+            Kind::Half => "f2",
             Kind::Float => "f4",
             Kind::Double => "f8",
             Kind::Int => "i4",
@@ -148,6 +149,7 @@ impl Header {
                     )));
                 }
                 match descr.trim_matches(|c: char| c == '=' || c == '<') {
+                    "f2" => Kind::Half,
                     "f4" => Kind::Float,
                     "f8" => Kind::Double,
                     "i4" => Kind::Int,

--- a/tests/serialization_tests.rs
+++ b/tests/serialization_tests.rs
@@ -1,4 +1,4 @@
-use tch::Tensor;
+use tch::{Kind, Tensor};
 
 #[test]
 fn save_and_load() {
@@ -28,6 +28,19 @@ fn save_and_load_npz() {
     let filename = std::env::temp_dir().join(format!("tch3-{}.npz", std::process::id()));
     let pi = Tensor::of_slice(&[3.0, 1.0, 4.0, 1.0, 5.0]);
     let e = Tensor::of_slice(&[2, 7, 1, 8, 2, 8, 1, 8, 2, 8, 4, 6]);
+    Tensor::write_npz(&[(&"pi", &pi), (&"e", &e)], &filename).unwrap();
+    let named_tensors = Tensor::read_npz(&filename).unwrap();
+    assert_eq!(named_tensors.len(), 2);
+    assert_eq!(named_tensors[0].0, "pi");
+    assert_eq!(named_tensors[1].0, "e");
+    assert_eq!(i64::from(&named_tensors[1].1.sum(tch::Kind::Float)), 57);
+}
+
+#[test]
+fn save_and_load_npz_half() {
+    let filename = std::env::temp_dir().join(format!("tch4-{}.npz", std::process::id()));
+    let pi = Tensor::of_slice(&[3.0, 1.0, 4.0, 1.0, 5.0]).to2(Kind::Half, true, false);
+    let e = Tensor::of_slice(&[2, 7, 1, 8, 2, 8, 1, 8, 2, 8, 4, 6]).to2(Kind::Half, true, false);
     Tensor::write_npz(&[(&"pi", &pi), (&"e", &e)], &filename).unwrap();
     let named_tensors = Tensor::read_npz(&filename).unwrap();
     assert_eq!(named_tensors.len(), 2);


### PR DESCRIPTION
Following the support for f16 tensors in https://github.com/LaurentMazare/tch-rs/pull/215, could we please add the support to load/read numpy arrays with half precision?

I just came across an example and the current setup requires me to serialize the weights with f32 precision and therefore ~ double the file size compared to the native Pytorch parameters.