### PR TITLE
Add Tensor::internal_amp_non_finite_check_and_unscale

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ members = ["torch-sys"]
 [features]
 python = ["cpython"]
 doc-only = ["torch-sys/doc-only"]
-autocast-tests = []
+cuda-tests = []
 
 [package.metadata.docs.rs]
 features = [ "doc-only" ]

--- a/src/wrappers/tensor.rs
+++ b/src/wrappers/tensor.rs
@@ -339,6 +339,41 @@ impl Tensor {
         Ok(())
     }
 
+    /// Unscale tensor while checking for infinities.
+    ///
+    /// `found_inf` is a singleton tensor that is used to record the
+    /// precense of infinite values. `inv` is a singleton containing
+    /// the inverse scaling factor. This method is only available
+    /// for CUDA tensors.
+    pub fn f_internal_amp_non_finite_check_and_unscale(
+        &mut self,
+        found_inf: &mut Tensor,
+        inv_scale: &Tensor,
+    ) -> Result<(), TchError> {
+        unsafe_torch_err!(at__amp_non_finite_check_and_unscale(
+            self.c_tensor,
+            found_inf.c_tensor,
+            inv_scale.c_tensor
+        ));
+
+        Ok(())
+    }
+
+    /// Unscale tensor while checking for infinities.
+    ///
+    /// `found_inf` is a singleton tensor that is used to record the
+    /// precense of infinite values. `inv` is a singleton containing
+    /// the inverse scaling factor. This method is only available
+    /// for CUDA tensors.
+    pub fn internal_amp_non_finite_check_and_unscale(
+        &mut self,
+        found_inf: &mut Tensor,
+        inv_scale: &Tensor,
+    ) {
+        self.f_internal_amp_non_finite_check_and_unscale(found_inf, inv_scale)
+            .unwrap()
+    }
+
     /// Copies `numel` elements from `self` to `dst`.
     pub fn copy_data_u8(&self, dst: &mut [u8], numel: usize) {
         self.f_copy_data_u8(dst, numel).unwrap()

--- a/src/wrappers/tensor.rs
+++ b/src/wrappers/tensor.rs
@@ -342,7 +342,7 @@ impl Tensor {
     /// Unscale tensor while checking for infinities.
     ///
     /// `found_inf` is a singleton tensor that is used to record the
-    /// precense of infinite values. `inv` is a singleton containing
+    /// presence of infinite values. `inv_scale` is a scalar containing
     /// the inverse scaling factor. This method is only available
     /// for CUDA tensors.
     pub fn f_internal_amp_non_finite_check_and_unscale(
@@ -362,7 +362,7 @@ impl Tensor {
     /// Unscale tensor while checking for infinities.
     ///
     /// `found_inf` is a singleton tensor that is used to record the
-    /// precense of infinite values. `inv` is a singleton containing
+    /// presence of infinite values. `inv_scale` is a scalar containing
     /// the inverse scaling factor. This method is only available
     /// for CUDA tensors.
     pub fn internal_amp_non_finite_check_and_unscale(

--- a/tests/autocast.rs
+++ b/tests/autocast.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-#[cfg(feature = "autocast-tests")]
+#[cfg(feature = "cuda-tests")]
 mod tests {
     use tch::{autocast, Device, Kind, Tensor};
 

--- a/torch-sys/libtch/torch_api.cpp
+++ b/torch-sys/libtch/torch_api.cpp
@@ -128,6 +128,12 @@ int at_scalar_type(tensor t) {
   return -1;
 }
 
+void at__amp_non_finite_check_and_unscale(tensor t, tensor found_inf, tensor inf_scale) {
+  PROTECT(
+    at::_amp_non_finite_check_and_unscale_(*t, *found_inf, *inf_scale);
+  )
+}
+
 void at_autocast_clear_cache() {
   at::autocast::clear_cache();
 }

--- a/torch-sys/libtch/torch_api.h
+++ b/torch-sys/libtch/torch_api.h
@@ -42,6 +42,7 @@ void at_shape(tensor, int64_t *);
 void at_stride(tensor, int64_t *);
 int at_scalar_type(tensor);
 
+void at__amp_non_finite_check_and_unscale(tensor, tensor, tensor);
 
 void at_autocast_clear_cache();
 int at_autocast_decrement_nesting();

--- a/torch-sys/src/lib.rs
+++ b/torch-sys/src/lib.rs
@@ -58,6 +58,11 @@ extern "C" {
         elt_size_in_bytes: size_t,
     );
     pub fn at_scalar_type(arg: *mut C_tensor) -> c_int;
+    pub fn at__amp_non_finite_check_and_unscale(
+        t: *mut C_tensor,
+        found_inf: *mut C_tensor,
+        inf_scale: *mut C_tensor,
+    );
     pub fn at_autocast_clear_cache();
     pub fn at_autocast_decrement_nesting() -> c_int;
     pub fn at_autocast_increment_nesting() -> c_int;


### PR DESCRIPTION
This function unscales a tensor and at the same time checks for
infinities.

This is one of the methods needed to implement gradient scaling for
auto mixed precision.