### PR TITLE
Support loading of i8 npz files generated by numpy

### DIFF
--- a/src/tensor/npy.rs
+++ b/src/tensor/npy.rs
@@ -148,7 +148,7 @@ impl Header {
                         descr
                     )));
                 }
-                match descr.trim_matches(|c: char| c == '=' || c == '<') {
+                match descr.trim_matches(|c: char| c == '=' || c == '<' || c == '|') {
                     "f2" => Kind::Half,
                     "f4" => Kind::Float,
                     "f8" => Kind::Double,

--- a/tests/serialization_tests.rs
+++ b/tests/serialization_tests.rs
@@ -48,3 +48,16 @@ fn save_and_load_npz_half() {
     assert_eq!(named_tensors[1].0, "e");
     assert_eq!(i64::from(&named_tensors[1].1.sum(tch::Kind::Float)), 57);
 }
+
+#[test]
+fn save_and_load_npz_byte() {
+    let filename = std::env::temp_dir().join(format!("tch5-{}.npz", std::process::id()));
+    let pi = Tensor::of_slice(&[3.0, 1.0, 4.0, 1.0, 5.0]).to2(Kind::Int8, true, false);
+    let e = Tensor::of_slice(&[2, 7, 1, 8, 2, 8, 1, 8, 2, 8, 4, 6]).to2(Kind::Int8, true, false);
+    Tensor::write_npz(&[(&"pi", &pi), (&"e", &e)], &filename).unwrap();
+    let named_tensors = Tensor::read_npz(&filename).unwrap();
+    assert_eq!(named_tensors.len(), 2);
+    assert_eq!(named_tensors[0].0, "pi");
+    assert_eq!(named_tensors[1].0, "e");
+    assert_eq!(i8::from(&named_tensors[1].1.sum(tch::Kind::Int8)), 57);
+}


### PR DESCRIPTION
Hello,

Numpy's description for the `np.int8` type is `|i1`, which unfortunately doesn't match the pattern used in the current library when loading `npz` files:
https://github.com/LaurentMazare/tch-rs/blob/660a20de43898ed473c2a1a41a355ec300007064/src/tensor/npy.rs#L151

This PR proposes adding support for loading these int8 numpy arrays, useful for quantized models