### PR TITLE
Add a padding mode to convolution operations

### DIFF
--- a/src/nn/conv.rs
+++ b/src/nn/conv.rs
@@ -1,7 +1,43 @@
 //! N-dimensional convolution layers.
 use super::Path;
-use crate::Tensor;
+use crate::{TchError, Tensor};
 use std::borrow::Borrow;
+
+/// How padding is performed by convolution operations
+/// on the edge of the input tensor.
+#[derive(Debug, Clone, Copy)]
+pub enum PaddingMode {
+    Zeros,
+    Reflect,
+    Replicate,
+    Circular,
+}
+
+impl PaddingMode {
+    fn to_string(self) -> &'static str {
+        // This has to match the internal representation used on the C++
+        // side.
+        match self {
+            // The default value when using constant is zero.
+            PaddingMode::Zeros => "constant",
+            PaddingMode::Reflect => "reflect",
+            PaddingMode::Replicate => "replicate",
+            PaddingMode::Circular => "circular",
+        }
+    }
+
+    pub fn f_pad(
+        self,
+        xs: &Tensor,
+        reversed_padding_repeated_twice: &[i64],
+    ) -> Result<Tensor, TchError> {
+        xs.f_pad(reversed_padding_repeated_twice, self.to_string(), None)
+    }
+
+    pub fn pad(self, xs: &Tensor, reversed_padding_repeated_twice: &[i64]) -> Tensor {
+        xs.pad(reversed_padding_repeated_twice, self.to_string(), None)
+    }
+}
 
 /// Generic convolution config.
 #[allow(clippy::upper_case_acronyms)]
@@ -14,6 +50,7 @@ pub struct ConvConfigND<ND> {
     pub bias: bool,
     pub ws_init: super::Init,
     pub bs_init: super::Init,
+    pub padding_mode: PaddingMode,
 }
 
 /// Convolution config using the same parameters on all dimensions.
@@ -29,6 +66,7 @@ impl Default for ConvConfig {
             bias: true,
             ws_init: super::Init::KaimingUniform,
             bs_init: super::Init::Const(0.),
+            padding_mode: PaddingMode::Zeros,
         }
     }
 }
@@ -43,6 +81,7 @@ impl Default for ConvConfigND<[i64; 2]> {
             bias: true,
             ws_init: super::Init::KaimingUniform,
             bs_init: super::Init::Const(0.),
+            padding_mode: PaddingMode::Zeros,
         }
     }
 }
@@ -58,6 +97,7 @@ pub fn no_bias() -> ConvConfig {
 pub struct Conv<ND> {
     pub ws: Tensor,
     pub bs: Option<Tensor>,
+    reversed_padding_repeated_twice: Vec<i64>,
     config: ConvConfigND<ND>,
 }
 
@@ -83,7 +123,14 @@ pub fn conv<'a, ND: std::convert::AsRef<[i64]>, T: Borrow<super::Path<'a>>>(
     let mut weight_size = vec![out_dim, in_dim / config.groups];
     weight_size.extend(ksizes.as_ref().iter());
     let ws = vs.var("weight", weight_size.as_slice(), config.ws_init);
-    Conv { ws, bs, config }
+    let mut reversed_padding_repeated_twice = vec![];
+    for &v in config.padding.as_ref().iter().rev() {
+        reversed_padding_repeated_twice.push(v)
+    }
+    for &v in config.padding.as_ref().iter().rev() {
+        reversed_padding_repeated_twice.push(v)
+    }
+    Conv { ws, bs, config, reversed_padding_repeated_twice }
 }
 
 trait Create: std::convert::AsRef<[i64]> + std::marker::Sized {
@@ -104,6 +151,7 @@ trait Create: std::convert::AsRef<[i64]> + std::marker::Sized {
             bias: config.bias,
             ws_init: config.ws_init,
             bs_init: config.bs_init,
+            padding_mode: PaddingMode::Zeros,
         };
         conv(vs, in_dim, out_dim, Self::make_array(ksize), config)
     }
@@ -144,12 +192,15 @@ pub fn conv3d<'a, T: Borrow<Path<'a>>>(vs: T, i: i64, o: i64, k: i64, c: ConvCon
 
 impl super::module::Module for Conv1D {
     fn forward(&self, xs: &Tensor) -> Tensor {
-        Tensor::conv1d(
-            xs,
+        let (xs, padding) = match self.config.padding_mode {
+            PaddingMode::Zeros => (xs.shallow_clone(), self.config.padding),
+            p => (p.pad(xs, &self.reversed_padding_repeated_twice), [0]),
+        };
+        xs.conv1d(
             &self.ws,
             self.bs.as_ref(),
             &self.config.stride,
-            &self.config.padding,
+            &padding,
             &self.config.dilation,
             self.config.groups,
         )
@@ -158,12 +209,15 @@ impl super::module::Module for Conv1D {
 
 impl super::module::Module for Conv2D {
     fn forward(&self, xs: &Tensor) -> Tensor {
-        Tensor::conv2d(
-            xs,
+        let (xs, padding) = match self.config.padding_mode {
+            PaddingMode::Zeros => (xs.shallow_clone(), self.config.padding),
+            p => (p.pad(xs, &self.reversed_padding_repeated_twice), [0, 0]),
+        };
+        xs.conv2d(
             &self.ws,
             self.bs.as_ref(),
             &self.config.stride,
-            &self.config.padding,
+            &padding,
             &self.config.dilation,
             self.config.groups,
         )
@@ -172,12 +226,15 @@ impl super::module::Module for Conv2D {
 
 impl super::module::Module for Conv3D {
     fn forward(&self, xs: &Tensor) -> Tensor {
-        Tensor::conv3d(
-            xs,
+        let (xs, padding) = match self.config.padding_mode {
+            PaddingMode::Zeros => (xs.shallow_clone(), self.config.padding),
+            p => (p.pad(xs, &self.reversed_padding_repeated_twice), [0, 0, 0]),
+        };
+        xs.conv3d(
             &self.ws,
             self.bs.as_ref(),
             &self.config.stride,
-            &self.config.padding,
+            &padding,
             &self.config.dilation,
             self.config.groups,
         )

--- a/src/nn/conv.rs
+++ b/src/nn/conv.rs
@@ -151,7 +151,7 @@ trait Create: std::convert::AsRef<[i64]> + std::marker::Sized {
             bias: config.bias,
             ws_init: config.ws_init,
             bs_init: config.bs_init,
-            padding_mode: PaddingMode::Zeros,
+            padding_mode: config.padding_mode,
         };
         conv(vs, in_dim, out_dim, Self::make_array(ksize), config)
     }

--- a/tests/nn_tests.rs
+++ b/tests/nn_tests.rs
@@ -316,3 +316,31 @@ fn linear() {
     linear_test(nn::LinearConfig { bias: true, ..Default::default() });
     linear_test(nn::LinearConfig { bias: false, ..Default::default() });
 }
+
+#[test]
+fn pad() {
+    let xs = Tensor::of_slice(&[1., 2., 3.]);
+    let padded = nn::PaddingMode::Zeros.pad(&xs, &[1, 1]);
+    assert_eq!(Vec::<f32>::from(&padded), [0., 1., 2., 3., 0.]);
+
+    let xs = Tensor::of_slice(&[1., 2., 3.]).view([1, 3]);
+    let padded = nn::PaddingMode::Zeros.pad(&xs, &[1, 1]);
+    assert_eq!(Vec::<f32>::from(&padded), [0., 1., 2., 3., 0.]);
+
+    let xs = Tensor::of_slice(&[1., 2., 3., 4.]).view([1, 2, 2]);
+    let padded = nn::PaddingMode::Reflect.pad(&xs, &[1, 1, 1, 1]);
+    assert_eq!(
+        Vec::<f32>::from(&padded),
+        &[4.0, 3.0, 4.0, 3.0, 2.0, 1.0, 2.0, 1.0, 4.0, 3.0, 4.0, 3.0, 2.0, 1.0, 2.0, 1.0]
+    );
+    let padded = nn::PaddingMode::Reflect.pad(&xs, &[1, 1, 1, 1]);
+    assert_eq!(
+        Vec::<f32>::from(&padded),
+        &[4.0, 3.0, 4.0, 3.0, 2.0, 1.0, 2.0, 1.0, 4.0, 3.0, 4.0, 3.0, 2.0, 1.0, 2.0, 1.0]
+    );
+    let padded = nn::PaddingMode::Reflect.pad(&xs, &[1, 1, 1, 1]);
+    assert_eq!(
+        Vec::<f32>::from(&padded),
+        &[4.0, 3.0, 4.0, 3.0, 2.0, 1.0, 2.0, 1.0, 4.0, 3.0, 4.0, 3.0, 2.0, 1.0, 2.0, 1.0]
+    );
+}


### PR DESCRIPTION
Add a padding mode to the convolution configs mimicing the Python implementation, fixes #532 .