### PR TITLE
Avoid generating variables for RNNs without biases.

### DIFF
--- a/src/nn/rnn.rs
+++ b/src/nn/rnn.rs
@@ -102,12 +102,14 @@ pub fn lstm(vs: &super::var_store::Path, in_dim: i64, hidden_dim: i64, c: RNNCon
                 &format!("weight_hh_l{}{}", layer_idx, suffix),
                 &[gate_dim, hidden_dim],
             );
-            let b_ih = vs.zeros(&format!("bias_ih_l{}{}", layer_idx, suffix), &[gate_dim]);
-            let b_hh = vs.zeros(&format!("bias_hh_l{}{}", layer_idx, suffix), &[gate_dim]);
             flat_weights.push(w_ih);
             flat_weights.push(w_hh);
-            flat_weights.push(b_ih);
-            flat_weights.push(b_hh);
+            if c.has_biases {
+                let b_ih = vs.zeros(&format!("bias_ih_l{}{}", layer_idx, suffix), &[gate_dim]);
+                let b_hh = vs.zeros(&format!("bias_hh_l{}{}", layer_idx, suffix), &[gate_dim]);
+                flat_weights.push(b_ih);
+                flat_weights.push(b_hh);
+            }
         }
     }
     if vs.device().is_cuda() && crate::Cuda::cudnn_is_available() {
@@ -206,12 +208,14 @@ pub fn gru(vs: &super::var_store::Path, in_dim: i64, hidden_dim: i64, c: RNNConf
                 &format!("weight_hh_l{}{}", layer_idx, suffix),
                 &[gate_dim, hidden_dim],
             );
-            let b_ih = vs.zeros(&format!("bias_ih_l{}{}", layer_idx, suffix), &[gate_dim]);
-            let b_hh = vs.zeros(&format!("bias_hh_l{}{}", layer_idx, suffix), &[gate_dim]);
             flat_weights.push(w_ih);
             flat_weights.push(w_hh);
-            flat_weights.push(b_ih);
-            flat_weights.push(b_hh);
+            if c.has_biases {
+                let b_ih = vs.zeros(&format!("bias_ih_l{}{}", layer_idx, suffix), &[gate_dim]);
+                let b_hh = vs.zeros(&format!("bias_hh_l{}{}", layer_idx, suffix), &[gate_dim]);
+                flat_weights.push(b_ih);
+                flat_weights.push(b_hh);
+            }
         }
     }
     if vs.device().is_cuda() && crate::Cuda::cudnn_is_available() {

--- a/tests/nn_tests.rs
+++ b/tests/nn_tests.rs
@@ -166,6 +166,10 @@ fn gru_test(rnn_config: nn::RNNConfig) {
 fn gru() {
     gru_test(Default::default());
     gru_test(nn::RNNConfig {
+        has_biases: false,
+        ..Default::default()
+    });
+    gru_test(nn::RNNConfig {
         bidirectional: true,
         ..Default::default()
     });
@@ -210,6 +214,10 @@ fn lstm_test(rnn_config: nn::RNNConfig) {
 #[test]
 fn lstm() {
     lstm_test(Default::default());
+    lstm_test(nn::RNNConfig {
+        has_biases: false,
+        ..Default::default()
+    });
     lstm_test(nn::RNNConfig {
         bidirectional: true,
         ..Default::default()


### PR DESCRIPTION
We generate biases variables for RNN that end up actually not using them. This PR avoids this and adds some tests checking that inference still works.
This was reported in #302 