### PR TITLE
Use Iter2's device instead of hardcoding CPU for shuffle method

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -1,5 +1,5 @@
 //! Dataset iterators.
-use crate::{kind, Device, IndexOp, TchError, Tensor};
+use crate::{kind, kind::Kind, Device, IndexOp, TchError, Tensor};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufReader, Read};
@@ -74,7 +74,7 @@ impl Iter2 {
     /// The iterator would still run over the whole dataset but the order in
     /// which elements are grouped in mini-batches is randomized.
     pub fn shuffle(&mut self) -> &mut Iter2 {
-        let index = Tensor::randperm(self.total_size, kind::INT64_CPU);
+        let index = Tensor::randperm(self.total_size, (Kind::Int64, self.device));
         self.xs = self.xs.index_select(0, &index);
         self.ys = self.ys.index_select(0, &index);
         self


### PR DESCRIPTION
Previously this would crash if `self.xs` or `self.xy` was on CUDA because it the tensor used in `index_select` was on a different device.

All tests pass.
I have tested this with and without CUDA and it doesn't crash.
I have not checked the correctness of the output, but I assume it is correct, since it is such a small change I don't see how it could go wrong.