### PR TITLE
manual impl retain_grad for Tensor

### DIFF
--- a/src/wrappers/scalar.rs
+++ b/src/wrappers/scalar.rs
@@ -71,6 +71,12 @@ impl From<f64> for Scalar {
     }
 }
 
+impl From<f32> for Scalar {
+    fn from(v: f32) -> Scalar {
+        Scalar::float(v as f64)
+    }
+}
+
 impl From<Scalar> for i64 {
     fn from(s: Scalar) -> i64 {
         Self::from(&s)

--- a/src/wrappers/tensor.rs
+++ b/src/wrappers/tensor.rs
@@ -249,6 +249,19 @@ impl Tensor {
         unsafe_torch!(at_requires_grad(self.c_tensor)) != 0
     }
 
+    /// Enables this Tensor to have their grad populated during backward().
+    /// This is a no-op for leaf tensors.
+    pub fn f_retain_grad(&self) -> Result<(), TchError> {
+        unsafe_torch_err!(at_retain_grad(self.c_tensor));
+        Ok(())
+    }
+
+    /// Enables this Tensor to have their grad populated during backward().
+    /// This is a no-op for leaf tensors.
+    pub fn retain_grad(&self) {
+        self.f_retain_grad().unwrap()
+    }
+
     /// Returns the address of the first element of this tensor.
     pub fn data_ptr(&self) -> *mut c_void {
         unsafe_torch!(at_data_ptr(self.c_tensor))

--- a/tests/tensor_tests.rs
+++ b/tests/tensor_tests.rs
@@ -88,6 +88,19 @@ fn grad() {
 }
 
 #[test]
+fn grad_retain_grad() {
+    let x = Tensor::from(2.0).set_requires_grad(true);
+    let y = &x * &x;
+    let z = &y * 2 + &x + 36;
+    y.retain_grad();
+    z.backward();
+    let dz_over_dx = x.grad();
+    assert_eq!(Vec::<f64>::from(&dz_over_dx), [9.0]);
+    let dz_over_dy = y.grad();
+    assert_eq!(Vec::<f64>::from(&dz_over_dy), [2.0]);
+}
+
+#[test]
 fn grad_grad() {
     // Compute a second order derivative using run_backward.
     let mut x = Tensor::from(42.0).set_requires_grad(true);

--- a/torch-sys/libtch/torch_api.cpp
+++ b/torch-sys/libtch/torch_api.cpp
@@ -216,6 +216,8 @@ int at_grad_set_enabled(int b) {
   return -1;
 }
 
+void at_retain_grad(tensor t) { PROTECT(t->retain_grad();) }
+
 tensor at_get(tensor t, int index) {
   PROTECT(return new torch::Tensor((*t)[index]);)
   return nullptr;

--- a/torch-sys/libtch/torch_api.h
+++ b/torch-sys/libtch/torch_api.h
@@ -54,6 +54,7 @@ bool at_autocast_set_enabled(bool b);
 void at_backward(tensor, int, int);
 int at_requires_grad(tensor);
 int at_grad_set_enabled(int);
+void at_retain_grad(tensor); // manual impl retain_grad
 
 tensor at_get(tensor, int index);
 void at_fill_double(tensor, double);

--- a/torch-sys/src/lib.rs
+++ b/torch-sys/src/lib.rs
@@ -35,6 +35,7 @@ extern "C" {
     pub fn at_dim(arg: *mut C_tensor) -> size_t;
     pub fn at_get(arg: *mut C_tensor, index: c_int) -> *mut C_tensor;
     pub fn at_requires_grad(arg: *mut C_tensor) -> c_int;
+    pub fn at_retain_grad(arg: *mut C_tensor);
     pub fn at_shape(arg: *mut C_tensor, sz: *mut i64);
     pub fn at_stride(arg: *mut C_tensor, sz: *mut i64);
     pub fn at_double_value_at_indexes(arg: *mut C_tensor, idx: *const i64, idx_len: c_int) -> f64;


### PR DESCRIPTION
hi, 

I just import retain_grad() function, so that we can enable grad attribute for non-leaf tensors.

