### PR TITLE
Download pytorch cuda 11 version using TORCH_CUDA_VERSION variable

### DIFF
--- a/torch-sys/build.rs
+++ b/torch-sys/build.rs
@@ -108,6 +108,7 @@ fn prepare_libtorch_dir() -> PathBuf {
                         "cpu" => "%2Bcpu",
                         "cu92" => "%2Bcu92",
                         "cu101" => "%2Bcu101",
+                        "cu110" => "%2Bcu110",
                         _ => ""
                     }
                 ),
@@ -121,6 +122,7 @@ fn prepare_libtorch_dir() -> PathBuf {
                         "cpu" => "%2Bcpu",
                         "cu92" => "%2Bcu92",
                         "cu101" => "%2Bcu101",
+                        "cu110" => "%2Bcu110",
                         _ => ""
                     }),
                 _ => panic!("Unsupported OS"),


### PR DESCRIPTION
Added ability to download cuda 11 version of pytorch via build script