### PR TITLE
Optional handling of scalar arguments that have default values.

### DIFF
--- a/src/wrappers/tensor_fallible_generated.rs
+++ b/src/wrappers/tensor_fallible_generated.rs
@@ -6762,6 +6762,25 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
+    pub fn f_baddbmm_s<S: Into<Scalar>>(
+        &self,
+        batch1: &Tensor,
+        batch2: &Tensor,
+        beta: S,
+        alpha: S,
+    ) -> Result<Tensor, TchError> {
+        let mut c_tensors = [std::ptr::null_mut(); 1];
+        unsafe_torch_err!(atg_baddbmm_s(
+            c_tensors.as_mut_ptr(),
+            self.c_tensor,
+            batch1.c_tensor,
+            batch2.c_tensor,
+            beta.into().c_scalar,
+            alpha.into().c_scalar
+        ));
+        Ok(Tensor { c_tensor: c_tensors[0] })
+    }
+
     pub fn f_bartlett_window(
         window_length: i64,
         options: (Kind, Device),

--- a/src/wrappers/tensor_generated.rs
+++ b/src/wrappers/tensor_generated.rs
@@ -3567,6 +3567,16 @@ impl Tensor {
         self.f_baddbmm_out(out, batch1, batch2).unwrap()
     }
 
+    pub fn baddbmm_s<S: Into<Scalar>>(
+        &self,
+        batch1: &Tensor,
+        batch2: &Tensor,
+        beta: S,
+        alpha: S,
+    ) -> Tensor {
+        self.f_baddbmm_s(batch1, batch2, beta, alpha).unwrap()
+    }
+
     pub fn bartlett_window(window_length: i64, options: (Kind, Device)) -> Tensor {
         Tensor::f_bartlett_window(window_length, options).unwrap()
     }

--- a/torch-sys/libtch/torch_api_generated.cpp.h
+++ b/torch-sys/libtch/torch_api_generated.cpp.h
@@ -3271,6 +3271,13 @@ void atg_baddbmm_out(tensor *out__, tensor out, tensor self, tensor batch1, tens
   )
 }
 
+void atg_baddbmm_s(tensor *out__, tensor self, tensor batch1, tensor batch2, scalar beta, scalar alpha) {
+  PROTECT(
+    auto outputs__ = torch::baddbmm(*self, *batch1, *batch2, *beta, *alpha);
+    out__[0] = new torch::Tensor(outputs__);
+  )
+}
+
 void atg_bartlett_window(tensor *out__, int64_t window_length, int options_kind, int options_device) {
   PROTECT(
     auto outputs__ = torch::bartlett_window(window_length, at::device(device_of_int(options_device)).dtype(at::ScalarType(options_kind)));

--- a/torch-sys/libtch/torch_api_generated.h
+++ b/torch-sys/libtch/torch_api_generated.h
@@ -453,6 +453,7 @@ void atg_avg_pool3d_out(tensor *, tensor out, tensor self, int64_t *kernel_size_
 void atg_baddbmm(tensor *, tensor self, tensor batch1, tensor batch2);
 void atg_baddbmm_(tensor *, tensor self, tensor batch1, tensor batch2);
 void atg_baddbmm_out(tensor *, tensor out, tensor self, tensor batch1, tensor batch2);
+void atg_baddbmm_s(tensor *, tensor self, tensor batch1, tensor batch2, scalar beta, scalar alpha);
 void atg_bartlett_window(tensor *, int64_t window_length, int options_kind, int options_device);
 void atg_bartlett_window_periodic(tensor *, int64_t window_length, int periodic, int options_kind, int options_device);
 void atg_batch_norm(tensor *, tensor input, tensor weight, tensor bias, tensor running_mean, tensor running_var, int training, double momentum, double eps, int cudnn_enabled);

--- a/torch-sys/src/c_generated.rs
+++ b/torch-sys/src/c_generated.rs
@@ -2765,6 +2765,14 @@ extern "C" {
         batch1_: *mut C_tensor,
         batch2_: *mut C_tensor,
     );
+    pub fn atg_baddbmm_s(
+        out__: *mut *mut C_tensor,
+        self_: *mut C_tensor,
+        batch1_: *mut C_tensor,
+        batch2_: *mut C_tensor,
+        beta_: *mut C_scalar,
+        alpha_: *mut C_scalar,
+    );
     pub fn atg_bartlett_window(
         out__: *mut *mut C_tensor,
         window_length_: i64,


### PR DESCRIPTION
Scalar arguments that have default values are not exposed on the Rust side so as to keep the api simple. This is quite limiting and was reported a few times, lately in #512.
This PR adds an optional way to generate two functions, one that use the default values for these scalar optional arguments, and one that require these arguments to be passed, this last function is named `foo_s` if the base function is `foo`.