### PR TITLE
Make `torch-sys/download-libtorch` an opt-in feature instead of default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,10 @@ anyhow = "1"
 members = ["torch-sys"]
 
 [features]
-default = ["torch-sys/download-libtorch"]
 python = ["cpython"]
 doc-only = ["torch-sys/doc-only"]
 cuda-tests = []
+download-libtorch = ["torch-sys/download-libtorch"]
 
 [package.metadata.docs.rs]
 features = [ "doc-only" ]

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ your system. You can either:
 
 - Use the system-wide libtorch installation (default).
 - Install libtorch manually and let the build script know about it via the `LIBTORCH` environment variable.
-- When a system-wide libtorch can't be found and `LIBTORCH` is not set, the build script will download a pre-built binary version
-of libtorch. By default a CPU version is used. The `TORCH_CUDA_VERSION` environment variable
-can be set to `cu111` in order to get a pre-built binary using CUDA 11.1.
+- When a system-wide libtorch can't be found, `LIBTORCH` is not set, and the `download-libtorch` feature is enabled,
+the build script will download a pre-built binary version of libtorch.
+By default a CPU version is used. The `TORCH_CUDA_VERSION` environment variable can be set to `cu111` in order to get a pre-built binary using CUDA 11.1.
 
 ### System-wide Libtorch
 


### PR DESCRIPTION
In the case of using `tch` as a sub-dependency of [other crates](https://crates.io/crates/tch/reverse_dependencies), disabling the default feature of downloading `libtorch` when depending on any of them becomes impossible.
According to [this comment](https://github.com/rust-lang/cargo/issues/1886#issuecomment-130089656), features that are marked as default should be so only if it's something that will be used in most cases, not as a way to mark something optional.