### PR TITLE
Add stride and stride1 to stride6

### DIFF
--- a/src/wrappers/tensor.rs
+++ b/src/wrappers/tensor.rs
@@ -108,6 +108,77 @@ impl Tensor {
         }
     }
 
+    /// Returns the stride of the input tensor.
+    pub fn stride(&self) -> Vec<i64> {
+        let dim = unsafe_torch!(at_dim(self.c_tensor));
+        let mut sz = vec![0i64; dim];
+        unsafe_torch!(at_stride(self.c_tensor, sz.as_mut_ptr()));
+        sz
+    }
+
+    /// Returns the tensor strides for single dimension tensors.
+    pub fn stride1(&self) -> Result<i64, TchError> {
+        match self.stride().as_slice() {
+            &[s0] => Ok(s0),
+            size => Err(TchError::Shape(format!("expected one dim, got {:?}", size))),
+        }
+    }
+
+    /// Returns the tensor strides for two dimension tensors.
+    pub fn stride2(&self) -> Result<(i64, i64), TchError> {
+        match self.stride().as_slice() {
+            &[s0, s1] => Ok((s0, s1)),
+            size => Err(TchError::Shape(format!(
+                "expected two dims, got {:?}",
+                size
+            ))),
+        }
+    }
+
+    /// Returns the tensor strides for three dimension tensors.
+    pub fn stride3(&self) -> Result<(i64, i64, i64), TchError> {
+        match self.stride().as_slice() {
+            &[s0, s1, s2] => Ok((s0, s1, s2)),
+            size => Err(TchError::Shape(format!(
+                "expected three dims, got {:?}",
+                size
+            ))),
+        }
+    }
+
+    /// Returns the tensor strides for four dimension tensors.
+    pub fn stride4(&self) -> Result<(i64, i64, i64, i64), TchError> {
+        match self.stride().as_slice() {
+            &[s0, s1, s2, s3] => Ok((s0, s1, s2, s3)),
+            size => Err(TchError::Shape(format!(
+                "expected four dims, got {:?}",
+                size
+            ))),
+        }
+    }
+
+    /// Returns the tensor strides for five dimension tensors.
+    pub fn stride5(&self) -> Result<(i64, i64, i64, i64, i64), TchError> {
+        match self.stride().as_slice() {
+            &[s0, s1, s2, s3, s4] => Ok((s0, s1, s2, s3, s4)),
+            size => Err(TchError::Shape(format!(
+                "expected five dims, got {:?}",
+                size
+            ))),
+        }
+    }
+
+    /// Returns the tensor strides for six dimension tensors.
+    pub fn stride6(&self) -> Result<(i64, i64, i64, i64, i64, i64), TchError> {
+        match self.stride().as_slice() {
+            &[s0, s1, s2, s3, s4, s5] => Ok((s0, s1, s2, s3, s4, s5)),
+            size => Err(TchError::Shape(format!(
+                "expected six dims, got {:?}",
+                size
+            ))),
+        }
+    }
+
     /// Returns the kind of elements stored in the input tensor. Returns
     /// an error on undefined tensors and unsupported data types.
     pub fn f_kind(&self) -> Result<Kind, TchError> {

--- a/tests/tensor_tests.rs
+++ b/tests/tensor_tests.rs
@@ -403,3 +403,26 @@ fn argmax() {
     let argmax = tensor.argmax(-1, false);
     assert_eq!(Vec::<i64>::from(argmax), [0, 2],);
 }
+
+#[test]
+fn strides() {
+    fn check_stride(t: &Tensor) {
+        let shape = t.size();
+        let ndim = shape.len();
+        let mut c = 1;
+        let mut strides = vec![0i64; ndim];
+        strides[ndim - 1] = c;
+        for i in (1..ndim).rev() {
+            c *= shape[i];
+            strides[i - 1] = c;
+        }
+
+        assert_eq!(t.stride(), strides);
+    }
+
+    let tensor = Tensor::zeros(&[2, 3, 4], tch::kind::FLOAT_CPU);
+    check_stride(&tensor);
+
+    let tensor: Tensor = Tensor::ones(&[3, 4, 5, 6, 7, 8], tch::kind::FLOAT_CPU);
+    check_stride(&tensor);
+}

--- a/torch-sys/libtch/torch_api.cpp
+++ b/torch-sys/libtch/torch_api.cpp
@@ -109,6 +109,13 @@ void at_shape(tensor t, int64_t *dims) {
   )
 }
 
+void at_stride(tensor t, int64_t *dims) {
+  PROTECT(
+    int i = 0;
+    for (int64_t dim: t->strides()) dims[i++] = dim;
+  )
+}
+
 int at_scalar_type(tensor t) {
   PROTECT(
     return static_cast<int>(t->scalar_type());

--- a/torch-sys/libtch/torch_api.h
+++ b/torch-sys/libtch/torch_api.h
@@ -38,6 +38,7 @@ int at_is_sparse(tensor);
 int at_device(tensor);
 size_t at_dim(tensor);
 void at_shape(tensor, int64_t *);
+void at_stride(tensor, int64_t *);
 int at_scalar_type(tensor);
 
 

--- a/torch-sys/src/lib.rs
+++ b/torch-sys/src/lib.rs
@@ -33,6 +33,7 @@ extern "C" {
     pub fn at_get(arg: *mut C_tensor, index: c_int) -> *mut C_tensor;
     pub fn at_requires_grad(arg: *mut C_tensor) -> c_int;
     pub fn at_shape(arg: *mut C_tensor, sz: *mut i64);
+    pub fn at_stride(arg: *mut C_tensor, sz: *mut i64);
     pub fn at_double_value_at_indexes(arg: *mut C_tensor, idx: *const i64, idx_len: c_int) -> f64;
     pub fn at_int64_value_at_indexes(arg: *mut C_tensor, idx: *const i64, idx_len: c_int) -> i64;
     pub fn at_get_num_interop_threads() -> c_int;


### PR DESCRIPTION
`stride()` is essential for converting `Tensor` to other ndarrays, e.g. `dlpack`, `numpy`.

