### PR TITLE
Add support for parameter groups

### DIFF
--- a/examples/custom-optimizer/sparse_adam.rs
+++ b/examples/custom-optimizer/sparse_adam.rs
@@ -58,7 +58,7 @@ impl SparseAdam {
             .lock()
             .unwrap()
             .trainable_variables
-            .iter()
+            .values()
             .map(|x| Buffer::new(&x.size()))
             .collect();
 
@@ -82,7 +82,7 @@ impl SparseAdam {
         let mut vars = self.vars.lock().unwrap();
 
         // iterate through all trainable variables
-        for (tensor, buffer) in vars.trainable_variables.iter_mut().zip(&mut self.buffers) {
+        for (tensor, buffer) in vars.trainable_variables.values_mut().zip(&mut self.buffers) {
             let mut grad = tensor.grad();
 
             // calculate both bias correction values
@@ -152,7 +152,7 @@ impl SparseAdam {
     // zero the gradient of all trainable variables
     pub fn zero_grad(&mut self) {
         let mut vars = self.vars.lock().unwrap();
-        for var in &mut vars.trainable_variables {
+        for var in &mut vars.trainable_variables.values_mut() {
             var.zero_grad();
         }
     }

--- a/torch-sys/libtch/torch_api.h
+++ b/torch-sys/libtch/torch_api.h
@@ -119,9 +119,12 @@ optimizer ato_sgd(double learning_rate,
                   double dampening,
                   double weight_decay,
                   int nesterov);
-void ato_add_parameters(optimizer, tensor *, int ntensors);
+void ato_add_parameters(optimizer, size_t, tensor *, int ntensors);
+void ato_ensure_n_parameter_groups(optimizer t, size_t n_groups);
 void ato_set_learning_rate(optimizer, double learning_rate);
+void ato_set_learning_rate_group(optimizer, size_t group, double learning_rate);
 void ato_set_momentum(optimizer, double momentum);
+void ato_set_momentum_group(optimizer, size_t group, double momentum);
 void ato_zero_grad(optimizer);
 void ato_step(optimizer);
 void ato_free(optimizer);

--- a/torch-sys/src/lib.rs
+++ b/torch-sys/src/lib.rs
@@ -136,9 +136,17 @@ extern "C" {
         wd: f64,
         nesterov: c_int,
     ) -> *mut C_optimizer;
-    pub fn ato_add_parameters(arg: *mut C_optimizer, ts: *const *mut C_tensor, n: c_int);
+    pub fn ato_add_parameters(
+        arg: *mut C_optimizer,
+        group: size_t,
+        ts: *const *mut C_tensor,
+        n: c_int,
+    );
+    pub fn ato_ensure_n_parameter_groups(arg: *mut C_optimizer, n_groups: size_t);
     pub fn ato_set_learning_rate(arg: *mut C_optimizer, lr: f64);
+    pub fn ato_set_learning_rate_group(arg: *mut C_optimizer, group: size_t, lr: f64);
     pub fn ato_set_momentum(arg: *mut C_optimizer, momentum: f64);
+    pub fn ato_set_momentum_group(arg: *mut C_optimizer, group: size_t, momentum: f64);
     pub fn ato_zero_grad(arg: *mut C_optimizer);
     pub fn ato_step(arg: *mut C_optimizer);
     pub fn ato_free(arg: *mut C_optimizer);


### PR DESCRIPTION
I have been working on support for discriminative learning rates in
optimizers, as e.g. PyTorch supports. Before polishing a bit more and
perhaps adding tests, I wanted to ask if you would be interested in
supporting discriminative learning rates, and if the proposed API
would be ok for you.

The commit message follows ;).

---

The tch crate places all parameters in the same group. This simplifies
construction of optimizers, however it does not allow training models
with discriminative learning rates as is e.g. common in finetuning
pretrained transformers such as BERT.

This change adds support for training with discriminative learning
rates. In order to do so, `OptimizerConfig` provides an extra
constructor, `build_with_groups`. Compared to the existing `build`
contructor, `build_with_groups` allows the caller to provide a
closure that partitions variables (by name) into parameter groups.
For example:

```rust
adam.build_with_groups(&vs, lr, |var_name| {
  if var_name.starts_with("classifier") {
    PARAMETER_GROUP_CLASSIFIER
  } else if var_name.starts_with("encoder") {
    PARAMETER_GROUP_ENCODER
  } else { unimplemented!() }
});
```

This can then later be used to set the learning rate per group.  For
example:

```rust
optimizer.set_lr_group(PARAMETER_GROUP_CLASSIFIER, classifier_lr);
```

In order to support group partitioning, `trainable_parameters` of
`VarStore` had to be changed into a `HashMap`, so that the names of
trainable parameters are known.