### PR TITLE
Use ok_or_else in `TryFrom<&ArrayBase>`

### DIFF
--- a/src/tensor/convert.rs
+++ b/src/tensor/convert.rs
@@ -97,11 +97,9 @@ where
     type Error = TchError;
 
     fn try_from(value: &ndarray::ArrayBase<T, D>) -> Result<Self, Self::Error> {
-        // TODO: Replace this with `?` once `std::option::NoneError` has been stabilized.
-        let slice = match value.as_slice() {
-            None => return Err(TchError::Convert("cannot convert to slice".to_string())),
-            Some(v) => v,
-        };
+        let slice = value
+            .as_slice()
+            .ok_or_else(|| TchError::Convert("cannot convert to slice".to_string()))?;
         let tn = Self::f_of_slice(slice)?;
         let shape: Vec<i64> = value.shape().iter().map(|s| *s as i64).collect();
         tn.f_reshape(&shape)


### PR DESCRIPTION
* Use `ok_or_else` instead of match
~~* Return value directly instead of separate `let v = ...?; Ok(v)`~~

~~This builds on #356 (but can be implemented without it). Don't merge unless #356 has been merged.~~