### PR TITLE
Derive Hash on Device and Reduction types

### DIFF
--- a/src/wrappers/device.rs
+++ b/src/wrappers/device.rs
@@ -1,7 +1,7 @@
 //! Devices on which tensor computations are run.
 
 /// A torch device.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Device {
     /// The main CPU device.
     Cpu,

--- a/src/wrappers/tensor.rs
+++ b/src/wrappers/tensor.rs
@@ -721,7 +721,7 @@ impl Drop for NoGradGuard {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Reduction {
     /// Do not reduce.
     None,


### PR DESCRIPTION
Shown as title. Adding `Hash` on `Device` enables checking if set of tensors are on the same device by hashset of device.