### PR TITLE
Fix Windows CI checks

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-2019, macOS-latest]
         rust: [stable, nightly]
     steps:
       - uses: actions/checkout@v2
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-2019, macOS-latest]
         rust: [stable, nightly]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Hello,

The latest version of Visual Studio (17.4) introduces a regression and causes issue for the compilation/linking of Pytorch (see https://developercommunity.visualstudio.com/t/thread_local-causing-fatal-error-LNK1161/10199441). Unfortunately this affects the github actions relying on `windows-latest` as they automatically include VS17.4.

Since the issue does not occur for earlier versions (17.3 and lower), downgrading temporarily the windows server version to 2019 solves the issue and allows building the library again. I have made the changes on the [rust-bert](https://github.com/guillaume-be/rust-bert/pull/304) repository and confirms this allows running the test on a windows machine as well.

I am opening this PR if you would be interested in fixing the Windows CI while the Microsoft team works on a fix. I will periodically check for a resolution of the issue on `windows-latest` on the rust-bert repo, I'd be happy to let you know/open a PR to upgrade again when the issue is fixed.

Related to https://github.com/LaurentMazare/tch-rs/issues/563