### PR TITLE
Patch mnist_conv example (see #434)

### DIFF
--- a/examples/mnist/mnist_conv.rs
+++ b/examples/mnist/mnist_conv.rs
@@ -31,7 +31,7 @@ impl nn::ModuleT for Net {
             .view([-1, 1024])
             .apply(&self.fc1)
             .relu()
-            .dropout_(0.5, train)
+            .dropout(0.5, train)
             .apply(&self.fc2)
     }
 }


### PR DESCRIPTION
Currently in the mnist examples, `mnist_conv.rs` panics because `dropout_` is changing a value in-place. Changing it to `dropout` fixes the issue (see #434)