### PR TITLE
Use generics instead of macros for From, TryFrom, TryInto impls

### DIFF
--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -483,35 +483,73 @@ impl Tensor {
     }
 }
 
-macro_rules! from_tensor {
-    ($typ:ident, $zero:expr, $kind:ident) => {
-        impl From<&Tensor> for Vec<$typ> {
-            fn from(tensor: &Tensor) -> Vec<$typ> {
-                let numel = tensor.numel();
-                let mut vec = vec![$zero; numel as usize];
-                tensor.to_kind(Kind::$kind).copy_data(&mut vec, numel);
-                vec
-            }
-        }
+impl<T> From<&Tensor> for Vec<T>
+where
+    T: crate::kind::Element + Default,
+{
+    fn from(tensor: &Tensor) -> Vec<T> {
+        let numel = tensor.numel();
+        let mut vec = Vec::new();
+        vec.resize_with(numel as usize, Default::default);
+        tensor.to_kind(T::KIND).copy_data(&mut vec, numel);
+        vec
+    }
+}
 
-        impl From<&Tensor> for Vec<Vec<$typ>> {
-            fn from(tensor: &Tensor) -> Vec<Vec<$typ>> {
-                let first_dim = tensor.size()[0];
-                (0..first_dim)
-                    .map(|i| Vec::<$typ>::from(tensor.get(i)))
-                    .collect()
-            }
-        }
+impl<T> From<&Tensor> for Vec<Vec<T>>
+where
+    T: crate::kind::Element + Default,
+{
+    fn from(tensor: &Tensor) -> Vec<Vec<T>> {
+        let first_dim = tensor.size()[0];
+        (0..first_dim)
+            .map(|i| Vec::<T>::from(tensor.get(i)))
+            .collect()
+    }
+}
 
-        impl From<&Tensor> for Vec<Vec<Vec<$typ>>> {
-            fn from(tensor: &Tensor) -> Vec<Vec<Vec<$typ>>> {
-                let first_dim = tensor.size()[0];
-                (0..first_dim)
-                    .map(|i| Vec::<Vec<$typ>>::from(tensor.get(i)))
-                    .collect()
-            }
-        }
+impl<T> From<&Tensor> for Vec<Vec<Vec<T>>>
+where
+    T: crate::kind::Element + Default,
+{
+    fn from(tensor: &Tensor) -> Vec<Vec<Vec<T>>> {
+        let first_dim = tensor.size()[0];
+        (0..first_dim)
+            .map(|i| Vec::<Vec<T>>::from(tensor.get(i)))
+            .collect()
+    }
+}
 
+impl<T> From<Tensor> for Vec<T>
+where
+    T: crate::kind::Element + Default,
+{
+    fn from(tensor: Tensor) -> Vec<T> {
+        Vec::<T>::from(&tensor)
+    }
+}
+
+impl<T> From<Tensor> for Vec<Vec<T>>
+where
+    T: crate::kind::Element + Default,
+{
+    fn from(tensor: Tensor) -> Vec<Vec<T>> {
+        Vec::<Vec<T>>::from(&tensor)
+    }
+}
+
+impl<T> From<Tensor> for Vec<Vec<Vec<T>>>
+where
+    T: crate::kind::Element + Default,
+{
+    fn from(tensor: Tensor) -> Vec<Vec<Vec<T>>> {
+        Vec::<Vec<Vec<T>>>::from(&tensor)
+    }
+}
+
+// Cannot be generic because of the orphan trait impl rules. T would be uncovered.
+macro_rules! scalar_from_tensor {
+    ($typ:ident) => {
         impl From<&Tensor> for $typ {
             fn from(tensor: &Tensor) -> $typ {
                 let numel = tensor.numel();
@@ -521,25 +559,6 @@ macro_rules! from_tensor {
                 Vec::from(tensor)[0]
             }
         }
-
-        impl From<Tensor> for Vec<$typ> {
-            fn from(tensor: Tensor) -> Vec<$typ> {
-                Vec::<$typ>::from(&tensor)
-            }
-        }
-
-        impl From<Tensor> for Vec<Vec<$typ>> {
-            fn from(tensor: Tensor) -> Vec<Vec<$typ>> {
-                Vec::<Vec<$typ>>::from(&tensor)
-            }
-        }
-
-        impl From<Tensor> for Vec<Vec<Vec<$typ>>> {
-            fn from(tensor: Tensor) -> Vec<Vec<Vec<$typ>>> {
-                Vec::<Vec<Vec<$typ>>>::from(&tensor)
-            }
-        }
-
         impl From<Tensor> for $typ {
             fn from(tensor: Tensor) -> $typ {
                 $typ::from(&tensor)
@@ -548,14 +567,14 @@ macro_rules! from_tensor {
     };
 }
 
-from_tensor!(f64, 0f64, Double);
-from_tensor!(f32, 0f32, Float);
-from_tensor!(f16, f16::from_f64(0.0), Half);
-from_tensor!(i64, 0i64, Int64);
-from_tensor!(i32, 0i32, Int);
-from_tensor!(i8, 0i8, Int8);
-from_tensor!(u8, 0u8, Uint8);
-from_tensor!(bool, false, Bool);
+scalar_from_tensor!(f64);
+scalar_from_tensor!(f32);
+scalar_from_tensor!(f16);
+scalar_from_tensor!(i64);
+scalar_from_tensor!(i32);
+scalar_from_tensor!(i8);
+scalar_from_tensor!(u8);
+scalar_from_tensor!(bool);
 
 impl Tensor {
     /// Computes the cross-entropy loss based on some logits and targets.
@@ -692,64 +711,49 @@ impl PartialEq for Tensor {
     }
 }
 
-macro_rules! try_into_impl {
-    ($type:ident) => {
-        impl TryInto<ndarray::ArrayD<$type>> for &Tensor {
-            type Error = ndarray::ShapeError;
+impl<T> TryInto<ndarray::ArrayD<T>> for &Tensor
+where
+    T: crate::kind::Element + Default,
+{
+    type Error = ndarray::ShapeError;
 
-            fn try_into(self) -> Result<ndarray::ArrayD<$type>, Self::Error> {
-                let v: Vec<$type> = self.into();
-                let shape: Vec<usize> = self.size().iter().map(|s| *s as usize).collect();
-                ndarray::ArrayD::from_shape_vec(ndarray::IxDyn(&shape), v)
-            }
-        }
-    };
+    fn try_into(self) -> Result<ndarray::ArrayD<T>, Self::Error> {
+        let v: Vec<T> = self.into();
+        let shape: Vec<usize> = self.size().iter().map(|s| *s as usize).collect();
+        ndarray::ArrayD::from_shape_vec(ndarray::IxDyn(&shape), v)
+    }
 }
 
-try_into_impl!(f16);
-try_into_impl!(f32);
-try_into_impl!(i32);
-try_into_impl!(f64);
-try_into_impl!(i64);
-try_into_impl!(bool);
+impl<T, D> TryFrom<ndarray::Array<T, D>> for Tensor
+where
+    T: crate::kind::Element,
+    D: ndarray::Dimension,
+{
+    type Error = TchError;
 
-macro_rules! try_from_impl {
-    ($type:ident) => {
-        impl<D> TryFrom<ndarray::Array<$type, D>> for Tensor
-        where
-            D: ndarray::Dimension,
-        {
-            type Error = TchError;
-
-            fn try_from(value: ndarray::Array<$type, D>) -> Result<Self, Self::Error> {
-                // TODO: Replace this with `?` once `std::option::NoneError` has been stabilized.
-                let slice = match value.as_slice() {
-                    None => return Err(TchError::Convert("cannot convert to slice".to_string())),
-                    Some(v) => v,
-                };
-                let tn = Self::f_of_slice(slice)?;
-                let shape: Vec<i64> = value.shape().iter().map(|s| *s as i64).collect();
-                tn.f_reshape(&shape)
-            }
-        }
-
-        impl TryFrom<Vec<$type>> for Tensor {
-            type Error = TchError;
-
-            fn try_from(value: Vec<$type>) -> Result<Self, Self::Error> {
-                let tn = Self::f_of_slice(value.as_slice())?;
-                Ok(tn)
-            }
-        }
-    };
+    fn try_from(value: ndarray::Array<T, D>) -> Result<Self, Self::Error> {
+        // TODO: Replace this with `?` once `std::option::NoneError` has been stabilized.
+        let slice = match value.as_slice() {
+            None => return Err(TchError::Convert("cannot convert to slice".to_string())),
+            Some(v) => v,
+        };
+        let tn = Self::f_of_slice(slice)?;
+        let shape: Vec<i64> = value.shape().iter().map(|s| *s as i64).collect();
+        tn.f_reshape(&shape)
+    }
 }
 
-try_from_impl!(f16);
-try_from_impl!(f32);
-try_from_impl!(i32);
-try_from_impl!(f64);
-try_from_impl!(i64);
-try_from_impl!(bool);
+impl<T> TryFrom<Vec<T>> for Tensor
+where
+    T: crate::kind::Element,
+{
+    type Error = TchError;
+
+    fn try_from(value: Vec<T>) -> Result<Self, Self::Error> {
+        let tn = Self::f_of_slice(value.as_slice())?;
+        Ok(tn)
+    }
+}
 
 #[used]
 static INIT_ARRAY: [unsafe extern "C" fn(); 1] = [dummy_cuda_dependency];


### PR DESCRIPTION
In most cases the macros were not necessary and can be replaced by a generic implementation over `T: crate::kind::Element`.

The `T: Default` bound is to allow zero-initializing Vec in `From<&Tensor> for Vec<T>`.
There's probably an unsafe way to avoid the zero-initialization since those values should be overwritten anyway, but that's out of scope for this commit.