### PR TITLE
Updated cu11.x reference version from cu110 to cu111

### DIFF
--- a/torch-sys/build.rs
+++ b/torch-sys/build.rs
@@ -104,7 +104,7 @@ fn prepare_libtorch_dir() -> PathBuf {
                         "cpu" => "%2Bcpu",
                         "cu92" => "%2Bcu92",
                         "cu101" => "%2Bcu101",
-                        "cu110" => "%2Bcu110",
+                        "cu111" => "%2Bcu111",
                         _ => ""
                     }
                 ),
@@ -118,7 +118,7 @@ fn prepare_libtorch_dir() -> PathBuf {
                         "cpu" => "%2Bcpu",
                         "cu92" => "%2Bcu92",
                         "cu101" => "%2Bcu101",
-                        "cu110" => "%2Bcu110",
+                        "cu111" => "%2Bcu111",
                         _ => ""
                     }),
                 _ => panic!("Unsupported OS"),


### PR DESCRIPTION
Hello,

I am currently looking to update the dependency of a project from `tch` 0.3.1 to `tch` 0.4.0. I am currently facing some issues with the update to CUDA11.x and Pytorch 1.8.1. While trying to identify the issue, I have tried to do a clean installation of tch without environment variables to force a download of the libtorch dependency.

It looks like the libtorch file for CUDA11.0 has been deprecated: I cannot download the file from the following addresses:
https://download.pytorch.org/libtorch/cu110/libtorch-cxx11-abi-shared-with-deps-1.8.1%2Bcu110.zip
https://download.pytorch.org/libtorch/cu110/libtorch-win-shared-with-deps-1.8.1%2Bcu110.zip

These files are available for version 11.1:
https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.8.1%2Bcu111.zip
https://download.pytorch.org/libtorch/cu111/libtorch-win-shared-with-deps-1.8.1%2Bcu111.zip

This PR proposes an update of the path when the user does not have an existing local version of libtorch. 

This also requires the user to update the environment variable `TORCH_CUDA_VERSION` from `11.0` to `11.1`.

To my understanding, if the user does not specifies this environment variable, the installation will silently default to CPU instead of using the GPU even if available. It may make sense to mention it in the README as currently I believe only an inspection of `build.rs` allows to find this out.