### PR TITLE
Expose set graph executor optimize.

### DIFF
--- a/src/wrappers/jit.rs
+++ b/src/wrappers/jit.rs
@@ -701,6 +701,15 @@ pub fn set_profiling_mode(b: bool) {
     f_set_profiling_mode(b).unwrap()
 }
 
+pub fn f_set_graph_executor_optimize(b: bool) -> Result<(), TchError> {
+    unsafe_torch_err!(at_set_graph_executor_optimize(b));
+    Ok(())
+}
+
+pub fn set_graph_executor_optimize(b: bool) {
+    f_set_graph_executor_optimize(b).unwrap();
+}
+
 #[derive(Debug, PartialEq)]
 pub struct Object {
     c_ivalue: *mut CIValue,

--- a/torch-sys/libtch/torch_api.cpp
+++ b/torch-sys/libtch/torch_api.cpp
@@ -3,6 +3,7 @@
 #include<torch/csrc/jit/runtime/graph_executor.h>
 #include <torch/csrc/jit/passes/fixup_trace_scope_blocks.h>
 #include <torch/csrc/jit/passes/normalize_ops.h>
+#include <torch/csrc/jit/runtime/graph_executor.h>
 #include<torch/torch.h>
 #include<ATen/autocast_mode.h>
 #include<torch/script.h>
@@ -1409,6 +1410,10 @@ ivalue ati_object_method_(ivalue i, char *method_name, ivalue *ivalues, int niva
 
 void ati_free(ivalue i) {
   delete(i);
+}
+
+void at_set_graph_executor_optimize(bool o) {
+  torch::jit::setGraphExecutorOptimize(o);
 }
 
 #include "torch_api_generated.cpp.h"

--- a/torch-sys/libtch/torch_api.h
+++ b/torch-sys/libtch/torch_api.h
@@ -217,6 +217,8 @@ ivalue ati_object_method_(ivalue i, char *method_name, ivalue *ivalues, int niva
 
 void ati_free(ivalue);
 
+void at_set_graph_executor_optimize(bool);
+
 // for internal use
 bool tch_write_stream_destructor(void *stream_ptr);
 bool tch_write_stream_write(void *stream_ptr, const uint8_t *buf, size_t size, size_t *out_size);

--- a/torch-sys/src/lib.rs
+++ b/torch-sys/src/lib.rs
@@ -127,6 +127,10 @@ extern "C" {
     pub fn at_manual_seed(seed: i64);
 }
 
+extern "C" {
+    pub fn at_set_graph_executor_optimize(b: bool);
+}
+
 pub mod c_generated;
 
 extern "C" {


### PR DESCRIPTION
This PR exposes `torch::jit::setGraphExecutorOptimize()`.

I tested it and the behavior of the network changes (reduces the amount of warmups needed), but it is not as effective as in the original C++ implementation, so I am open to any suggestions on how to improve this