### PR TITLE
Updated `Linear` bias to be optional instead of zeroes

### DIFF
--- a/src/nn/linear.rs
+++ b/src/nn/linear.rs
@@ -1,5 +1,4 @@
 //! A linear fully-connected layer.
-use crate::wrappers::kind::Kind::Float;
 use crate::Tensor;
 use std::borrow::Borrow;
 
@@ -25,7 +24,7 @@ impl Default for LinearConfig {
 #[derive(Debug)]
 pub struct Linear {
     pub ws: Tensor,
-    pub bs: Tensor,
+    pub bs: Option<Tensor>,
 }
 
 /// Creates a new linear layer.
@@ -44,9 +43,9 @@ pub fn linear<'a, T: Borrow<super::Path<'a>>>(
                 up: bound,
             }
         });
-        vs.var("bias", &[out_dim], bs_init)
+        Some(vs.var("bias", &[out_dim], bs_init))
     } else {
-        Tensor::zeros(&[out_dim], (Float, vs.device()))
+        None
     };
 
     Linear {
@@ -57,6 +56,10 @@ pub fn linear<'a, T: Borrow<super::Path<'a>>>(
 
 impl super::module::Module for Linear {
     fn forward(&self, xs: &Tensor) -> Tensor {
-        xs.matmul(&self.ws.tr()) + &self.bs
+        if let Some(bias) = &self.bs {
+            xs.matmul(&self.ws.tr()) + bias
+        } else {
+            xs.matmul(&self.ws.tr())
+        }
     }
 }

--- a/tests/nn_tests.rs
+++ b/tests/nn_tests.rs
@@ -38,7 +38,7 @@ fn optimizer_test() {
     // Reset the weights to their initial values.
     tch::no_grad(|| {
         linear.ws.init(nn::Init::Const(0.));
-        linear.bs.init(nn::Init::Const(0.));
+        linear.bs.as_mut().unwrap().init(nn::Init::Const(0.));
     });
     let initial_loss2 = f64::from(xs.apply(&linear).mse_loss(&ys, Reduction::Mean));
     assert_eq!(initial_loss, initial_loss2);

--- a/tests/var_store.rs
+++ b/tests/var_store.rs
@@ -400,7 +400,7 @@ fn path_half_precision_conversion() {
         Kind::Float
     );
     assert_eq!(linear_layer.ws.kind(), Kind::Float);
-    assert_eq!(linear_layer.bs.kind(), Kind::Float);
+    assert_eq!(linear_layer.bs.as_ref().unwrap().kind(), Kind::Float);
 
     vs.root().sub("convert").half();
 
@@ -418,7 +418,7 @@ fn path_half_precision_conversion() {
         Kind::Half
     );
     assert_eq!(linear_layer.ws.kind(), Kind::Half);
-    assert_eq!(linear_layer.bs.kind(), Kind::Half);
+    assert_eq!(linear_layer.bs.as_ref().unwrap().kind(), Kind::Half);
 
     vs.root().sub("convert").float();
 
@@ -436,7 +436,7 @@ fn path_half_precision_conversion() {
         Kind::Float
     );
     assert_eq!(linear_layer.ws.kind(), Kind::Float);
-    assert_eq!(linear_layer.bs.kind(), Kind::Float);
+    assert_eq!(linear_layer.bs.as_ref().unwrap().kind(), Kind::Float);
 }
 
 #[test]
@@ -573,7 +573,7 @@ fn device_migration() {
         assert_eq!(vs.root().get("zeros").unwrap().device(), Device::Cuda(0));
         assert_eq!(vs.root().get("ones").unwrap().device(), Device::Cuda(0));
         assert_eq!(linear_layer.ws.device(), Device::Cuda(0));
-        assert_eq!(linear_layer.bs.device(), Device::Cuda(0));
+        assert_eq!(linear_layer.bs.as_ref().unwrap().device(), Device::Cuda(0));
         assert_eq!(vs.device(), Device::Cuda(0));
 
         vs.set_device(Device::Cpu);
@@ -581,7 +581,7 @@ fn device_migration() {
         assert_eq!(vs.root().get("zeros").unwrap().device(), Device::Cpu);
         assert_eq!(vs.root().get("ones").unwrap().device(), Device::Cpu);
         assert_eq!(linear_layer.ws.device(), Device::Cpu);
-        assert_eq!(linear_layer.bs.device(), Device::Cpu);
+        assert_eq!(linear_layer.bs.as_ref().unwrap().device(), Device::Cpu);
         assert_eq!(vs.device(), Device::Cpu);
     }
 }


### PR DESCRIPTION
- Change type of `bs` to `Option<Tensor>`
- Updated forward pass to add bias only when non-None
- Updated unit tests that were accessing the `bs` field directly

Fixes https://github.com/LaurentMazare/tch-rs/issues/421