### PR TITLE
Add Optimizer::set_weight_decay(_group)?

### DIFF
--- a/src/nn/optimizer.rs
+++ b/src/nn/optimizer.rs
@@ -245,4 +245,16 @@ impl<T> Optimizer<T> {
     pub fn set_momentum_group(&mut self, group: usize, m: f64) {
         self.opt.set_momentum_group(group, m).unwrap()
     }
+
+    /// Sets the optimizer weight decay.
+    pub fn set_weight_decay(&mut self, weight_decay: f64) {
+        self.opt.set_weight_decay(weight_decay).unwrap()
+    }
+
+    /// Sets the optimizer weight decay.
+    pub fn set_weight_decay_group(&mut self, group: usize, weight_decay: f64) {
+        self.opt
+            .set_weight_decay_group(group, weight_decay)
+            .unwrap()
+    }
 }

--- a/src/wrappers/optimizer.rs
+++ b/src/wrappers/optimizer.rs
@@ -54,7 +54,11 @@ impl COptimizer {
     }
 
     pub fn add_parameters(&mut self, t: &Tensor, group: usize) -> Result<(), TchError> {
-        unsafe_torch_err!({ torch_sys::ato_add_parameters(self.c_optimizer, t.c_tensor, group) });
+        unsafe_torch_err!(torch_sys::ato_add_parameters(
+            self.c_optimizer,
+            t.c_tensor,
+            group
+        ));
         Ok(())
     }
 
@@ -82,6 +86,27 @@ impl COptimizer {
             self.c_optimizer,
             group,
             m
+        ));
+        Ok(())
+    }
+
+    pub fn set_weight_decay(&mut self, weight_decay: f64) -> Result<(), TchError> {
+        unsafe_torch_err!(torch_sys::ato_set_weight_decay(
+            self.c_optimizer,
+            weight_decay
+        ));
+        Ok(())
+    }
+
+    pub fn set_weight_decay_group(
+        &mut self,
+        group: usize,
+        weight_decay: f64,
+    ) -> Result<(), TchError> {
+        unsafe_torch_err!(torch_sys::ato_set_weight_decay_group(
+            self.c_optimizer,
+            group,
+            weight_decay
         ));
         Ok(())
     }

--- a/torch-sys/libtch/torch_api.cpp
+++ b/torch-sys/libtch/torch_api.cpp
@@ -674,6 +674,76 @@ void ato_set_momentum_group(optimizer t, size_t group, double momentum) {
     )
 }
 
+void ato_set_weight_decay(optimizer t, double weight_decay) {
+    PROTECT(
+            torch::optim::OptimizerOptions* d = &(t->defaults());
+    if (auto adam = dynamic_cast<torch::optim::AdamOptions*>(d)) {
+        adam->weight_decay(weight_decay);
+        for (auto &param_group: t->param_groups()) {
+            torch::optim::OptimizerOptions* d = &(param_group.options());
+            if (auto adam2 = dynamic_cast<torch::optim::AdamOptions*>(d)) {
+                adam2->weight_decay(weight_decay);
+            }
+            else throw std::invalid_argument("unexpected param group type");
+        }
+    }
+    else if (auto adamw = dynamic_cast<torch::optim::AdamWOptions*>(d)) {
+        adamw->weight_decay(weight_decay);
+        for (auto &param_group: t->param_groups()) {
+            torch::optim::OptimizerOptions* d = &(param_group.options());
+            if (auto adamw2 = dynamic_cast<torch::optim::AdamWOptions*>(d)) {
+                adamw2->weight_decay(weight_decay);
+            }
+            else throw std::invalid_argument("unexpected param group type");
+        }
+    }
+    else if (auto rms = dynamic_cast<torch::optim::RMSpropOptions*>(d)) {
+        rms->weight_decay(weight_decay);
+        for (auto &param_group: t->param_groups()) {
+            torch::optim::OptimizerOptions* d = &(param_group.options());
+            if (auto rms2 = dynamic_cast<torch::optim::RMSpropOptions*>(d)) {
+                rms2->weight_decay(weight_decay);
+            }
+            else throw std::invalid_argument("unexpected param group type");
+        }
+    }
+    else if (auto sgd = dynamic_cast<torch::optim::SGDOptions*>(d)) {
+        sgd->weight_decay(weight_decay);
+        for (auto &param_group: t->param_groups()) {
+            torch::optim::OptimizerOptions* d = &(param_group.options());
+            if (auto sgd2 = dynamic_cast<torch::optim::SGDOptions*>(d)) {
+                sgd2->weight_decay(weight_decay);
+            }
+            else throw std::invalid_argument("unexpected param group type");
+        }
+    }
+    else
+        throw std::invalid_argument("unexpected optimizer");
+    )
+}
+
+void ato_set_weight_decay_group(optimizer t, size_t group, double weight_decay) {
+    PROTECT(
+            auto &param_group = t->param_groups().at(group);
+    torch::optim::OptimizerOptions* d = &(param_group.options());
+
+    if (auto adam = dynamic_cast<torch::optim::AdamOptions*>(d)) {
+        adam->weight_decay(weight_decay);
+    }
+    else if (auto adamw = dynamic_cast<torch::optim::AdamWOptions*>(d)) {
+        adamw->weight_decay(weight_decay);
+    }
+    else if (auto rms = dynamic_cast<torch::optim::RMSpropOptions*>(d)) {
+        rms->weight_decay(weight_decay);
+    }
+    else if (auto sgd = dynamic_cast<torch::optim::SGDOptions*>(d)) {
+        sgd->weight_decay(weight_decay);
+    }
+    else
+        throw std::invalid_argument("unexpected optimizer");
+    )
+}
+
 void ato_zero_grad(optimizer t) {
   PROTECT(t->zero_grad();)
 }

--- a/torch-sys/libtch/torch_api.h
+++ b/torch-sys/libtch/torch_api.h
@@ -124,6 +124,8 @@ void ato_set_learning_rate(optimizer, double learning_rate);
 void ato_set_momentum(optimizer, double momentum);
 void ato_set_learning_rate_group(optimizer, size_t group, double learning_rate);
 void ato_set_momentum_group(optimizer, size_t group, double momentum);
+void ato_set_weight_decay(optimizer t, double weight_decay);
+void ato_set_weight_decay_group(optimizer t, size_t group, double weight_decay);
 void ato_zero_grad(optimizer);
 void ato_step(optimizer);
 void ato_free(optimizer);

--- a/torch-sys/src/lib.rs
+++ b/torch-sys/src/lib.rs
@@ -141,6 +141,8 @@ extern "C" {
     pub fn ato_set_learning_rate_group(arg: *mut C_optimizer, group: size_t, lr: f64);
     pub fn ato_set_momentum(arg: *mut C_optimizer, momentum: f64);
     pub fn ato_set_momentum_group(arg: *mut C_optimizer, group: size_t, momentum: f64);
+    pub fn ato_set_weight_decay(arg: *mut C_optimizer, weight_decay: f64);
+    pub fn ato_set_weight_decay_group(arg: *mut C_optimizer, group: size_t, weight_decay: f64);
     pub fn ato_zero_grad(arg: *mut C_optimizer);
     pub fn ato_step(arg: *mut C_optimizer);
     pub fn ato_free(arg: *mut C_optimizer);


### PR DESCRIPTION
This makes it possible to set the weight decay per group, which is
useful to exclude e.g. layer normalization from weight decay.
