### PR TITLE
Add the autocast function to run a closure in mixed-precision

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = ["torch-sys"]
 [features]
 python = ["cpython"]
 doc-only = ["torch-sys/doc-only"]
+autocast-tests = []
 
 [package.metadata.docs.rs]
 features = [ "doc-only" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,8 @@ pub use wrappers::{
 
 mod tensor;
 pub use tensor::{
-    index, no_grad, no_grad_guard, IndexOp, NewAxis, NoGradGuard, Reduction, Shape, Tensor,
-    TensorIndexer,
+    autocast, index, no_grad, no_grad_guard, IndexOp, NewAxis, NoGradGuard, Reduction, Shape,
+    Tensor, TensorIndexer,
 };
 
 pub mod nn;

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -9,7 +9,9 @@ pub mod index;
 mod iter;
 mod npy;
 
-pub use super::wrappers::tensor::{no_grad, no_grad_guard, NoGradGuard, Reduction, Tensor};
+pub use super::wrappers::tensor::{
+    autocast, no_grad, no_grad_guard, NoGradGuard, Reduction, Tensor,
+};
 pub use index::{IndexOp, NewAxis, TensorIndexer};
 
 macro_rules! impl_op {

--- a/tests/autocast.rs
+++ b/tests/autocast.rs
@@ -1,0 +1,22 @@
+#[cfg(test)]
+#[cfg(feature = "autocast-tests")]
+mod tests {
+    use tch::{autocast, Device, Kind, Tensor};
+
+    #[test]
+    fn autocast_narrows_type() {
+        let device = Device::Cuda(0);
+
+        let linear = Tensor::rand(&[10, 10], (Kind::Float, device));
+        let input = Tensor::rand(&[10], (Kind::Float, device));
+
+        autocast(true, || {
+            let output1 = autocast(false, || linear.matmul(&input));
+            assert_eq!(output1.kind(), Kind::Float);
+            let output2 = linear.matmul(&output1);
+            assert_eq!(output2.kind(), Kind::Half);
+            let output3 = autocast(false, || linear.matmul(&output1));
+            assert_eq!(output3.kind(), Kind::Float);
+        });
+    }
+}

--- a/torch-sys/libtch/torch_api.cpp
+++ b/torch-sys/libtch/torch_api.cpp
@@ -1,6 +1,7 @@
 #include<torch/csrc/autograd/engine.h>
 #include<torch/csrc/jit/runtime/graph_executor.h>
 #include<torch/torch.h>
+#include<ATen/autocast_mode.h>
 #include<torch/script.h>
 #include<stdexcept>
 #include<vector>
@@ -111,6 +112,40 @@ void at_shape(tensor t, int64_t *dims) {
 int at_scalar_type(tensor t) {
   PROTECT(
     return static_cast<int>(t->scalar_type());
+  )
+  return -1;
+}
+
+void at_autocast_clear_cache() {
+  at::autocast::clear_cache();
+}
+
+int at_autocast_decrement_nesting() {
+  PROTECT(
+    return at::autocast::decrement_nesting();
+  )
+  return -1;
+}
+
+int at_autocast_increment_nesting() {
+  PROTECT(
+    return at::autocast::increment_nesting();
+  )
+  return -1;
+}
+
+bool at_autocast_is_enabled() {
+  PROTECT(
+    return at::autocast::is_enabled();
+  )
+  return -1;
+}
+
+bool at_autocast_set_enabled(bool b) {
+  PROTECT(
+    bool is_enabled = at::autocast::is_enabled();
+    at::autocast::set_enabled(b);
+    return is_enabled;
   )
   return -1;
 }

--- a/torch-sys/libtch/torch_api.h
+++ b/torch-sys/libtch/torch_api.h
@@ -40,6 +40,13 @@ size_t at_dim(tensor);
 void at_shape(tensor, int64_t *);
 int at_scalar_type(tensor);
 
+
+void at_autocast_clear_cache();
+int at_autocast_decrement_nesting();
+int at_autocast_increment_nesting();
+bool at_autocast_is_enabled();
+bool at_autocast_set_enabled(bool b);
+
 void at_backward(tensor, int, int);
 int at_requires_grad(tensor);
 int at_grad_set_enabled(int);

--- a/torch-sys/src/lib.rs
+++ b/torch-sys/src/lib.rs
@@ -56,6 +56,11 @@ extern "C" {
         elt_size_in_bytes: size_t,
     );
     pub fn at_scalar_type(arg: *mut C_tensor) -> c_int;
+    pub fn at_autocast_clear_cache();
+    pub fn at_autocast_decrement_nesting() -> c_int;
+    pub fn at_autocast_increment_nesting() -> c_int;
+    pub fn at_autocast_is_enabled() -> c_int;
+    pub fn at_autocast_set_enabled(b: c_int) -> c_int;
     pub fn at_device(arg: *mut C_tensor) -> c_int;
     pub fn at_tensor_of_data(
         vs: *const c_void,


### PR DESCRIPTION
I have made this a draft PR, because I can't currently test this (all our GPUs that support mixed-precision have jobs running for multiple days). Also, I haven't added any unit tests, since actually testing this would require a CUDA-capable GPU.