### PR TITLE
expose `getattr` for jit object

### DIFF
--- a/src/wrappers/jit.rs
+++ b/src/wrappers/jit.rs
@@ -738,6 +738,18 @@ impl Object {
         }
         IValue::of_c(c_ivalue)
     }
+
+    pub fn getattr(&self, attr_name: &str) -> Result<IValue, TchError> {
+        let property_name = std::ffi::CString::new(attr_name)?;
+        let c_ivalue =
+            unsafe_torch_err!(ati_object_getattr_(self.c_ivalue, property_name.as_ptr()));
+        if c_ivalue == std::ptr::null_mut() {
+            return Err(TchError::Torch(
+                "getattr return nullptr c_ivalue".to_string(),
+            ));
+        }
+        IValue::of_c(c_ivalue)
+    }
 }
 
 impl Drop for Object {

--- a/src/wrappers/jit.rs
+++ b/src/wrappers/jit.rs
@@ -744,9 +744,10 @@ impl Object {
         let c_ivalue =
             unsafe_torch_err!(ati_object_getattr_(self.c_ivalue, property_name.as_ptr()));
         if c_ivalue.is_null() {
-            return Err(TchError::Torch(
-                format!("Object.getattr(\"{}\") returned CIValue nullptr", attr_name),
-            ));
+            return Err(TchError::Torch(format!(
+                "Object.getattr(\"{}\") returned CIValue nullptr",
+                attr_name
+            )));
         }
         IValue::of_c(c_ivalue)
     }

--- a/src/wrappers/jit.rs
+++ b/src/wrappers/jit.rs
@@ -743,9 +743,9 @@ impl Object {
         let property_name = std::ffi::CString::new(attr_name)?;
         let c_ivalue =
             unsafe_torch_err!(ati_object_getattr_(self.c_ivalue, property_name.as_ptr()));
-        if c_ivalue == std::ptr::null_mut() {
+        if c_ivalue.is_null() {
             return Err(TchError::Torch(
-                "getattr return nullptr c_ivalue".to_string(),
+                format!("Object.getattr(\"{}\") returned CIValue nullptr", attr_name),
             ));
         }
         IValue::of_c(c_ivalue)

--- a/torch-sys/libtch/torch_api.cpp
+++ b/torch-sys/libtch/torch_api.cpp
@@ -1408,11 +1408,18 @@ ivalue ati_object_method_(ivalue i, char *method_name, ivalue *ivalues, int niva
   return nullptr;
 }
 
+ivalue ati_object_getattr_(ivalue i, char *attr_name) {
+  PROTECT(
+    torch::jit::IValue output  = i->toObjectRef().getAttr(attr_name);
+    return new torch::jit::IValue(output);
+  )
+  return nullptr;
+}
+
 ivalue ati_clone(ivalue i) {
   PROTECT(
     return new torch::jit::IValue(*i);
   )
-  return nullptr;
 }
 
 void ati_free(ivalue i) {

--- a/torch-sys/libtch/torch_api.cpp
+++ b/torch-sys/libtch/torch_api.cpp
@@ -1420,6 +1420,7 @@ ivalue ati_clone(ivalue i) {
   PROTECT(
     return new torch::jit::IValue(*i);
   )
+  return nullptr;
 }
 
 void ati_free(ivalue i) {

--- a/torch-sys/libtch/torch_api.h
+++ b/torch-sys/libtch/torch_api.h
@@ -214,6 +214,7 @@ void ati_to_tensor_list(ivalue, tensor *, int);
 int ati_tag(ivalue);
 
 ivalue ati_object_method_(ivalue i, char *method_name, ivalue *ivalues, int nivalues);
+ivalue ati_object_getattr_(ivalue i, char *attr_name);
 
 ivalue ati_clone(ivalue);
 void ati_free(ivalue);

--- a/torch-sys/src/lib.rs
+++ b/torch-sys/src/lib.rs
@@ -248,10 +248,7 @@ extern "C" {
         n: c_int,
     ) -> *mut CIValue;
 
-    pub fn ati_object_getattr_(
-        arg: *mut CIValue,
-        attr_name: *const c_char,
-    ) -> *mut CIValue;
+    pub fn ati_object_getattr_(arg: *mut CIValue, attr_name: *const c_char) -> *mut CIValue;
 
     pub fn atm_load(filename: *const c_char) -> *mut CModule_;
     pub fn atm_load_on_device(filename: *const c_char, device: c_int) -> *mut CModule_;

--- a/torch-sys/src/lib.rs
+++ b/torch-sys/src/lib.rs
@@ -248,6 +248,11 @@ extern "C" {
         n: c_int,
     ) -> *mut CIValue;
 
+    pub fn ati_object_getattr_(
+        arg: *mut CIValue,
+        attr_name: *const c_char,
+    ) -> *mut CIValue;
+
     pub fn atm_load(filename: *const c_char) -> *mut CModule_;
     pub fn atm_load_on_device(filename: *const c_char, device: c_int) -> *mut CModule_;
     pub fn atm_load_str(data: *const c_char, sz: size_t) -> *mut CModule_;


### PR DESCRIPTION
## Summary
- expose `getattr` for `tch::jit::object`
  - allow access to the torch jit object attributes