### PR TITLE
lstm/gru: use Borrow<Path> instead of &var_store::Path

### DIFF
--- a/src/nn/rnn.rs
+++ b/src/nn/rnn.rs
@@ -1,5 +1,6 @@
 //! Recurrent Neural Networks
 use crate::{Device, Kind, Tensor};
+use std::borrow::Borrow;
 
 /// Trait for Recurrent Neural Networks.
 #[allow(clippy::upper_case_acronyms)]
@@ -86,7 +87,13 @@ pub struct LSTM {
 }
 
 /// Creates a LSTM layer.
-pub fn lstm(vs: &super::var_store::Path, in_dim: i64, hidden_dim: i64, c: RNNConfig) -> LSTM {
+pub fn lstm<'a, T: Borrow<super::Path<'a>>>(
+    vs: T,
+    in_dim: i64,
+    hidden_dim: i64,
+    c: RNNConfig,
+) -> LSTM {
+    let vs = vs.borrow();
     let num_directions = if c.bidirectional { 2 } else { 1 };
     let gate_dim = 4 * hidden_dim;
     let mut flat_weights = vec![];
@@ -186,7 +193,13 @@ pub struct GRU {
 }
 
 /// Creates a new GRU layer.
-pub fn gru(vs: &super::var_store::Path, in_dim: i64, hidden_dim: i64, c: RNNConfig) -> GRU {
+pub fn gru<'a, T: Borrow<super::Path<'a>>>(
+    vs: T,
+    in_dim: i64,
+    hidden_dim: i64,
+    c: RNNConfig,
+) -> GRU {
+    let vs = vs.borrow();
     let num_directions = if c.bidirectional { 2 } else { 1 };
     let gate_dim = 3 * hidden_dim;
     let mut flat_weights = vec![];


### PR DESCRIPTION
This changes `nn::rnn::lstm()` and `nn::rnn::gru()` function signatures to take in a `Borrow<Path>` instead of a `&Path`, similar to how it's done seemingly everywhere else.

Without this, lstm/gru creation is slightly less ergonomic than other layers. Example of inconsistency:

```Rust
let embed = nn::embedding(
    // we can easily use "/" for custom path and don't have to reborrow whole thing manually
    &vs.root() / "embed",
    ..
);
let lstm = nn::lstm(
    // have to manually borrow the result of the "/" expression...
    &(&vs.root() / "lstm"),
    ..
);
```

This should be backwards-compatible.