### PR TITLE
Add Path::components, which returns an iterator over the path components

### DIFF
--- a/src/nn/var_store.rs
+++ b/src/nn/var_store.rs
@@ -221,6 +221,11 @@ impl VarStore {
 }
 
 impl<'a> Path<'a> {
+    /// Get the components of the path.
+    pub fn components(&self) -> impl Iterator<Item = &str> {
+        self.path.iter().map(String::as_str)
+    }
+
     /// Gets a sub-path of the given path.
     pub fn sub<T: std::string::ToString>(&'a self, s: T) -> Path<'a> {
         let s = s.to_string();

--- a/tests/var_store.rs
+++ b/tests/var_store.rs
@@ -3,6 +3,15 @@ use tch::nn::OptimizerConfig;
 use tch::{nn::Init, nn::VarStore, Device, Kind, Tensor};
 
 #[test]
+fn path_components() {
+    let vs = VarStore::new(Device::Cpu);
+    let root = vs.root();
+    let path = root.sub("a");
+    let path = path.sub("test");
+    assert_eq!(path.components().collect::<Vec<_>>(), vec!["a", "test"]);
+}
+
+#[test]
 fn var_store_entry() {
     let vs = VarStore::new(Device::Cpu);
     let root = vs.root();


### PR DESCRIPTION
I have been implementing an extension to `Path` to assign groups by
name as proposed in #257. However, in order to do so, I need access to
the path components.

This function returns an iterator over the components (similar to
`std::path::Path`), though returning `&[String]` is also an option.
Though returning an iterator should make it easier to change internals
without changing the API in the future.
