### PR TITLE
Adding backward with gradient function

### DIFF
--- a/src/wrappers/tensor.rs
+++ b/src/wrappers/tensor.rs
@@ -322,6 +322,19 @@ impl Tensor {
         self.f_backward().unwrap()
     }
 
+    /// Runs the backward pass, populating the gradient tensors for tensors
+    /// which gradients are tracked.
+    ///
+    /// Gradients tracking can be turned on via `set_requires_grad`.
+    pub fn f_backward_with_grad(&self, grad: &Self) -> Result<(), TchError> {
+        unsafe_torch_err!(at_backward_with_grad(self.c_tensor, grad.c_tensor, 0, 0));
+        Ok(())
+    }
+
+    pub fn backward_with_grad(&self, grad: &Self) {
+        self.f_backward_with_grad(grad).unwrap()
+    }
+
     pub fn f_run_backward<T1, T2>(
         tensors: &[T1],
         inputs: &[T2],

--- a/src/wrappers/tensor.rs
+++ b/src/wrappers/tensor.rs
@@ -326,13 +326,15 @@ impl Tensor {
     /// which gradients are tracked.
     ///
     /// Gradients tracking can be turned on via `set_requires_grad`.
-    pub fn f_backward_with_grad(&self, grad: &Self) -> Result<(), TchError> {
-        unsafe_torch_err!(at_backward_with_grad(self.c_tensor, grad.c_tensor, 0, 0));
+    pub fn f_backward_with_grad(&self, grad: &Self, keep_graph: bool, create_graph: bool) -> Result<(), TchError> {
+        let keep_graph = if keep_graph { 1 } else { 0 };
+        let create_graph = if create_graph { 1 } else { 0 };
+        unsafe_torch_err!(at_backward_with_grad(self.c_tensor, grad.c_tensor, keep_graph, create_graph));
         Ok(())
     }
 
-    pub fn backward_with_grad(&self, grad: &Self) {
-        self.f_backward_with_grad(grad).unwrap()
+    pub fn backward_with_grad(&self, grad: &Self, keep_graph: bool, create_graph: bool) {
+        self.f_backward_with_grad(grad, keep_graph, create_graph).unwrap()
     }
 
     pub fn f_run_backward<T1, T2>(

--- a/torch-sys/libtch/torch_api.cpp
+++ b/torch-sys/libtch/torch_api.cpp
@@ -200,6 +200,10 @@ void at_backward(tensor t, int keep_graph, int create_graph) {
   PROTECT(t->backward({}, keep_graph, create_graph);)
 }
 
+void at_backward_with_grad(tensor t, tensor grad, int keep_graph, int create_graph) {
+  PROTECT(t->backward(*grad, keep_graph, create_graph);)
+}
+
 int at_requires_grad(tensor t) {
   PROTECT(return t->requires_grad();)
   return -1;
@@ -933,7 +937,7 @@ module atm_create_for_tracing(
     for (int i = 0; i < ninputs; ++i) {
       auto value = state->graph->addInput();
       value->setType(torch::jit::TensorType::get());
-      state->setValue(*inputs[i], value); 
+      state->setValue(*inputs[i], value);
     }
     return new torch::jit::script::Module(modl);
   )

--- a/torch-sys/libtch/torch_api.h
+++ b/torch-sys/libtch/torch_api.h
@@ -52,6 +52,7 @@ bool at_autocast_is_enabled();
 bool at_autocast_set_enabled(bool b);
 
 void at_backward(tensor, int, int);
+void at_backward_with_grad(tensor, tensor, int, int);
 int at_requires_grad(tensor);
 int at_grad_set_enabled(int);
 

--- a/torch-sys/src/lib.rs
+++ b/torch-sys/src/lib.rs
@@ -28,6 +28,7 @@ extern "C" {
     pub fn at_is_sparse(arg: *mut C_tensor) -> c_int;
     pub fn at_is_mkldnn(arg: *mut C_tensor) -> c_int;
     pub fn at_backward(arg: *mut C_tensor, keep_graph: c_int, create_graph: c_int);
+    pub fn at_backward_with_grad(arg: *mut C_tensor, grad: *mut C_tensor, keep_graph: c_int, create_graph: c_int);
     pub fn at_print(arg: *mut C_tensor);
     pub fn at_to_string(arg: *mut C_tensor, line_size: c_int) -> *mut c_char;
     pub fn at_dim(arg: *mut C_tensor) -> size_t;


### PR DESCRIPTION
Recently I've been working on a project where I need to supply custom gradient into the back propagation process. Therefore I need an advanced `backward` function where I can pass in `gradient`, `retain_graph` and `create_graph` as parameters. That's why I introduced this new function `backward_with_grad` in this pull request.

I know that the documentation as well as the function name is not finalized yet in this pull request, I merely want to submit and enter the discussion of whether we can manage to add this feature to the code base. It would of great help to many other projects involving custom gradient!