### PR TITLE
Add support for the tracer api

### DIFF
--- a/tests/jit_tests.rs
+++ b/tests/jit_tests.rs
@@ -124,7 +124,7 @@ fn jit5() {
 
 #[test]
 fn create_traced() {
-    let closure = |inputs: Vec<Tensor>| {
+    let mut closure = |inputs: &[Tensor]| {
         let v1 = inputs[0].shallow_clone();
         let v2 = inputs[1].shallow_clone();
         vec![v1 + v2]
@@ -133,8 +133,7 @@ fn create_traced() {
         "MyModule",
         "MyFn",
         &[Tensor::from(0.0), Tensor::from(1.0)],
-        1,
-        &closure,
+        &mut closure,
     )
     .unwrap();
     let filename = std::env::temp_dir().join(format!("tch-modl-{}", std::process::id()));

--- a/tests/jit_tests.rs
+++ b/tests/jit_tests.rs
@@ -124,5 +124,21 @@ fn jit5() {
 
 #[test]
 fn create_traced() {
-    let modl = tch::CModule::create_by_tracing("MyModule", "MyFn", &[], 0);
+    let closure = |inputs: Vec<Tensor>| {
+        let v1 = inputs[0].shallow_clone();
+        let v2 = inputs[1].shallow_clone();
+        vec![v1 + v2]
+    };
+    let modl = tch::CModule::create_by_tracing(
+        "MyModule",
+        "MyFn",
+        &[Tensor::from(0.0), Tensor::from(1.0)],
+        1,
+        &closure,
+    )
+    .unwrap();
+    let xs = Tensor::of_slice(&[1.0, 2.0, 3.0, 4.0, 5.0]);
+    let ys = Tensor::of_slice(&[41.0, 1335.0, 0.1415, 4.0, 5.0]);
+    let result = modl.method_ts("MyFn", &[xs, ys]).unwrap();
+    assert_eq!(Vec::<f64>::from(&result), [42.0, 1337.0, 3.1415, 8.0, 10.0])
 }

--- a/tests/jit_tests.rs
+++ b/tests/jit_tests.rs
@@ -121,3 +121,8 @@ fn jit5() {
     assert_eq!(v2, "ba");
     assert_eq!(v3, "fooba");
 }
+
+#[test]
+fn create_traced() {
+    let modl = tch::CModule::create_by_tracing("MyModule", "MyFn", &[], 0);
+}

--- a/tests/jit_tests.rs
+++ b/tests/jit_tests.rs
@@ -137,6 +137,9 @@ fn create_traced() {
         &closure,
     )
     .unwrap();
+    let filename = std::env::temp_dir().join(format!("tch-modl-{}", std::process::id()));
+    modl.save(&filename).unwrap();
+    let modl = tch::CModule::load(&filename).unwrap();
     let xs = Tensor::of_slice(&[1.0, 2.0, 3.0, 4.0, 5.0]);
     let ys = Tensor::of_slice(&[41.0, 1335.0, 0.1415, 4.0, 5.0]);
     let result = modl.method_ts("MyFn", &[xs, ys]).unwrap();

--- a/torch-sys/libtch/torch_api.h
+++ b/torch-sys/libtch/torch_api.h
@@ -169,6 +169,14 @@ void atm_save(module m, char*);
 int atm_get_profiling_mode();
 void atm_set_profiling_mode(int);
 void atm_named_parameters(module, void *data, void (*f)(void *, char *, tensor));
+module atm_create_by_tracing(
+  char *modl_name,
+  char *fn_name,
+  ivalue *inputs,
+  int ninputs,
+  int noutputs,
+  void (*f)(void*, ivalue*, ivalue*),
+  void *user_data);
 
 ivalue ati_none();
 ivalue ati_tensor(tensor);

--- a/torch-sys/libtch/torch_api.h
+++ b/torch-sys/libtch/torch_api.h
@@ -172,10 +172,10 @@ void atm_named_parameters(module, void *data, void (*f)(void *, char *, tensor))
 module atm_create_by_tracing(
   char *modl_name,
   char *fn_name,
-  ivalue *inputs,
+  tensor *inputs,
   int ninputs,
   int noutputs,
-  void (*f)(void*, ivalue*, ivalue*),
+  void (*f)(void*, tensor*, int, tensor*, int),
   void *user_data);
 
 ivalue ati_none();

--- a/torch-sys/libtch/torch_api.h
+++ b/torch-sys/libtch/torch_api.h
@@ -178,6 +178,10 @@ module atm_create_by_tracing(
   void (*f)(void*, tensor*, int, tensor*, int),
   void *user_data);
 
+// This function has to be followed by a call to atm_end_tracing.
+module atm_create_for_tracing(char *modl_name, tensor *inputs, int ninputs);
+void atm_end_tracing(module m, char *fn_name, tensor *outputs, int noutputs);
+
 ivalue ati_none();
 ivalue ati_tensor(tensor);
 ivalue ati_int(int64_t);

--- a/torch-sys/src/lib.rs
+++ b/torch-sys/src/lib.rs
@@ -257,6 +257,17 @@ extern "C" {
         ),
         user_data: *mut c_void,
     ) -> *mut CModule_;
+    pub fn atm_create_for_tracing(
+        modl_name: *const c_char,
+        inputs: *const *mut C_tensor,
+        ninputs: c_int,
+    ) -> *mut CModule_;
+    pub fn atm_end_tracing(
+        m: *mut CModule_,
+        fn_name: *const c_char,
+        outputs: *const *mut C_tensor,
+        noutputs: c_int,
+    );
 }
 
 extern "C" {

--- a/torch-sys/src/lib.rs
+++ b/torch-sys/src/lib.rs
@@ -242,6 +242,19 @@ extern "C" {
         data: *mut c_void,
         f: extern "C" fn(*mut c_void, name: *const c_char, t: *mut C_tensor),
     );
+    pub fn atm_create_by_tracing(
+        modl_name: *const c_char,
+        fn_name: *const c_char,
+        inputs: *const *mut CIValue,
+        ninputs: c_int,
+        noutputs: c_int,
+        f: unsafe extern "C" fn(
+            user_data: *mut c_void,
+            inputs: *const *mut CIValue,
+            outputs: *const *mut CIValue,
+        ),
+        user_data: *mut c_void,
+    ) -> *mut CModule_;
 }
 
 extern "C" {

--- a/torch-sys/src/lib.rs
+++ b/torch-sys/src/lib.rs
@@ -245,13 +245,15 @@ extern "C" {
     pub fn atm_create_by_tracing(
         modl_name: *const c_char,
         fn_name: *const c_char,
-        inputs: *const *mut CIValue,
+        inputs: *const *mut C_tensor,
         ninputs: c_int,
         noutputs: c_int,
         f: unsafe extern "C" fn(
             user_data: *mut c_void,
-            inputs: *const *mut CIValue,
-            outputs: *const *mut CIValue,
+            inputs: *const *mut C_tensor,
+            ninputs: c_int,
+            outputs: *mut *mut C_tensor,
+            noutputs: c_int,
         ),
         user_data: *mut c_void,
     ) -> *mut CModule_;

--- a/torch-sys/src/lib.rs
+++ b/torch-sys/src/lib.rs
@@ -248,7 +248,7 @@ extern "C" {
         inputs: *const *mut C_tensor,
         ninputs: c_int,
         noutputs: c_int,
-        f: unsafe extern "C" fn(
+        f: extern "C" fn(
             user_data: *mut c_void,
             inputs: *const *mut C_tensor,
             ninputs: c_int,


### PR DESCRIPTION
As suggested in #311, this adds support for the tracer api.
The implementation however is quite rough:
- The number of outputs has to be specified manually (and this is unsafe as an error here might lead to a segfault).
- Errors raised within the closure are not handled properly.
- There might remain some memory leaks too.

This snippet extracted from the test shows how this can be used.
```rust
    let closure = |inputs: Vec<Tensor>| {
        let v1 = inputs[0].shallow_clone();
        let v2 = inputs[1].shallow_clone();
        vec![v1 + v2]
    };
    let modl = tch::CModule::create_by_tracing(
        "MyModule",
        "MyFn",
        &[Tensor::from(0.0), Tensor::from(1.0)],
        1,
        &closure,
    )
    .unwrap();

    // Save the module in a file.
    let filename = std::env::temp_dir().join(format!("tch-modl-{}", std::process::id()));
    modl.save(&filename).unwrap();

    // Reload the module to try it out.
    let modl = tch::CModule::load(&filename).unwrap();
    let xs = Tensor::of_slice(&[1.0, 2.0, 3.0, 4.0, 5.0]);
    let ys = Tensor::of_slice(&[41.0, 1335.0, 0.1415, 4.0, 5.0]);
    let result = modl.method_ts("MyFn", &[xs, ys]).unwrap();
    assert_eq!(Vec::<f64>::from(&result), [42.0, 1337.0, 3.1415, 8.0, 10.0])
```

It's a bit unclear whether the current implementation (wrapping around the C++ `tracer::trace` function) is a good idea, re-implementing this entirely in Rust might be better.