### PR TITLE
Rework the Kaiming initialization.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tch"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Laurent Mazare <lmazare@gmail.com>"]
 edition = "2018"
 
@@ -21,7 +21,7 @@ libc = "0.2.0"
 ndarray = "0.15"
 rand = "0.8"
 thiserror = "1"
-torch-sys = { version = "0.9.0", path = "torch-sys" }
+torch-sys = { version = "0.10.0", path = "torch-sys" }
 zip = "0.6"
 half = "1.6"
 

--- a/src/nn/conv.rs
+++ b/src/nn/conv.rs
@@ -64,7 +64,7 @@ impl Default for ConvConfig {
             dilation: 1,
             groups: 1,
             bias: true,
-            ws_init: super::Init::KaimingUniform,
+            ws_init: super::init::DEFAULT_KAIMING_UNIFORM,
             bs_init: super::Init::Const(0.),
             padding_mode: PaddingMode::Zeros,
         }
@@ -79,7 +79,7 @@ impl Default for ConvConfigND<[i64; 2]> {
             dilation: [1, 1],
             groups: 1,
             bias: true,
-            ws_init: super::Init::KaimingUniform,
+            ws_init: super::init::DEFAULT_KAIMING_UNIFORM,
             bs_init: super::Init::Const(0.),
             padding_mode: PaddingMode::Zeros,
         }

--- a/src/nn/conv_transpose.rs
+++ b/src/nn/conv_transpose.rs
@@ -29,7 +29,7 @@ impl Default for ConvTransposeConfig {
             dilation: 1,
             groups: 1,
             bias: true,
-            ws_init: super::Init::KaimingUniform,
+            ws_init: super::init::DEFAULT_KAIMING_UNIFORM,
             bs_init: super::Init::Const(0.),
         }
     }

--- a/src/nn/init.rs
+++ b/src/nn/init.rs
@@ -1,6 +1,72 @@
 //! Variable initialization.
 use crate::{Device, Kind, TchError, Tensor};
 
+/// Number of features as input or output of a layer.
+/// In Kaiming initialization, choosing `FanIn` preserves
+/// the magnitude of the variance of the weights in the
+/// forward pass, choosing `FanOut` preserves this
+/// magnitude in the backward pass.
+#[derive(Debug, Copy, Clone)]
+pub enum FanInOut {
+    FanIn,
+    FanOut,
+}
+
+impl FanInOut {
+    /// Compute the fan-in or fan-out value for a weight tensor of
+    /// the specified dims.
+    /// https://github.com/pytorch/pytorch/blob/dbeacf11820e336e803bb719b7aaaf2125ae4d9c/torch/nn/init.py#L284
+    pub fn for_weight_dims(&self, dims: &[i64]) -> i64 {
+        let receptive_field_size: i64 = dims.iter().skip(2).product();
+        match &self {
+            FanInOut::FanIn => {
+                if dims.len() < 2 {
+                    1
+                } else {
+                    dims[1] * receptive_field_size
+                }
+            }
+            FanInOut::FanOut => {
+                if dims.is_empty() {
+                    1
+                } else {
+                    dims[0] * receptive_field_size
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum NormalOrUniform {
+    Normal,
+    Uniform,
+}
+
+/// The non-linear function that follows this layer. ReLU is the
+/// recommended value.
+#[derive(Debug, Copy, Clone)]
+pub enum NonLinearity {
+    ReLU,
+    Linear,
+    Sigmoid,
+    Tanh,
+    SELU,
+    ExplicitGain(f64),
+}
+
+impl NonLinearity {
+    pub fn gain(&self) -> f64 {
+        match *self {
+            NonLinearity::ReLU => 2f64.sqrt(),
+            NonLinearity::Tanh => 5. / 3.,
+            NonLinearity::Linear | NonLinearity::Sigmoid => 1.,
+            NonLinearity::SELU => 0.75,
+            NonLinearity::ExplicitGain(g) => g,
+        }
+    }
+}
+
 /// Variable initializations.
 #[derive(Debug, Copy, Clone)]
 pub enum Init {
@@ -14,11 +80,25 @@ pub enum Init {
     Uniform { lo: f64, up: f64 },
 
     /// Kaiming uniform initialization.
-    KaimingUniform,
+    /// See "Delving deep into rectifiers: Surpassing human-level performance on ImageNet classification"
+    /// He, K. et al. (2015). This uses a uniform distribution.
+    Kaiming { dist: NormalOrUniform, fan: FanInOut, non_linearity: NonLinearity },
 
     /// Orthogonal initialization
     Orthogonal { gain: f64 },
 }
+
+pub const DEFAULT_KAIMING_UNIFORM: Init = Init::Kaiming {
+    dist: NormalOrUniform::Uniform,
+    fan: FanInOut::FanIn,
+    non_linearity: NonLinearity::ReLU,
+};
+
+pub const DEFAULT_KAIMING_NORMAL: Init = Init::Kaiming {
+    dist: NormalOrUniform::Normal,
+    fan: FanInOut::FanIn,
+    non_linearity: NonLinearity::ReLU,
+};
 
 /// Creates a new float tensor with the specified shape, device, and initialization.
 pub fn f_init(i: Init, dims: &[i64], device: Device) -> Result<Tensor, TchError> {
@@ -43,10 +123,20 @@ pub fn f_init(i: Init, dims: &[i64], device: Device) -> Result<Tensor, TchError>
                 Tensor::f_randn(dims, (Kind::Float, device)).map(|t| t * stdev + mean)
             }
         }
-        Init::KaimingUniform => {
-            let fan_in: i64 = dims.iter().skip(1).product();
-            let bound = (1.0 / fan_in as f64).sqrt();
-            Tensor::f_zeros(dims, (Kind::Float, device))?.f_uniform_(-bound, bound)
+        Init::Kaiming { dist, fan, non_linearity } => {
+            let fan = fan.for_weight_dims(dims);
+            let gain = non_linearity.gain();
+            let std = gain / (fan as f64).sqrt();
+            match dist {
+                NormalOrUniform::Uniform => {
+                    let bound = 3f64.sqrt() * std;
+                    Tensor::f_zeros(dims, (Kind::Float, device))?.f_uniform_(-bound, bound)
+                }
+                NormalOrUniform::Normal => {
+                    let randn = Tensor::f_randn(dims, (Kind::Float, device))?;
+                    Ok(randn * std)
+                }
+            }
         }
         Init::Orthogonal { gain } => {
             if dims.len() < 2 {
@@ -89,10 +179,19 @@ impl Init {
             Init::Uniform { lo, up } => {
                 let _ = tensor.uniform_(lo, up);
             }
-            Init::KaimingUniform => {
-                let fan_in: i64 = tensor.size().iter().skip(1).product();
-                let bound = (1.0 / fan_in as f64).sqrt();
-                let _ = tensor.uniform_(-bound, bound);
+            Init::Kaiming { dist, fan, non_linearity } => {
+                let fan = fan.for_weight_dims(&tensor.size());
+                let gain = non_linearity.gain();
+                let std = gain / (fan as f64).sqrt();
+                match dist {
+                    NormalOrUniform::Uniform => {
+                        let bound = 3f64.sqrt() * std;
+                        let _ = tensor.uniform_(-bound, bound);
+                    }
+                    NormalOrUniform::Normal => {
+                        tensor.copy_(&(tensor.randn_like() * std));
+                    }
+                }
             }
             Init::Randn { mean, stdev } => {
                 tensor.copy_(&(tensor.randn_like() * stdev + mean));

--- a/src/nn/linear.rs
+++ b/src/nn/linear.rs
@@ -12,7 +12,7 @@ pub struct LinearConfig {
 
 impl Default for LinearConfig {
     fn default() -> Self {
-        LinearConfig { ws_init: super::Init::KaimingUniform, bs_init: None, bias: true }
+        LinearConfig { ws_init: super::init::DEFAULT_KAIMING_UNIFORM, bs_init: None, bias: true }
     }
 }
 

--- a/src/nn/mod.rs
+++ b/src/nn/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! This library tries to stay as close as possible to the original
 //! Python and C++ implementations.
-mod init;
+pub mod init;
 pub use init::{f_init, init, Init};
 
 mod var_store;

--- a/src/nn/rnn.rs
+++ b/src/nn/rnn.rs
@@ -74,8 +74,8 @@ impl Default for RNNConfig {
             train: true,
             bidirectional: false,
             batch_first: true,
-            w_ih_init: super::Init::KaimingUniform,
-            w_hh_init: super::Init::KaimingUniform,
+            w_ih_init: super::init::DEFAULT_KAIMING_UNIFORM,
+            w_hh_init: super::init::DEFAULT_KAIMING_UNIFORM,
             b_ih_init: Some(super::Init::Const(0.)),
             b_hh_init: Some(super::Init::Const(0.)),
         }

--- a/src/nn/var_store.rs
+++ b/src/nn/var_store.rs
@@ -573,7 +573,18 @@ impl<'a> Path<'a> {
     /// The variable uses a float tensor initialized randomly using a
     /// uniform distribution which bounds follow Kaiming initialization.
     pub fn f_kaiming_uniform(&self, name: &str, dims: &[i64]) -> Result<Tensor, TchError> {
-        self.f_var(name, dims, Init::KaimingUniform)
+        self.f_var(name, dims, super::init::DEFAULT_KAIMING_UNIFORM)
+    }
+
+    /// Creates a new variable initialized randomly with kaiming normal.
+    ///
+    /// The new variable is named according to the name parameter and
+    /// has the specified shape. The variable is trainable, its gradient
+    /// will be tracked.
+    /// The variable uses a float tensor initialized randomly using a
+    /// normal distribution which stdev follow Kaiming initialization.
+    pub fn f_kaiming_normal(&self, name: &str, dims: &[i64]) -> Result<Tensor, TchError> {
+        self.f_var(name, dims, super::init::DEFAULT_KAIMING_NORMAL)
     }
 
     /// Creates a new variable initialized randomly with an orthogonal matrix
@@ -698,6 +709,17 @@ impl<'a> Path<'a> {
         self.f_kaiming_uniform(name, dims).unwrap()
     }
 
+    /// Creates a new variable initialized randomly with kaiming normal.
+    ///
+    /// The new variable is named according to the name parameter and
+    /// has the specified shape. The variable is trainable, its gradient
+    /// will be tracked.
+    /// The variable uses a float tensor initialized randomly using a
+    /// normal distribution which stdev follow Kaiming initialization.
+    pub fn kaiming_normal(&self, name: &str, dims: &[i64]) -> Tensor {
+        self.f_kaiming_normal(name, dims).unwrap()
+    }
+
     /// Creates a new variable initialized randomly with an orthogonal matrix
     ///
     /// The new variable is named according to the name parameter and
@@ -758,7 +780,12 @@ impl<'a> Entry<'a> {
 
     /// Returns the existing entry if, otherwise create a new variable.
     pub fn or_kaiming_uniform(self, dims: &[i64]) -> Tensor {
-        self.or_var(dims, Init::KaimingUniform)
+        self.or_var(dims, super::init::DEFAULT_KAIMING_NORMAL)
+    }
+
+    /// Returns the existing entry if, otherwise create a new variable.
+    pub fn or_kaiming_normal(self, dims: &[i64]) -> Tensor {
+        self.or_var(dims, super::init::DEFAULT_KAIMING_NORMAL)
     }
 
     /// Returns the existing entry if, otherwise create a new variable.

--- a/torch-sys/Cargo.toml
+++ b/torch-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "torch-sys"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Laurent Mazare <lmazare@gmail.com>"]
 edition = "2018"
 build = "build.rs"


### PR DESCRIPTION
Add support for the following in Kaiming initialization:
- Use `FanIn` or `FanOut` rather than always defaulting to `FanIn`.
- Add support for using a normal distribution.
- Specify the non-linearity that follows this layer so that the gain is adapted.

This is a breaking change so will only be included in the next major release. It also changes the default behavior when using Kaiming uniform (which is the default for most linear/conv layers): the gain is multiplied by sqrt(2) because of the non-linearity part and there is also a bugfix included here that multiplies the bounds by sqrt(3). Overall the initial values will be scaled up by a factor of sqrt(6).