### PR TITLE
Orthogonal weight initialization, RNN weight and bias config

### DIFF
--- a/src/nn/rnn.rs
+++ b/src/nn/rnn.rs
@@ -59,6 +59,10 @@ pub struct RNNConfig {
     pub train: bool,
     pub bidirectional: bool,
     pub batch_first: bool,
+    pub w_ih_init: super::Init,
+    pub w_hh_init: super::Init,
+    pub b_ih_init: Option<super::Init>,
+    pub b_hh_init: Option<super::Init>,
 }
 
 impl Default for RNNConfig {
@@ -70,8 +74,57 @@ impl Default for RNNConfig {
             train: true,
             bidirectional: false,
             batch_first: true,
+            w_ih_init: super::Init::KaimingUniform,
+            w_hh_init: super::Init::KaimingUniform,
+            b_ih_init: Some(super::Init::Const(0.)),
+            b_hh_init: Some(super::Init::Const(0.)),
         }
     }
+}
+
+fn rnn_weights<'a, T: Borrow<super::Path<'a>>>(
+    vs: T,
+    in_dim: i64,
+    hidden_dim: i64,
+    gate_dim: i64,
+    num_directions: i64,
+    c: RNNConfig,
+) -> Vec<Tensor> {
+    let vs = vs.borrow();
+    let mut flat_weights = vec![];
+    for layer_idx in 0..c.num_layers {
+        for direction_idx in 0..num_directions {
+            let in_dim = if layer_idx == 0 { in_dim } else { hidden_dim * num_directions };
+            let suffix = if direction_idx == 1 { "_reverse" } else { "" };
+            let w_ih = vs.var(
+                &format!("weight_ih_l{}{}", layer_idx, suffix),
+                &[gate_dim, in_dim],
+                c.w_ih_init,
+            );
+            let w_hh = vs.var(
+                &format!("weight_hh_l{}{}", layer_idx, suffix),
+                &[gate_dim, hidden_dim],
+                c.w_hh_init,
+            );
+            flat_weights.push(w_ih);
+            flat_weights.push(w_hh);
+            if c.has_biases {
+                let b_ih = vs.var(
+                    &format!("bias_ih_l{}{}", layer_idx, suffix),
+                    &[gate_dim],
+                    c.b_ih_init.unwrap(),
+                );
+                let b_hh = vs.var(
+                    &format!("bias_hh_l{}{}", layer_idx, suffix),
+                    &[gate_dim],
+                    c.b_hh_init.unwrap(),
+                );
+                flat_weights.push(b_ih);
+                flat_weights.push(b_hh);
+            }
+        }
+    }
+    flat_weights
 }
 
 /// A Long Short-Term Memory (LSTM) layer.
@@ -96,29 +149,8 @@ pub fn lstm<'a, T: Borrow<super::Path<'a>>>(
     let vs = vs.borrow();
     let num_directions = if c.bidirectional { 2 } else { 1 };
     let gate_dim = 4 * hidden_dim;
-    let mut flat_weights = vec![];
-    for layer_idx in 0..c.num_layers {
-        for direction_idx in 0..num_directions {
-            let in_dim = if layer_idx == 0 { in_dim } else { hidden_dim * num_directions };
-            let suffix = if direction_idx == 1 { "_reverse" } else { "" };
-            let w_ih = vs.kaiming_uniform(
-                &format!("weight_ih_l{}{}", layer_idx, suffix),
-                &[gate_dim, in_dim],
-            );
-            let w_hh = vs.kaiming_uniform(
-                &format!("weight_hh_l{}{}", layer_idx, suffix),
-                &[gate_dim, hidden_dim],
-            );
-            flat_weights.push(w_ih);
-            flat_weights.push(w_hh);
-            if c.has_biases {
-                let b_ih = vs.zeros(&format!("bias_ih_l{}{}", layer_idx, suffix), &[gate_dim]);
-                let b_hh = vs.zeros(&format!("bias_hh_l{}{}", layer_idx, suffix), &[gate_dim]);
-                flat_weights.push(b_ih);
-                flat_weights.push(b_hh);
-            }
-        }
-    }
+    let flat_weights = rnn_weights(vs, in_dim, hidden_dim, gate_dim, num_directions, c);
+
     if vs.device().is_cuda() && crate::Cuda::cudnn_is_available() {
         let _ = Tensor::internal_cudnn_rnn_flatten_weight(
             &flat_weights,
@@ -202,29 +234,8 @@ pub fn gru<'a, T: Borrow<super::Path<'a>>>(
     let vs = vs.borrow();
     let num_directions = if c.bidirectional { 2 } else { 1 };
     let gate_dim = 3 * hidden_dim;
-    let mut flat_weights = vec![];
-    for layer_idx in 0..c.num_layers {
-        for direction_idx in 0..num_directions {
-            let in_dim = if layer_idx == 0 { in_dim } else { hidden_dim * num_directions };
-            let suffix = if direction_idx == 1 { "_reverse" } else { "" };
-            let w_ih = vs.kaiming_uniform(
-                &format!("weight_ih_l{}{}", layer_idx, suffix),
-                &[gate_dim, in_dim],
-            );
-            let w_hh = vs.kaiming_uniform(
-                &format!("weight_hh_l{}{}", layer_idx, suffix),
-                &[gate_dim, hidden_dim],
-            );
-            flat_weights.push(w_ih);
-            flat_weights.push(w_hh);
-            if c.has_biases {
-                let b_ih = vs.zeros(&format!("bias_ih_l{}{}", layer_idx, suffix), &[gate_dim]);
-                let b_hh = vs.zeros(&format!("bias_hh_l{}{}", layer_idx, suffix), &[gate_dim]);
-                flat_weights.push(b_ih);
-                flat_weights.push(b_hh);
-            }
-        }
-    }
+    let flat_weights = rnn_weights(vs, in_dim, hidden_dim, gate_dim, num_directions, c);
+
     if vs.device().is_cuda() && crate::Cuda::cudnn_is_available() {
         let _ = Tensor::internal_cudnn_rnn_flatten_weight(
             &flat_weights,

--- a/src/nn/var_store.rs
+++ b/src/nn/var_store.rs
@@ -530,6 +530,20 @@ impl<'a> Path<'a> {
         self.f_var(name, dims, Init::KaimingUniform)
     }
 
+    /// Creats a new variable initialized randomly with an orthogonal matrix
+    ///
+    /// The new variable is named according to the name parameter and
+    /// has the specified shape. The variable is trainable, its gradient
+    /// will be tracked.
+    /// The variable uses a float tensor initialized randomly with an orthogonal
+    /// matrix as described in *Exact solutions to the nonlinear dynamics
+    /// of learning in deep linear neural networks* - Saxe, A. et. al. (2013).
+    /// The input tensor must have at least 2 dimensions, and for tensors
+    /// with more than 2 dimensions the trailing dimensions are flattened.
+    pub fn f_orthogonal(&self, name: &str, dims: &[i64], gain: f64) -> Result<Tensor, TchError> {
+        self.f_var(name, dims, Init::Orthogonal { gain })
+    }
+
     /// Creates a new variable initialized by copying an existing tensor.
     ///
     /// The new variable is named according to the name parameter and
@@ -638,6 +652,20 @@ impl<'a> Path<'a> {
         self.f_kaiming_uniform(name, dims).unwrap()
     }
 
+    /// Creats a new variable initialized randomly with an orthogonal matrix
+    ///
+    /// The new variable is named according to the name parameter and
+    /// has the specified shape. The variable is trainable, its gradient
+    /// will be tracked.
+    /// The variable uses a float tensor initialized randomly with an orthogonal
+    /// matrix as described in *Exact solutions to the nonlinear dynamics
+    /// of learning in deep linear neural networks* - Saxe, A. et. al. (2013).
+    /// The input tensor must have at least 2 dimensions, and for tensors
+    /// with more than 2 dimensions the trailing dimensions are flattened.
+    pub fn orthogonal(&self, name: &str, dims: &[i64], gain: f64) -> Tensor {
+        self.f_orthogonal(name, dims, gain).unwrap()
+    }
+
     /// Creates a new variable initialized by copying an existing tensor.
     ///
     /// The new variable is named according to the name parameter and
@@ -685,6 +713,11 @@ impl<'a> Entry<'a> {
     /// Returns the existing entry if, otherwise create a new variable.
     pub fn or_kaiming_uniform(self, dims: &[i64]) -> Tensor {
         self.or_var(dims, Init::KaimingUniform)
+    }
+
+    /// Returns the existing entry if, otherwise create a new variable.
+    pub fn or_orthogonal(self, dims: &[i64], gain: f64) -> Tensor {
+        self.or_var(dims, Init::Orthogonal { gain })
     }
 
     /// Returns the existing entry if, otherwise create a new variable.

--- a/tests/var_store.rs
+++ b/tests/var_store.rs
@@ -244,6 +244,11 @@ fn init_test() {
     assert_eq!(Vec::<f64>::from(&ones), [1., 1., 1.]);
     vs2.copy(&vs).unwrap();
     assert_eq!(Vec::<f64>::from(&ones), [0., 0., 0.]);
+    let ortho = vs.root().var("orthogonal", &[100, 100], Init::Orthogonal { gain: 2.0 });
+    let ortho_norm = f64::from(ortho.linalg_norm_ord_str("fro", None, true, Kind::Float));
+    assert_eq!(20., ortho_norm);
+    let ortho_shape_fail = tch::nn::f_init(Init::Orthogonal { gain: 1.0 }, &[10], Device::Cpu);
+    assert!(ortho_shape_fail.is_err());
 }
 
 fn check_param_group(mut opt: tch::nn::Optimizer, foo: Tensor, bar: Tensor) {


### PR DESCRIPTION
This PR adds Orthogonal Matrix weight initialization to nn::Init and exposes weight and bias initialization in RNNConfig.

Orthogonal matrix initialization is useful in reinforcement learning and used extensively in policy-based methods. The init code is based on the [pytorch code](https://pytorch.org/docs/stable/_modules/torch/nn/init.html#orthogonal_). There is a [c++ api function](https://pytorch.org/cppdocs/api/function_namespacetorch_1_1nn_1_1init_1a5978fcc257460475f635b5960e892a8e.html#_CPPv4N5torch2nn4init11orthogonal_E6Tensord), but it wasn't clear to me how to expose those functions for use. If it's preferable to use the c++ api point me to a good example of how to expose them and I can adjust the code accordingly.
Added two tests, one to check the init function works properly and second to ensure the check for shape requirements is present.

The RNNConfig exposes weight and bias initialization like is done for Linear and Embedding modules. I also factored out the for loops to its own function since they were practically identical for GRU and LSTM. I did not add a test to check that the proper number of layers were created as flat_weights is marked private and wasn't sure about the reasoning there. If there's a better way to test that or if your open to making flat_weights public I can add them.

I did run into something strange when writing the orthogonal test: Tensor::norm does not return consistent values. It's either a little high or a little low vs the expected value Tensor::linalg_norm gives. Torch::norm is deprecated so maybe this isn't a concern, but the python version is exact every run.

