### PR TITLE
Support externally created tensors

### DIFF
--- a/src/wrappers/tensor.rs
+++ b/src/wrappers/tensor.rs
@@ -451,7 +451,7 @@ impl Tensor {
     /// Creates a tensor from data that is assumed to be initialized.
     /// Resize operations are now allowed on this tensor without copying the data first.
     /// # Safety
-    ///   This will panic if `data` is points to invalid data.
+    ///   This will panic if `data` points to invalid data.
     pub unsafe fn f_of_blob(
         data: *const u8,
         size: &[i64],
@@ -475,7 +475,7 @@ impl Tensor {
     /// Creates a tensor from data that is assumed to be initialized.
     /// Resize operations are now allowed on this tensor without copying the data first.
     /// # Safety
-    ///   This will panic if `data` is points to invalid data.
+    ///   This will panic if `data` points to invalid data.
     pub unsafe fn of_blob(
         data: *const u8,
         size: &[i64],

--- a/src/wrappers/tensor.rs
+++ b/src/wrappers/tensor.rs
@@ -450,7 +450,9 @@ impl Tensor {
 
     /// Creates a tensor from data that is assumed to be initialized.
     /// Resize operations are now allowed on this tensor without copying the data first.
-    pub fn f_of_blob(
+    /// # Safety
+    ///   This will panic if `data` is points to invalid data.
+    pub unsafe fn f_of_blob(
         data: *const u8,
         size: &[i64],
         strides: &[i64],
@@ -472,6 +474,8 @@ impl Tensor {
 
     /// Creates a tensor from data that is assumed to be initialized.
     /// Resize operations are now allowed on this tensor without copying the data first.
+    /// # Safety
+    ///   This will panic if `data` is points to invalid data.
     pub unsafe fn of_blob(
         data: *const u8,
         size: &[i64],

--- a/src/wrappers/tensor.rs
+++ b/src/wrappers/tensor.rs
@@ -450,12 +450,20 @@ impl Tensor {
 
     /// Creates a tensor from data that is assumed to be initialized.
     /// Resize operations are now allowed on this tensor without copying the data first.
-    pub fn f_of_blob(data: *const u8, size: &[i64], kind: Kind, device: Device) -> Result<Tensor, TchError> {
+    pub fn f_of_blob(
+        data: *const u8,
+        size: &[i64],
+        strides: &[i64],
+        kind: Kind,
+        device: Device,
+    ) -> Result<Tensor, TchError> {
         let data = data as *const c_void;
         let c_tensor = unsafe_torch_err!(at_tensor_of_blob(
             data,
             size.as_ptr(),
             size.len(),
+            strides.as_ptr(),
+            strides.len(),
             kind.c_int(),
             device.c_int()
         ));
@@ -464,8 +472,14 @@ impl Tensor {
 
     /// Creates a tensor from data that is assumed to be initialized.
     /// Resize operations are now allowed on this tensor without copying the data first.
-    pub unsafe fn of_blob(data: *const u8, size: &[i64], kind: Kind, device: Device) -> Tensor {
-        Self::f_of_blob(data, size, kind, device).unwrap()
+    pub unsafe fn of_blob(
+        data: *const u8,
+        size: &[i64],
+        strides: &[i64],
+        kind: Kind,
+        device: Device,
+    ) -> Tensor {
+        Self::f_of_blob(data, size, strides, kind, device).unwrap()
     }
 
     /// Converts some byte data to a tensor with some specified kind and shape.

--- a/src/wrappers/tensor.rs
+++ b/src/wrappers/tensor.rs
@@ -448,6 +448,26 @@ impl Tensor {
         Ok(Tensor { c_tensor })
     }
 
+    /// Creates a tensor from data that is assumed to be initialized.
+    /// Resize operations are now allowed on this tensor without copying the data first.
+    pub fn f_of_blob(data: *const u8, size: &[i64], kind: Kind, device: Device) -> Result<Tensor, TchError> {
+        let data = data as *const c_void;
+        let c_tensor = unsafe_torch_err!(at_tensor_of_blob(
+            data,
+            size.as_ptr(),
+            size.len(),
+            kind.c_int(),
+            device.c_int()
+        ));
+        Ok(Tensor { c_tensor })
+    }
+
+    /// Creates a tensor from data that is assumed to be initialized.
+    /// Resize operations are now allowed on this tensor without copying the data first.
+    pub unsafe fn of_blob(data: *const u8, size: &[i64], kind: Kind, device: Device) -> Tensor {
+        Self::f_of_blob(data, size, kind, device).unwrap()
+    }
+
     /// Converts some byte data to a tensor with some specified kind and shape.
     pub fn of_data_size(data: &[u8], size: &[i64], kind: Kind) -> Tensor {
         Self::f_of_data_size(data, size, kind).unwrap()

--- a/torch-sys/libtch/torch_api.cpp
+++ b/torch-sys/libtch/torch_api.cpp
@@ -45,6 +45,15 @@ tensor at_new_tensor() {
   return nullptr;
 }
 
+tensor at_tensor_of_blob(void *data, int64_t *dims, size_t ndims, int type, int device) {
+  PROTECT(
+    at::TensorOptions blobOptions = at::TensorOptions().device(device_of_int(device)).dtype(torch::ScalarType(type));
+    return new torch::Tensor(torch::from_blob(data, torch::IntArrayRef(dims, ndims), blobOptions));
+  )
+
+  return nullptr;
+}
+
 tensor at_tensor_of_data(void *vs, int64_t *dims, size_t ndims, size_t element_size_in_bytes, int type) {
   PROTECT(
     torch::Tensor tensor = torch::zeros(torch::IntArrayRef(dims, ndims), torch::ScalarType(type));

--- a/torch-sys/libtch/torch_api.cpp
+++ b/torch-sys/libtch/torch_api.cpp
@@ -45,10 +45,10 @@ tensor at_new_tensor() {
   return nullptr;
 }
 
-tensor at_tensor_of_blob(void *data, int64_t *dims, size_t ndims, int type, int device) {
+tensor at_tensor_of_blob(void *data, int64_t *dims, size_t ndims, int64_t *strides, size_t nstrides, int type, int device) {
   PROTECT(
     at::TensorOptions blobOptions = at::TensorOptions().device(device_of_int(device)).dtype(torch::ScalarType(type));
-    return new torch::Tensor(torch::from_blob(data, torch::IntArrayRef(dims, ndims), blobOptions));
+    return new torch::Tensor(torch::from_blob(data, torch::IntArrayRef(dims, ndims), torch::IntArrayRef(strides, nstrides), blobOptions));
   )
 
   return nullptr;

--- a/torch-sys/libtch/torch_api.h
+++ b/torch-sys/libtch/torch_api.h
@@ -28,6 +28,7 @@ typedef void *ivalue;
 char *get_and_reset_last_err(); // thread-local
 void at_manual_seed(int64_t);
 tensor at_new_tensor();
+tensor at_tensor_of_blob(void *data, int64_t *dims, size_t ndims, int type, int device);
 tensor at_tensor_of_data(void *vs, int64_t *dims, size_t ndims, size_t element_size_in_bytes, int type);
 void at_copy_data(tensor tensor, void *vs, size_t numel, size_t element_size_in_bytes);
 tensor at_shallow_clone(tensor);

--- a/torch-sys/libtch/torch_api.h
+++ b/torch-sys/libtch/torch_api.h
@@ -28,7 +28,7 @@ typedef void *ivalue;
 char *get_and_reset_last_err(); // thread-local
 void at_manual_seed(int64_t);
 tensor at_new_tensor();
-tensor at_tensor_of_blob(void *data, int64_t *dims, size_t ndims, int type, int device);
+tensor at_tensor_of_blob(void *data, int64_t *dims, size_t ndims, int64_t *strides, size_t nstrides, int type, int device);
 tensor at_tensor_of_data(void *vs, int64_t *dims, size_t ndims, size_t element_size_in_bytes, int type);
 void at_copy_data(tensor tensor, void *vs, size_t numel, size_t element_size_in_bytes);
 tensor at_shallow_clone(tensor);

--- a/torch-sys/src/lib.rs
+++ b/torch-sys/src/lib.rs
@@ -76,6 +76,13 @@ extern "C" {
         elt_size_in_bytes: size_t,
         kind: c_int,
     ) -> *mut C_tensor;
+    pub fn at_tensor_of_blob(
+        vs: *const c_void,
+        dims: *const i64,
+        ndims: size_t,
+        kind: c_int,
+        device: c_int
+    ) -> *mut C_tensor;
     pub fn at_grad_set_enabled(b: c_int) -> c_int;
     pub fn at_save(arg: *mut C_tensor, filename: *const c_char);
     pub fn at_load(filename: *const c_char) -> *mut C_tensor;

--- a/torch-sys/src/lib.rs
+++ b/torch-sys/src/lib.rs
@@ -80,8 +80,10 @@ extern "C" {
         vs: *const c_void,
         dims: *const i64,
         ndims: size_t,
+        strides: *const i64,
+        nstrides: size_t,
         kind: c_int,
-        device: c_int
+        device: c_int,
     ) -> *mut C_tensor;
     pub fn at_grad_set_enabled(b: c_int) -> c_int;
     pub fn at_save(arg: *mut C_tensor, filename: *const c_char);


### PR DESCRIPTION
Following #265, I was wondering if this API addition is something consider accepting into upstream.

It resulted in massive performance wins for us when manipulating huge tensors that are externally allocated by TensorRT.
Are there any changes that should be added?