### PR TITLE
Add support for system-wide libtorch installations (addresses #343)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,16 @@ The code generation part for the C api on top of libtorch comes from
 This crate requires the C++ PyTorch library (libtorch) in version *v1.8.1* to be available on
 your system. You can either:
 
+- Use the system-wide libtorch installation (default).
 - Install libtorch manually and let the build script know about it via the `LIBTORCH` environment variable.
-- When `LIBTORCH` is not set, the build script will download a pre-built binary version
+- When a system-wide libtorch can't be found and `LIBTORCH` is not set, the build script will download a pre-built binary version
 of libtorch. By default a CPU version is used. The `TORCH_CUDA_VERSION` environment variable
 can be set to `cu111` in order to get a pre-built binary using CUDA 11.1.
+
+### System-wide Libtorch
+
+The build script will look for a system-wide libtorch library in the following locations:
+- In Linux: `/usr/lib/libtorch.so`
 
 ### Libtorch Manual Install
 

--- a/torch-sys/build.rs
+++ b/torch-sys/build.rs
@@ -67,6 +67,15 @@ fn env_var_rerun(name: &str) -> Result<String, env::VarError> {
     env::var(name)
 }
 
+fn check_system_location() -> Option<PathBuf> {
+    let os = env::var("CARGO_CFG_TARGET_OS").expect("Unable to get TARGET_OS");
+
+    match os.as_str() {
+        "linux" => Path::new("/usr/lib/libtorch.so").exists().then(|| PathBuf::from("/usr")),
+        _ => None,
+    }
+}
+
 fn prepare_libtorch_dir() -> PathBuf {
     let os = env::var("CARGO_CFG_TARGET_OS").expect("Unable to get TARGET_OS");
 
@@ -93,6 +102,8 @@ fn prepare_libtorch_dir() -> PathBuf {
 
     if let Ok(libtorch) = env_var_rerun("LIBTORCH") {
         PathBuf::from(libtorch)
+    } else if let Some(pathbuf) = check_system_location() {
+        pathbuf
     } else {
         let libtorch_dir = PathBuf::from(env::var("OUT_DIR").unwrap()).join("libtorch");
         if !libtorch_dir.exists() {

--- a/torch-sys/build.rs
+++ b/torch-sys/build.rs
@@ -71,7 +71,9 @@ fn check_system_location() -> Option<PathBuf> {
     let os = env::var("CARGO_CFG_TARGET_OS").expect("Unable to get TARGET_OS");
 
     match os.as_str() {
-        "linux" => Path::new("/usr/lib/libtorch.so").exists().then(|| PathBuf::from("/usr")),
+        "linux" => Path::new("/usr/lib/libtorch.so")
+            .exists()
+            .then(|| PathBuf::from("/usr")),
         _ => None,
     }
 }


### PR DESCRIPTION
This attempts to find the `libtorch` library at common locations, and deduces the libtorch prefix from that.

I've only implemented the Linux support (looking for `/usr/lib/libtorch.so` and deducing `/usr` as the path). Support for other operating systems and paths should be easy to add.

I've also updated the README, listing this as the _default_ option (which it is, when `LIBTORCH` isn't set).

EDIT: fixed typo