### PR TITLE
Addition of VarStore merging capabilities 

### DIFF
--- a/src/nn/var_store.rs
+++ b/src/nn/var_store.rs
@@ -92,12 +92,8 @@ impl VarStore {
                         }
                     }
                 }
-                for trainable_var in Arc::try_unwrap(var_store.variables_)
-                    .unwrap()
-                    .into_inner()
-                    .unwrap()
-                    .trainable_variables
-                    .into_iter()
+                for trainable_var in
+                    var_store.variables_.lock().unwrap().trainable_variables.drain(..)
                 {
                     new_variables.trainable_variables.push(trainable_var);
                 }

--- a/src/nn/var_store.rs
+++ b/src/nn/var_store.rs
@@ -59,6 +59,58 @@ impl VarStore {
         VarStore { variables_: Arc::new(Mutex::new(variables)), device }
     }
 
+    pub fn from_existing(
+        mut var_stores: Vec<VarStore>,
+        prefixes: Option<&[&str]>,
+    ) -> Result<VarStore, TchError> {
+        let mut new_var_store = VarStore::new(Device::Cpu);
+
+        if var_stores.is_empty() {
+            Ok(new_var_store)
+        } else if var_stores.len() == 1 {
+            Ok(var_stores.pop().unwrap())
+        } else {
+            let mut new_variables =
+                Variables { named_variables: HashMap::new(), trainable_variables: Vec::new() };
+            let device = var_stores[0].device();
+            if let Some(prefixes_value) = prefixes {
+                if prefixes_value.len() != var_stores.len() {
+                    return Err(TchError::Shape(format!(
+                    "if prefixes are provided they must be of the same length of the var_stores, got {} prefixes and {} var stores",
+                    prefixes_value.len(),
+                    var_stores.len())));
+                }
+            }
+            for (var_store_index, var_store) in var_stores.into_iter().enumerate() {
+                if var_store.device() != device {
+                    return Err(TchError::Torch(format!(
+                        "All VarStores must be on the same device, got {:?} and {:?}",
+                        device,
+                        var_store.device()
+                    )));
+                }
+                for (var_name, var) in var_store.variables() {
+                    let prefix = prefixes.map_or("", |prefixes| prefixes[var_store_index]);
+                    let new_var_name = format!("{}{}", prefix, var_name);
+                    new_variables.named_variables.insert(new_var_name, var);
+                }
+                for trainable_var in Arc::try_unwrap(var_store.variables_)
+                    .unwrap()
+                    .into_inner()
+                    .unwrap()
+                    .trainable_variables
+                    .into_iter()
+                {
+                    new_variables.trainable_variables.push(trainable_var);
+                }
+            }
+            new_var_store.variables_ = Arc::new(Mutex::new(new_variables));
+            new_var_store.device = device;
+
+            Ok(new_var_store)
+        }
+    }
+
     /// Gets the device for this var-store.
     pub fn device(&self) -> Device {
         self.device

--- a/tests/var_store.rs
+++ b/tests/var_store.rs
@@ -508,7 +508,7 @@ fn merge_var_stores_no_prefixes() {
     let _ = vs_2.root().entry("key_3").or_zeros(&[2, 4, 4]);
     let _ = vs_2.root().entry("key_4").or_zeros(&[5, 2, 3]);
 
-    let merged_vs = VarStore::from_existing(vec![vs_1, vs_2], None).unwrap();
+    let merged_vs = VarStore::merge(vec![(vs_1, None), (vs_2, None)]).unwrap();
     assert_eq!(merged_vs.variables().len(), 4);
     assert_eq!(merged_vs.trainable_variables().len(), 4);
     assert!(merged_vs.variables().contains_key("key_1"));
@@ -527,7 +527,7 @@ fn merge_var_stores_with_prefixes() {
     let _ = vs_2.root().entry("key_3").or_zeros(&[2, 4, 4]);
     let _ = vs_2.root().entry("key_4").or_zeros(&[5, 2, 3]);
 
-    let merged_vs = VarStore::from_existing(vec![vs_1, vs_2], Some(&["vs_1.", "vs_2."])).unwrap();
+    let merged_vs = VarStore::merge(vec![(vs_1, Some("vs_1.")), (vs_2, Some("vs_2."))]).unwrap();
     assert_eq!(merged_vs.variables().len(), 4);
     assert_eq!(merged_vs.trainable_variables().len(), 4);
     assert!(merged_vs.variables().contains_key("vs_1.key_1"));

--- a/tests/var_store.rs
+++ b/tests/var_store.rs
@@ -497,3 +497,41 @@ fn device_migration() {
         assert_eq!(vs.device(), Device::Cpu);
     }
 }
+
+#[test]
+fn merge_var_stores_no_prefixes() {
+    let vs_1 = VarStore::new(Device::Cpu);
+    let _ = vs_1.root().entry("key_1").or_zeros(&[3, 1, 4]);
+    let _ = vs_1.root().entry("key_2").or_zeros(&[1, 5, 9]);
+
+    let vs_2 = VarStore::new(Device::Cpu);
+    let _ = vs_2.root().entry("key_3").or_zeros(&[2, 4, 4]);
+    let _ = vs_2.root().entry("key_4").or_zeros(&[5, 2, 3]);
+
+    let merged_vs = VarStore::from_existing(vec![vs_1, vs_2], None).unwrap();
+    assert_eq!(merged_vs.variables().len(), 4);
+    assert_eq!(merged_vs.trainable_variables().len(), 4);
+    assert!(merged_vs.variables().contains_key("key_1"));
+    assert!(merged_vs.variables().contains_key("key_2"));
+    assert!(merged_vs.variables().contains_key("key_3"));
+    assert!(merged_vs.variables().contains_key("key_4"));
+}
+
+#[test]
+fn merge_var_stores_with_prefixes() {
+    let vs_1 = VarStore::new(Device::Cpu);
+    let _ = vs_1.root().entry("key_1").or_zeros(&[3, 1, 4]);
+    let _ = vs_1.root().entry("key_2").or_zeros(&[1, 5, 9]);
+
+    let vs_2 = VarStore::new(Device::Cpu);
+    let _ = vs_2.root().entry("key_3").or_zeros(&[2, 4, 4]);
+    let _ = vs_2.root().entry("key_4").or_zeros(&[5, 2, 3]);
+
+    let merged_vs = VarStore::from_existing(vec![vs_1, vs_2], Some(&["vs_1.", "vs_2."])).unwrap();
+    assert_eq!(merged_vs.variables().len(), 4);
+    assert_eq!(merged_vs.trainable_variables().len(), 4);
+    assert!(merged_vs.variables().contains_key("vs_1.key_1"));
+    assert!(merged_vs.variables().contains_key("vs_1.key_2"));
+    assert!(merged_vs.variables().contains_key("vs_2.key_3"));
+    assert!(merged_vs.variables().contains_key("vs_2.key_4"));
+}


### PR DESCRIPTION
Addition of merge capabilities for `VarStore`:
- an input `Vec` of `VarStore` is consumed and the variables are moved into a new combined `VarStore`
- optional prefixes can be provided and prepended to the `VarStore` variables, for example to avoid key conflicts.

Fixes https://github.com/LaurentMazare/tch-rs/issues/494