### PR TITLE
Add examples on tensor index/put

### DIFF
--- a/tests/tensor_indexing.rs
+++ b/tests/tensor_indexing.rs
@@ -125,3 +125,44 @@ fn index_3d() {
     assert_eq!(Vec::<i64>::from(tensor.i((1, 0, 0))), &[12]);
     assert_eq!(Vec::<i64>::from(tensor.i((0..2, 0, 0))), &[0, 12]);
 }
+
+#[test]
+fn tensor_index() {
+    let t = Tensor::arange(6, (Kind::Int64, Device::Cpu)).view((2, 3));
+    let rows_select = Tensor::of_slice(&[0i64, 1, 0]);
+    let column_select = Tensor::of_slice(&[1i64, 2, 2]);
+
+    let selected = t.index(&[rows_select, column_select]);
+    assert_eq!(selected.size(), &[3]);
+    assert_eq!(Vec::<i64>::from(selected), &[1, 5, 2]);
+}
+
+#[test]
+fn tensor_multi_index() {
+    let t = Tensor::arange(6, (Kind::Int64, Device::Cpu)).view((2, 3));
+    
+    let select_1 = Tensor::of_slice(&[0i64, 1, 0]);
+    let select_2 = Tensor::of_slice(&[1i64, 0, 0]);
+    let select_final = Tensor::stack(&[select_1, select_2], 0);
+    assert_eq!(select_final.size(), &[2, 3]);
+
+    let selected = t.index(&[select_final]); // index only rows
+    assert_eq!(selected.size(), &[2, 3, 3]);
+    assert_eq!(Vec::<i64>::from(selected), &[0, 1, 2, 
+                                            3, 4, 5, 
+                                            0, 1, 2, 
+                                            3, 4, 5, 
+                                            0, 1, 2, 
+                                            0, 1, 2]); // after flattening
+}
+
+#[test]
+fn tensor_put() {
+    let t = Tensor::arange(6, (Kind::Int64, Device::Cpu)).view((2, 3));
+    let rows_select = Tensor::of_slice(&[0i64, 1, 0]);
+    let column_select = Tensor::of_slice(&[1i64, 2, 2]);
+    let values = Tensor::of_slice(&[10i64, 12, 24]);
+
+    let updated = t.index_put(&[rows_select, column_select], &values, false);
+    assert_eq!(Vec::<i64>::from(updated), &[0i64, 10, 24, 3, 4, 12]); // after flattening
+}


### PR DESCRIPTION
Could not find previously needed examples of tensor index/put operations in provided tests/examples, thus created own tests for demonstration purposes.