### PR TITLE
Add an affine parameter to the batch-norm layer.

### DIFF
--- a/src/nn/batch_norm.rs
+++ b/src/nn/batch_norm.rs
@@ -8,6 +8,7 @@ pub struct BatchNormConfig {
     pub cudnn_enabled: bool,
     pub eps: f64,
     pub momentum: f64,
+    pub affine: bool,
     pub ws_init: super::Init,
     pub bs_init: super::Init,
 }
@@ -18,6 +19,7 @@ impl Default for BatchNormConfig {
             cudnn_enabled: true,
             eps: 1e-5,
             momentum: 0.1,
+            affine: true,
             ws_init: super::Init::Uniform { lo: 0., up: 1. },
             bs_init: super::Init::Const(0.),
         }
@@ -30,8 +32,8 @@ pub struct BatchNorm {
     config: BatchNormConfig,
     pub running_mean: Tensor,
     pub running_var: Tensor,
-    pub ws: Tensor,
-    pub bs: Tensor,
+    pub ws: Option<Tensor>,
+    pub bs: Option<Tensor>,
     pub nd: usize,
 }
 
@@ -42,12 +44,19 @@ fn batch_norm<'a, T: Borrow<super::Path<'a>>>(
     config: BatchNormConfig,
 ) -> BatchNorm {
     let vs = vs.borrow();
+    let (ws, bs) = if config.affine {
+        let ws = vs.var("weight", &[out_dim], config.ws_init);
+        let bs = vs.var("bias", &[out_dim], config.bs_init);
+        (Some(ws), Some(bs))
+    } else {
+        (None, None)
+    };
     BatchNorm {
         config,
         running_mean: vs.zeros_no_train("running_mean", &[out_dim]),
         running_var: vs.ones_no_train("running_var", &[out_dim]),
-        ws: vs.var("weight", &[out_dim], config.ws_init),
-        bs: vs.var("bias", &[out_dim], config.bs_init),
+        ws,
+        bs,
         nd,
     }
 }
@@ -110,8 +119,8 @@ impl super::module::ModuleT for BatchNorm {
         };
         Tensor::batch_norm(
             xs,
-            Some(&self.ws),
-            Some(&self.bs),
+            self.ws.as_ref(),
+            self.bs.as_ref(),
             Some(&self.running_mean),
             Some(&self.running_var),
             train,

--- a/tests/nn_tests.rs
+++ b/tests/nn_tests.rs
@@ -136,6 +136,18 @@ fn bn_test() {
     let bn = nn::batch_norm1d(vs.root(), 40, Default::default());
     let x = Tensor::randn(&[10, 40], opts);
     let _y = x.apply_t(&bn, true);
+    assert_eq!(vs.len(), 4);
+}
+
+#[test]
+fn bn_test_no_affine() {
+    let opts = (tch::Kind::Float, tch::Device::Cpu);
+    let vs = nn::VarStore::new(tch::Device::Cpu);
+    let bn_cfg = nn::BatchNormConfig { affine: false, ..Default::default() };
+    let bn = nn::batch_norm1d(vs.root(), 40, bn_cfg);
+    let x = Tensor::randn(&[10, 40], opts);
+    let _y = x.apply_t(&bn, true);
+    assert_eq!(vs.len(), 2);
 }
 
 #[test]


### PR DESCRIPTION
Add an `affine` optional parameter for the batch norm layers, this is similar to the Python api, e.g. [nn.BatchNorm2d](https://pytorch.org/docs/stable/generated/torch.nn.BatchNorm2d.html#torch.nn.BatchNorm2d).