### PR TITLE
Fix build on windows for PyTorch 1.8.1

### DIFF
--- a/torch-sys/libtch/dummy_cuda_dependency.cpp
+++ b/torch-sys/libtch/dummy_cuda_dependency.cpp
@@ -5,9 +5,15 @@ extern "C" {
     void dummy_cuda_dependency();
 }
 
+struct cublasContext;
+
 namespace at {
+    class Tensor;
+    namespace native {
+        class at::Tensor searchsorted_cuda(class at::Tensor const &,class at::Tensor const &,bool,bool);
+    }
     namespace cuda {
-        void *getCurrentCUDABlasHandle();
+        cublasContext* getCurrentCUDABlasHandle();
         int warp_size();
     }
 }

--- a/torch-sys/libtch/dummy_cuda_dependency.cpp
+++ b/torch-sys/libtch/dummy_cuda_dependency.cpp
@@ -8,10 +8,6 @@ extern "C" {
 struct cublasContext;
 
 namespace at {
-    class Tensor;
-    namespace native {
-        class at::Tensor searchsorted_cuda(class at::Tensor const &,class at::Tensor const &,bool,bool);
-    }
     namespace cuda {
         cublasContext* getCurrentCUDABlasHandle();
         int warp_size();


### PR DESCRIPTION
This should fix [Build error on Windows10](https://github.com/LaurentMazare/tch-rs/issues/342)

On inspection of torch_cuda_cu.lib using
`dumpbin`, the following symbol shows up:

                  ?getCurrentCUDABlasHandle@cuda@at@@YAPEAUcublasContext@@XZ (struct cublasContext * __cdecl at::cuda::getCurrentCUDABlasHandle(void))

The return type is a `struct cublasContext*` but in `dummy_cuda_dependency.cpp` it was declared as `void` which causes a link error on Windows.

I haven't tested this on Linux since I don't have a working CUDA version for WSL. Could someone verify that this still works cross platform?