### PR TITLE
Define separate fallible f_sizeN methods with N up to 6

### DIFF
--- a/examples/neural-style-transfer/README.md
+++ b/examples/neural-style-transfer/README.md
@@ -55,7 +55,7 @@ define a loss that is location independent.
 
 ```rust
 fn gram_matrix(m: &Tensor) -> Tensor {
-    let (a, b, c, d) = m.size4().unwrap();
+    let (a, b, c, d) = m.size4();
     let m = m.view(&[a * b, c * d]);
     let g = m.matmul(&m.tr());
     g / (a * b * c * d)

--- a/examples/neural-style-transfer/main.rs
+++ b/examples/neural-style-transfer/main.rs
@@ -14,7 +14,7 @@ const STYLE_INDEXES: [usize; 5] = [0, 2, 5, 7, 10];
 const CONTENT_INDEXES: [usize; 1] = [7];
 
 fn gram_matrix(m: &Tensor) -> Tensor {
-    let (a, b, c, d) = m.size4().unwrap();
+    let (a, b, c, d) = m.size4();
     let m = m.view([a * b, c * d]);
     let g = m.matmul(&m.tr());
     g / (a * b * c * d)

--- a/examples/translation/main.rs
+++ b/examples/translation/main.rs
@@ -86,7 +86,7 @@ impl Decoder {
         let attn_weights = Tensor::cat(&[&xs, &state.value()], 1)
             .apply(&self.attn)
             .unsqueeze(0);
-        let (sz1, sz2, sz3) = enc_outputs.size3().unwrap();
+        let (sz1, sz2, sz3) = enc_outputs.size3();
         let enc_outputs = if sz2 == MAX_LENGTH as i64 {
             enc_outputs.shallow_clone()
         } else {

--- a/examples/yolo/darknet.rs
+++ b/examples/yolo/darknet.rs
@@ -157,7 +157,7 @@ fn conv(vs: nn::Path, index: usize, p: i64, b: &Block) -> Result<(i64, Bl)> {
 
 fn upsample(prev_channels: i64) -> Result<(i64, Bl)> {
     let layer = nn::func_t(|xs, _is_training| {
-        let (_n, _c, h, w) = xs.size4().unwrap();
+        let (_n, _c, h, w) = xs.size4();
         xs.upsample_nearest2d(&[2 * h, 2 * w], 2.0, 2.0)
     });
     Ok((prev_channels, Bl::Layer(Box::new(layer))))
@@ -214,7 +214,7 @@ where
 }
 
 fn detect(xs: &Tensor, image_height: i64, classes: i64, anchors: &Vec<(i64, i64)>) -> Tensor {
-    let (bsize, _channels, height, _width) = xs.size4().unwrap();
+    let (bsize, _channels, height, _width) = xs.size4();
     let stride = image_height / height;
     let grid_size = image_height / stride;
     let bbox_attrs = 5 + classes;

--- a/examples/yolo/main.rs
+++ b/examples/yolo/main.rs
@@ -45,7 +45,7 @@ pub fn draw_rect(t: &mut Tensor, x1: i64, x2: i64, y1: i64, y2: i64) {
 }
 
 pub fn report(pred: &Tensor, img: &Tensor, w: i64, h: i64) -> Result<Tensor> {
-    let (npreds, pred_size) = pred.size2()?;
+    let (npreds, pred_size) = pred.size2();
     let nclasses = (pred_size - 5) as usize;
     // The bounding boxes grouped by (maximum) class index.
     let mut bboxes: Vec<Vec<Bbox>> = (0..nclasses).map(|_| vec![]).collect();
@@ -95,7 +95,7 @@ pub fn report(pred: &Tensor, img: &Tensor, w: i64, h: i64) -> Result<Tensor> {
         bboxes_for_class.truncate(current_index);
     }
     // Annotate the original image and print boxes information.
-    let (_, initial_h, initial_w) = img.size3()?;
+    let (_, initial_h, initial_w) = img.size3();
     let mut img = img.to_kind(tch::Kind::Float) / 255.;
     let w_ratio = initial_w as f64 / w as f64;
     let h_ratio = initial_h as f64 / h as f64;

--- a/src/tensor/iter.rs
+++ b/src/tensor/iter.rs
@@ -12,7 +12,7 @@ impl Tensor {
     pub fn iter<T>(&self) -> Result<Iter<T>, TchError> {
         Ok(Iter {
             index: 0,
-            len: self.size1()?,
+            len: self.f_size1()?,
             content: self.shallow_clone(),
             phantom: std::marker::PhantomData,
         })

--- a/src/wrappers/tensor.rs
+++ b/src/wrappers/tensor.rs
@@ -42,7 +42,44 @@ impl Tensor {
     }
 
     /// Returns the tensor size for single dimension tensors.
-    pub fn size1(&self) -> Result<i64, TchError> {
+    /// Panics if the dimension count does not match.
+    pub fn size1(&self) -> i64 {
+        self.f_size1().unwrap()
+    }
+
+    /// Returns the tensor sizes for two dimension tensors.
+    /// Panics if the dimension count does not match.
+    pub fn size2(&self) -> (i64, i64) {
+        self.f_size2().unwrap()
+    }
+
+    /// Returns the tensor sizes for three dimension tensors.
+    /// Panics if the dimension count does not match.
+    pub fn size3(&self) -> (i64, i64, i64) {
+        self.f_size3().unwrap()
+    }
+
+    /// Returns the tensor sizes for four dimension tensors.
+    /// Panics if the dimension count does not match.
+    pub fn size4(&self) -> (i64, i64, i64, i64) {
+        self.f_size4().unwrap()
+    }
+
+    /// Returns the tensor sizes for five dimension tensors.
+    /// Panics if the dimension count does not match.
+    pub fn size5(&self) -> (i64, i64, i64, i64, i64) {
+        self.f_size5().unwrap()
+    }
+
+    /// Returns the tensor sizes for six dimension tensors.
+    /// Panics if the dimension count does not match.
+    pub fn size6(&self) -> (i64, i64, i64, i64, i64, i64) {
+        self.f_size6().unwrap()
+    }
+
+    /// Returns the tensor size for single dimension tensors.
+    /// Returns an error if the dimension count does not match.
+    pub fn f_size1(&self) -> Result<i64, TchError> {
         match self.size().as_slice() {
             &[s0] => Ok(s0),
             size => Err(TchError::Shape(format!("expected one dim, got {:?}", size))),
@@ -50,7 +87,8 @@ impl Tensor {
     }
 
     /// Returns the tensor sizes for two dimension tensors.
-    pub fn size2(&self) -> Result<(i64, i64), TchError> {
+    /// Returns an error if the dimension count does not match.
+    pub fn f_size2(&self) -> Result<(i64, i64), TchError> {
         match self.size().as_slice() {
             &[s0, s1] => Ok((s0, s1)),
             size => Err(TchError::Shape(format!(
@@ -61,7 +99,8 @@ impl Tensor {
     }
 
     /// Returns the tensor sizes for three dimension tensors.
-    pub fn size3(&self) -> Result<(i64, i64, i64), TchError> {
+    /// Returns an error if the dimension count does not match.
+    pub fn f_size3(&self) -> Result<(i64, i64, i64), TchError> {
         match self.size().as_slice() {
             &[s0, s1, s2] => Ok((s0, s1, s2)),
             size => Err(TchError::Shape(format!(
@@ -72,11 +111,36 @@ impl Tensor {
     }
 
     /// Returns the tensor sizes for four dimension tensors.
-    pub fn size4(&self) -> Result<(i64, i64, i64, i64), TchError> {
+    /// Returns an error if the dimension count does not match.
+    pub fn f_size4(&self) -> Result<(i64, i64, i64, i64), TchError> {
         match self.size().as_slice() {
             &[s0, s1, s2, s3] => Ok((s0, s1, s2, s3)),
             size => Err(TchError::Shape(format!(
                 "expected four dims, got {:?}",
+                size
+            ))),
+        }
+    }
+
+    /// Returns the tensor sizes for five dimension tensors.
+    /// Returns an error if the dimension count does not match.
+    pub fn f_size5(&self) -> Result<(i64, i64, i64, i64, i64), TchError> {
+        match self.size().as_slice() {
+            &[s0, s1, s2, s3, s4] => Ok((s0, s1, s2, s3, s4)),
+            size => Err(TchError::Shape(format!(
+                "expected five dims, got {:?}",
+                size
+            ))),
+        }
+    }
+
+    /// Returns the tensor sizes for six dimension tensors.
+    /// Returns an error if the dimension count does not match.
+    pub fn f_size6(&self) -> Result<(i64, i64, i64, i64, i64, i64), TchError> {
+        match self.size().as_slice() {
+            &[s0, s1, s2, s3, s4, s5] => Ok((s0, s1, s2, s3, s4, s5)),
+            size => Err(TchError::Shape(format!(
+                "expected six dims, got {:?}",
                 size
             ))),
         }


### PR DESCRIPTION
It follows the convensions to separate `sizeN` and `f_sizeN` methods, and extends to N up to 6. I found higher dimension count is needed when writing YOLO, for example `[batch_size, anchors, height, width, outputs]`.