### PR TITLE
Update dependencies via cargo-edit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,19 +12,19 @@ license = "MIT/Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-lazy_static = "1.3.0"
-libc = "0.2.0"
-ndarray = "0.13"
-rand = "0.7"
-thiserror = "1"
+lazy_static = "1.4.0"
+libc = "0.2.82"
+ndarray = "0.14.0"
+rand = "0.8.2"
+thiserror = "1.0.23"
 torch-sys = { version = "0.3.1", path = "torch-sys" }
-zip = "0.5"
-half = "1.6"
+zip = "0.5.9"
+half = "1.7.1"
 
-cpython = { version = "0.2.0", optional = true }
+cpython = { version = "0.5.2", optional = true }
 
 [dev-dependencies]
-anyhow = "1"
+anyhow = "1.0.38"
 
 [workspace]
 members = ["torch-sys"]

--- a/src/vision/dataset.rs
+++ b/src/vision/dataset.rs
@@ -58,8 +58,8 @@ pub fn random_crop(t: &Tensor, pad: i64) -> Tensor {
     let output = t.zeros_like();
     for bindex in 0..size[0] {
         let mut output_view = output.i(bindex);
-        let start_w = rand::thread_rng().gen_range(0, 2 * pad);
-        let start_h = rand::thread_rng().gen_range(0, 2 * pad);
+        let start_w = rand::thread_rng().gen_range(0..(2 * pad));
+        let start_h = rand::thread_rng().gen_range(0..(2 * pad));
         let src = padded.i((bindex, .., start_h..start_h + sz_h, start_w..start_w + sz_w));
         output_view.copy_(&src)
     }
@@ -76,8 +76,8 @@ pub fn random_cutout(t: &Tensor, sz: i64) -> Tensor {
     let mut output = t.zeros_like();
     output.copy_(&t);
     for bindex in 0..size[0] {
-        let start_h = rand::thread_rng().gen_range(0, size[2] - sz + 1);
-        let start_w = rand::thread_rng().gen_range(0, size[3] - sz + 1);
+        let start_h = rand::thread_rng().gen_range(0..(size[2] - sz + 1));
+        let start_w = rand::thread_rng().gen_range(0..(size[3] - sz + 1));
         let _output = output
             .i((bindex, .., start_h..start_h + sz, start_w..start_w + sz))
             .fill_(0.0);


### PR DESCRIPTION
This PR upgrades dependencies using `cargo upgrade` from [cargo-edit](https://crates.io/crates/cargo-edit).
Note that it introduces breaking changes due to `cpython` and `half` update, requiring minor version bump.