### PR TITLE
convert f32 to scalar

### DIFF
--- a/src/wrappers/scalar.rs
+++ b/src/wrappers/scalar.rs
@@ -71,6 +71,12 @@ impl From<f64> for Scalar {
     }
 }
 
+impl From<f32> for Scalar {
+    fn from(v: f32) -> Scalar {
+        Scalar::float(v as f64)
+    }
+}
+
 impl From<Scalar> for i64 {
     fn from(s: Scalar) -> i64 {
         Self::from(&s)


### PR DESCRIPTION
it is very useful to have covert f32 to Scalar, so that we can call with

```
let a = some tensor;

let a = a /  3.0;

```