### PR TITLE
Add the ToMKLDNN trait and implement it for Linear

### DIFF
--- a/src/nn/mod.rs
+++ b/src/nn/mod.rs
@@ -9,7 +9,7 @@ mod var_store;
 pub use var_store::{Path, VarStore, Variables};
 
 mod module;
-pub use module::{Module, ModuleT};
+pub use module::{Module, ModuleT, ToMKLDNN};
 
 mod linear;
 pub use linear::*;

--- a/src/nn/module.rs
+++ b/src/nn/module.rs
@@ -67,3 +67,9 @@ impl Tensor {
         }
     }
 }
+
+/// Modules that support processing by MKL-DNN/oneDNN.
+pub trait ToMKLDNN {
+    /// Convert a module to use MKL-DNN/oneDNN.
+    fn to_mkldnn(&self) -> Self;
+}


### PR DESCRIPTION
I am not sure if this functionality/interface fits the tch crate, but this attempts to make something close to

https://github.com/pytorch/pytorch/blob/master/torch/utils/mkldnn.py

Some people have reported large improvements with something as simple as converting all BERT linear layers to use MKL-DNN:

https://github.com/pytorch/pytorch/pull/21851

It's a bit annoying that these things are not automatically done, but MKL-DNN/oneDNN require different ordering of dimensions.

If this doesn't fit the `tch` crate, no big loss, I can just import it in my own projects ;).