### PR TITLE
Refine excluded AMP prefix

### DIFF
--- a/gen/gen.ml
+++ b/gen/gen.ml
@@ -51,7 +51,7 @@ let prefixed_functions =
     (module String)
     [ "add"; "add_"; "div"; "div_"; "mul"; "mul_"; "sub"; "sub_"; "nll_loss"; "to_mkldnn" ]
 
-let excluded_prefixes = [ "_thnn_"; "_th_"; "thnn_"; "th_"; "_foreach"; "_amp" ]
+let excluded_prefixes = [ "_thnn_"; "_th_"; "thnn_"; "th_"; "_foreach"; "_amp_foreach" ]
 let excluded_suffixes = [ "_forward"; "_forward_out" ]
 let yaml_error yaml ~msg = Printf.failwithf "%s, %s" msg (Yaml.to_string_exn yaml) ()
 

--- a/src/wrappers/tensor_fallible_generated.rs
+++ b/src/wrappers/tensor_fallible_generated.rs
@@ -396,6 +396,29 @@ impl Tensor {
         ))
     }
 
+    pub fn f_internal_amp_update_scale(
+        growth_tracker: &Tensor,
+        current_scale: &Tensor,
+        found_inf: &Tensor,
+        scale_growth_factor: f64,
+        scale_backoff_factor: f64,
+        growth_interval: i64,
+    ) -> Result<Tensor, TchError> {
+        let mut c_tensors = [std::ptr::null_mut(); 1];
+        unsafe_torch_err!(atg__amp_update_scale(
+            c_tensors.as_mut_ptr(),
+            growth_tracker.c_tensor,
+            current_scale.c_tensor,
+            found_inf.c_tensor,
+            scale_growth_factor,
+            scale_backoff_factor,
+            growth_interval
+        ));
+        Ok(Tensor {
+            c_tensor: c_tensors[0],
+        })
+    }
+
     pub fn f_internal_baddbmm_mkl_(
         &mut self,
         batch1: &Tensor,

--- a/src/wrappers/tensor_generated.rs
+++ b/src/wrappers/tensor_generated.rs
@@ -122,6 +122,25 @@ impl Tensor {
         self.f_internal_aminmax1(dim, keepdim).unwrap()
     }
 
+    pub fn internal_amp_update_scale(
+        growth_tracker: &Tensor,
+        current_scale: &Tensor,
+        found_inf: &Tensor,
+        scale_growth_factor: f64,
+        scale_backoff_factor: f64,
+        growth_interval: i64,
+    ) -> Tensor {
+        Tensor::f_internal_amp_update_scale(
+            growth_tracker,
+            current_scale,
+            found_inf,
+            scale_growth_factor,
+            scale_backoff_factor,
+            growth_interval,
+        )
+        .unwrap()
+    }
+
     pub fn internal_baddbmm_mkl_(&mut self, batch1: &Tensor, batch2: &Tensor) -> Tensor {
         self.f_internal_baddbmm_mkl_(batch1, batch2).unwrap()
     }

--- a/torch-sys/libtch/torch_api_generated.cpp.h
+++ b/torch-sys/libtch/torch_api_generated.cpp.h
@@ -205,6 +205,13 @@ void atg__aminmax1(tensor *out__, tensor self, int64_t dim, int keepdim) {
   )
 }
 
+void atg__amp_update_scale(tensor *out__, tensor growth_tracker, tensor current_scale, tensor found_inf, double scale_growth_factor, double scale_backoff_factor, int64_t growth_interval) {
+  PROTECT(
+    auto outputs__ = torch::_amp_update_scale(*growth_tracker, *current_scale, *found_inf, scale_growth_factor, scale_backoff_factor, growth_interval);
+    out__[0] = new torch::Tensor(outputs__);
+  )
+}
+
 void atg__baddbmm_mkl_(tensor *out__, tensor self, tensor batch1, tensor batch2) {
   PROTECT(
     auto outputs__ = torch::_baddbmm_mkl_(*self, *batch1, *batch2);

--- a/torch-sys/libtch/torch_api_generated.h
+++ b/torch-sys/libtch/torch_api_generated.h
@@ -29,6 +29,7 @@ void atg__add_relu_out(tensor *, tensor out, tensor self, tensor other);
 void atg__addmv_impl_(tensor *, tensor self, tensor self2, tensor mat, tensor vec);
 void atg__aminmax(tensor *, tensor self);
 void atg__aminmax1(tensor *, tensor self, int64_t dim, int keepdim);
+void atg__amp_update_scale(tensor *, tensor growth_tracker, tensor current_scale, tensor found_inf, double scale_growth_factor, double scale_backoff_factor, int64_t growth_interval);
 void atg__baddbmm_mkl_(tensor *, tensor self, tensor batch1, tensor batch2);
 void atg__bmm(tensor *, tensor self, tensor mat2, int deterministic);
 void atg__bmm_out(tensor *, tensor out, tensor self, tensor mat2, int deterministic);

--- a/torch-sys/src/c_generated.rs
+++ b/torch-sys/src/c_generated.rs
@@ -63,6 +63,15 @@ extern "C" {
         dim_: i64,
         keepdim_: c_int,
     );
+    pub fn atg__amp_update_scale(
+        out__: *mut *mut C_tensor,
+        growth_tracker_: *mut C_tensor,
+        current_scale_: *mut C_tensor,
+        found_inf_: *mut C_tensor,
+        scale_growth_factor_: f64,
+        scale_backoff_factor_: f64,
+        growth_interval_: i64,
+    );
     pub fn atg__baddbmm_mkl_(
         out__: *mut *mut C_tensor,
         self_: *mut C_tensor,


### PR DESCRIPTION
Refine AMP function exclusion: `_amp` -> `_amp_foreach`

Exclusion of the `_amp` prefix also excludes `internal_amp_update_scale`,
which is needed for mixed-precision training.
