### PR TITLE
Use windows unicode paths to get around windows 260 char path limit.

### DIFF
--- a/torch-sys/Cargo.toml
+++ b/torch-sys/Cargo.toml
@@ -20,6 +20,9 @@ anyhow = "1.0"
 cc = "1.0"
 curl = "0.4.9"
 zip = "0.5"
+normpath="0.3.0"
+verbatim="0.1.1"
+cfg-if="1.0.0"
 
 [features]
 doc-only = []

--- a/torch-sys/build.rs
+++ b/torch-sys/build.rs
@@ -7,7 +7,6 @@
 // like 9.0, 90, or cu90 to specify the version of CUDA to use for libtorch.
 
 use curl::easy::Easy;
-use normpath::PathExt;
 use std::env;
 use std::fs;
 use std::io;
@@ -56,6 +55,7 @@ fn extract<P: AsRef<Path>>(filename: P, outpath: P) -> anyhow::Result<()> {
                     let mut path = p.to_verbatim();
                     cfg_if::cfg_if! {
                         if #[cfg(any(windows))] {
+                            use normpath::PathExt;
                             //
                             path = p.normalize_virtually()?.as_path().to_verbatim();
                         }

--- a/torch-sys/build.rs
+++ b/torch-sys/build.rs
@@ -56,7 +56,7 @@ fn extract<P: AsRef<Path>>(filename: P, outpath: P) -> anyhow::Result<()> {
                     cfg_if::cfg_if! {
                         if #[cfg(any(windows))] {
                             use normpath::PathExt;
-                            //
+                            // Normalize the path to get rid of any relative paths, then use the Windows extended-length path to get around the 260 char path limit.
                             path = p.normalize_virtually()?.as_path().to_verbatim();
                         }
                     }

--- a/torch-sys/build.rs
+++ b/torch-sys/build.rs
@@ -52,11 +52,13 @@ fn extract<P: AsRef<Path>>(filename: P, outpath: P) -> anyhow::Result<()> {
             );
             if let Some(p) = outpath.parent() {
                 if !p.exists() {
-                    let mut path = p.to_verbatim();
+                    #[allow(clippy::unused_mut)]
+                    let mut path: PathBuf = p.to_verbatim();
                     cfg_if::cfg_if! {
                         if #[cfg(any(windows))] {
                             use normpath::PathExt;
-                            // Normalize the path to get rid of any relative paths, then use the Windows extended-length path to get around the 260 char path limit.
+                            // Normalize the path to get rid of any relative paths,
+                            // then use the Windows extended-length path to get around the 260 char path limit.
                             path = p.normalize_virtually()?.as_path().to_verbatim();
                         }
                     }


### PR DESCRIPTION
`libtorch` fails to extract on Windows when the project is near the 260 char windows path limit, this adds a windows check and adjusts the path. Secondly, this normalizes paths using `to_verbatim`, normalizing paths should fix any issues while using a custom `CARGO_TARGET_DIR` on Windows. This PR still needs some work.