### PR TITLE
Add Device::Mps

### DIFF
--- a/src/wrappers/device.rs
+++ b/src/wrappers/device.rs
@@ -7,6 +7,8 @@ pub enum Device {
     Cpu,
     /// The main GPU device.
     Cuda(usize),
+    /// The main MPS device.
+    Mps,
 }
 
 /// Cuda related helper functions.
@@ -56,12 +58,14 @@ impl Device {
         match self {
             Device::Cpu => -1,
             Device::Cuda(device_index) => device_index as libc::c_int,
+            Device::Mps => -2,
         }
     }
 
     pub(super) fn of_c_int(v: libc::c_int) -> Self {
         match v {
             -1 => Device::Cpu,
+            -2 => Device::Mps,
             index if index >= 0 => Device::Cuda(index as usize),
             _ => panic!("unexpected device {}", v),
         }
@@ -80,6 +84,7 @@ impl Device {
         match self {
             Device::Cuda(_) => true,
             Device::Cpu => false,
+            Device::Mps => false,
         }
     }
 }

--- a/torch-sys/libtch/torch_api.cpp
+++ b/torch-sys/libtch/torch_api.cpp
@@ -47,6 +47,7 @@ c10::List<c10::optional<torch::Tensor>> of_carray_tensor_opt(torch::Tensor **vs,
 }
 
 at::Device device_of_int(int d) {
+    if (d == -2) return at::Device(at::kMPS);
     if (d < 0) return at::Device(at::kCPU);
     return at::Device(at::kCUDA, /*index=*/d);
 }


### PR DESCRIPTION
This adds `Device::Mps`, which is necessary to run kernels using Metal Performance Shaders.

I confirmed that I can run SyntaxDot models on the GPU. Unfortunately, it is still much slower than the `Cpu` device that uses the AMX co-processor on M1 Macs. SyntaxDot is a fairly large codebase/set of models and I seem to be hitting some degenerate cases that I don't have time to debug now, but at least the device support seems to work.
