### PR TITLE
use std::fs::read instead of manual BufReader in data::TextData::new()

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -1,8 +1,6 @@
 //! Dataset iterators.
 use crate::{kind, kind::Kind, Device, IndexOp, TchError, Tensor};
 use std::collections::HashMap;
-use std::fs::File;
-use std::io::{BufReader, Read};
 
 /// An iterator over a pair of tensors which have the same first dimension
 /// size.
@@ -134,9 +132,7 @@ pub struct TextDataIter {
 impl TextData {
     /// Creates a text dataset from a file.
     pub fn new<P: AsRef<std::path::Path>>(filename: P) -> Result<TextData, TchError> {
-        let mut buf_reader = BufReader::new(File::open(filename)?);
-        let mut buffer = Vec::new();
-        buf_reader.read_to_end(&mut buffer)?;
+        let mut buffer = std::fs::read(filename)?;
 
         let mut label_for_char = HashMap::<u8, u8>::new();
         let mut char_for_label = Vec::<char>::new();


### PR DESCRIPTION
hi, sry, another drive-by "improvement"

`TextData::new()` function manually creates a `BufReader` around `File`, and then calls `read_to_end` on it to read all the data in memory. In `read_to_end` case, `BufReader` actually defers to inner's implementation, in this case `File`'s impl, we can easily verify this here: https://doc.rust-lang.org/stable/src/std/io/buffered/bufreader.rs.html#313

But for handling `File::read_to_end()` into a `Vec<u8>`, Rust's std library has a nice convenience method ready to go: `std::fs::read()`

This PR merely calls the stdlib convenience function for reading file into vec of bytes. This should have no measurable performance impact. The code is a bit shorter, though.