### PR TITLE
Param group

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tch"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Laurent Mazare <lmazare@gmail.com>"]
 edition = "2018"
 
@@ -17,7 +17,7 @@ libc = "0.2.0"
 ndarray = "0.13"
 rand = "0.7"
 thiserror = "1"
-torch-sys = { version = "0.2.1", path = "torch-sys" }
+torch-sys = { version = "0.2.2", path = "torch-sys" }
 zip = "0.5"
 half = "1.6"
 

--- a/src/nn/optimizer.rs
+++ b/src/nn/optimizer.rs
@@ -235,4 +235,14 @@ impl<T> Optimizer<T> {
     pub fn set_momentum(&mut self, m: f64) {
         self.opt.set_momentum(m).unwrap()
     }
+
+    /// Sets the optimizer learning rate for a parameter group.
+    pub fn set_lr_group(&mut self, group: usize, lr: f64) {
+        self.opt.set_learning_rate_group(group, lr).unwrap()
+    }
+
+    /// Sets the optimizer momentum.
+    pub fn set_momentum_group(&mut self, group: usize, m: f64) {
+        self.opt.set_momentum_group(group, m).unwrap()
+    }
 }

--- a/src/nn/var_store.rs
+++ b/src/nn/var_store.rs
@@ -9,13 +9,19 @@ use std::sync::{Arc, Mutex, MutexGuard};
 /// The separator is used to separate path elements in the tensor names.
 const SEP: char = '.';
 
+#[derive(Debug)]
+pub struct Var {
+    pub tensor: Tensor,
+    pub group: usize,
+}
+
 // When the variable store is frozen, the trainable_variables vector
 // still contains the same tensors however these tensors are set not
 // to require gradients.
 #[derive(Debug)]
 pub struct Variables {
     pub named_variables: HashMap<String, Tensor>,
-    pub trainable_variables: Vec<Tensor>,
+    pub trainable_variables: Vec<Var>,
 }
 
 /// A VarStore is used to store variables used by one or multiple layers.
@@ -78,7 +84,7 @@ impl VarStore {
         variables
             .trainable_variables
             .iter()
-            .map(|v| v.shallow_clone())
+            .map(|v| v.tensor.shallow_clone())
             .collect()
     }
 
@@ -174,7 +180,7 @@ impl VarStore {
     pub fn freeze(&mut self) {
         let variables = self.variables_.lock().unwrap();
         for variable in variables.trainable_variables.iter() {
-            let _v = variable.set_requires_grad(false);
+            let _v = variable.tensor.set_requires_grad(false);
         }
     }
 
@@ -184,7 +190,7 @@ impl VarStore {
     pub fn unfreeze(&mut self) {
         let variables = self.variables_.lock().unwrap();
         for variable in variables.trainable_variables.iter() {
-            let _v = variable.set_requires_grad(true);
+            let _v = variable.tensor.set_requires_grad(true);
         }
     }
 
@@ -257,7 +263,11 @@ impl<'a> Path<'a> {
             tensor
         };
         if trainable {
-            variables.trainable_variables.push(tensor.shallow_clone());
+            let var = Var {
+                tensor: tensor.shallow_clone(),
+                group: 0,
+            };
+            variables.trainable_variables.push(var);
         };
         variables
             .named_variables
@@ -283,7 +293,11 @@ impl<'a> Path<'a> {
             tensor
         };
         if trainable {
-            variables.trainable_variables.push(tensor.shallow_clone());
+            let var = Var {
+                tensor: tensor.shallow_clone(),
+                group: 0,
+            };
+            variables.trainable_variables.push(var);
         }
         variables
             .named_variables

--- a/src/wrappers/optimizer.rs
+++ b/src/wrappers/optimizer.rs
@@ -54,10 +54,9 @@ impl COptimizer {
         Ok(COptimizer { c_optimizer })
     }
 
-    pub fn add_parameters(&mut self, ts: &[Tensor]) -> Result<(), TchError> {
-        let ts: Vec<_> = ts.iter().map(|x| x.c_tensor).collect();
+    pub fn add_parameters(&mut self, t: &Tensor, group: usize) -> Result<(), TchError> {
         unsafe_torch_err!({
-            torch_sys::ato_add_parameters(self.c_optimizer, ts.as_ptr(), ts.len() as c_int)
+            torch_sys::ato_add_parameters(self.c_optimizer, t.c_tensor, group as c_int)
         });
         Ok(())
     }

--- a/src/wrappers/optimizer.rs
+++ b/src/wrappers/optimizer.rs
@@ -1,6 +1,5 @@
 use super::tensor::Tensor;
 use crate::TchError;
-use libc::c_int;
 
 pub struct COptimizer {
     c_optimizer: *mut torch_sys::C_optimizer,
@@ -55,9 +54,7 @@ impl COptimizer {
     }
 
     pub fn add_parameters(&mut self, t: &Tensor, group: usize) -> Result<(), TchError> {
-        unsafe_torch_err!({
-            torch_sys::ato_add_parameters(self.c_optimizer, t.c_tensor, group as c_int)
-        });
+        unsafe_torch_err!({ torch_sys::ato_add_parameters(self.c_optimizer, t.c_tensor, group) });
         Ok(())
     }
 
@@ -66,8 +63,26 @@ impl COptimizer {
         Ok(())
     }
 
+    pub fn set_learning_rate_group(&mut self, group: usize, lr: f64) -> Result<(), TchError> {
+        unsafe_torch_err!(torch_sys::ato_set_learning_rate_group(
+            self.c_optimizer,
+            group,
+            lr
+        ));
+        Ok(())
+    }
+
     pub fn set_momentum(&mut self, m: f64) -> Result<(), TchError> {
         unsafe_torch_err!(torch_sys::ato_set_momentum(self.c_optimizer, m));
+        Ok(())
+    }
+
+    pub fn set_momentum_group(&mut self, group: usize, m: f64) -> Result<(), TchError> {
+        unsafe_torch_err!(torch_sys::ato_set_momentum_group(
+            self.c_optimizer,
+            group,
+            m
+        ));
         Ok(())
     }
 

--- a/torch-sys/Cargo.toml
+++ b/torch-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "torch-sys"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Laurent Mazare <lmazare@gmail.com>"]
 edition = "2018"
 build = "build.rs"

--- a/torch-sys/libtch/torch_api.cpp
+++ b/torch-sys/libtch/torch_api.cpp
@@ -521,10 +521,13 @@ optimizer ato_sgd(double learning_rate,
   return nullptr;
 }
 
-void ato_add_parameters(optimizer t, tensor *tensors, int ntensors) {
+void ato_add_parameters(optimizer t, tensor tensor, int group) {
   PROTECT(
-    for (int i = 0; i < ntensors; ++i)
-      t->param_groups()[0].params().push_back(*(tensors[i]));
+    auto &groups = t->param_groups();
+    while (groups.size() <= group) {
+      groups.push_back(torch::optim::OptimizerParamGroup({}, t->defaults().clone()));
+    }
+    groups[group].params().push_back(*tensor);
   )
 }
 

--- a/torch-sys/libtch/torch_api.h
+++ b/torch-sys/libtch/torch_api.h
@@ -119,9 +119,11 @@ optimizer ato_sgd(double learning_rate,
                   double dampening,
                   double weight_decay,
                   int nesterov);
-void ato_add_parameters(optimizer, tensor, int group);
+void ato_add_parameters(optimizer, tensor, size_t group);
 void ato_set_learning_rate(optimizer, double learning_rate);
 void ato_set_momentum(optimizer, double momentum);
+void ato_set_learning_rate_group(optimizer, size_t group, double learning_rate);
+void ato_set_momentum_group(optimizer, size_t group, double momentum);
 void ato_zero_grad(optimizer);
 void ato_step(optimizer);
 void ato_free(optimizer);

--- a/torch-sys/libtch/torch_api.h
+++ b/torch-sys/libtch/torch_api.h
@@ -119,7 +119,7 @@ optimizer ato_sgd(double learning_rate,
                   double dampening,
                   double weight_decay,
                   int nesterov);
-void ato_add_parameters(optimizer, tensor *, int ntensors);
+void ato_add_parameters(optimizer, tensor, int group);
 void ato_set_learning_rate(optimizer, double learning_rate);
 void ato_set_momentum(optimizer, double momentum);
 void ato_zero_grad(optimizer);

--- a/torch-sys/src/lib.rs
+++ b/torch-sys/src/lib.rs
@@ -136,9 +136,11 @@ extern "C" {
         wd: f64,
         nesterov: c_int,
     ) -> *mut C_optimizer;
-    pub fn ato_add_parameters(arg: *mut C_optimizer, ts: *mut C_tensor, group: c_int);
+    pub fn ato_add_parameters(arg: *mut C_optimizer, ts: *mut C_tensor, group: size_t);
     pub fn ato_set_learning_rate(arg: *mut C_optimizer, lr: f64);
+    pub fn ato_set_learning_rate_group(arg: *mut C_optimizer, group: size_t, lr: f64);
     pub fn ato_set_momentum(arg: *mut C_optimizer, momentum: f64);
+    pub fn ato_set_momentum_group(arg: *mut C_optimizer, group: size_t, momentum: f64);
     pub fn ato_zero_grad(arg: *mut C_optimizer);
     pub fn ato_step(arg: *mut C_optimizer);
     pub fn ato_free(arg: *mut C_optimizer);

--- a/torch-sys/src/lib.rs
+++ b/torch-sys/src/lib.rs
@@ -136,7 +136,7 @@ extern "C" {
         wd: f64,
         nesterov: c_int,
     ) -> *mut C_optimizer;
-    pub fn ato_add_parameters(arg: *mut C_optimizer, ts: *const *mut C_tensor, n: c_int);
+    pub fn ato_add_parameters(arg: *mut C_optimizer, ts: *mut C_tensor, group: c_int);
     pub fn ato_set_learning_rate(arg: *mut C_optimizer, lr: f64);
     pub fn ato_set_momentum(arg: *mut C_optimizer, momentum: f64);
     pub fn ato_zero_grad(arg: *mut C_optimizer);


### PR DESCRIPTION
Add some parameter group support, similar to #257 .
When adding new parameters, a group can be chosen, this is done by tweaking the path as illustrated in the following example.
```rust
    let vs = VarStore::new(Device::Cpu);
    let root = vs.root();
    let foo = root.set_group(0).zeros("foo", &[]);
    let bar = root.set_group(7).zeros("bar", &[]);
```
(this actually comes from the test added to the PR)

Then the learning rate for group 7 to 0.1 can be done using the following.
```rust
  opt.set_lr_group(7, 0.1);
```