### PR TITLE
Import weight files generated by the Python api

### DIFF
--- a/examples/tensor-tools.rs
+++ b/examples/tensor-tools.rs
@@ -29,6 +29,11 @@ pub fn main() -> Result<()> {
                     for (name, tensor) in tensors.iter() {
                         println!("{}: {} {:?}", filename, name, tensor)
                     }
+                } else if filename.ends_with(".bin") || filename.ends_with(".zip") {
+                    let tensors = tch::Tensor::loadz_multi(filename)?;
+                    for (name, tensor) in tensors.iter() {
+                        println!("{}: {} {:?}", filename, name, tensor)
+                    }
                 } else {
                     bail!("unhandled file {}", filename);
                 }
@@ -42,6 +47,8 @@ pub fn main() -> Result<()> {
                 tch::Tensor::read_npz(src_filename)?
             } else if src_filename.ends_with(".ot") {
                 tch::Tensor::load_multi(src_filename)?
+            } else if src_filename.ends_with(".bin") || src_filename.ends_with(".zip") {
+                tch::Tensor::loadz_multi(src_filename)?
             } else {
                 bail!("unhandled file {}", src_filename)
             };

--- a/src/wrappers/tensor.rs
+++ b/src/wrappers/tensor.rs
@@ -619,7 +619,8 @@ impl Tensor {
 
     /// Loads some named tensors from a file
     ///
-    /// The file format is the same as the one used by the PyTorch C++ API.
+    /// The file format is the same as the one used for modules in the PyTorch C++ API.
+    /// It commonly uses the .ot extension.
     pub fn load_multi<T: AsRef<Path>>(path: T) -> Result<Vec<(String, Tensor)>, TchError> {
         let path = path_to_cstring(path)?;
         let mut v: Vec<(String, Tensor)> = vec![];
@@ -633,7 +634,8 @@ impl Tensor {
 
     /// Loads some named tensors from a file to a given device
     ///
-    /// The file format is the same as the one used by the PyTorch C++ API.
+    /// The file format is the same as the one used for modules in the PyTorch C++ API.
+    /// It commonly uses the .ot extension.
     pub fn load_multi_with_device<T: AsRef<Path>>(
         path: T,
         device: Device,
@@ -641,6 +643,42 @@ impl Tensor {
         let path = path_to_cstring(path)?;
         let mut v: Vec<(String, Tensor)> = vec![];
         unsafe_torch_err!(at_load_callback_with_device(
+            path.as_ptr(),
+            &mut v as *mut _ as *mut c_void,
+            add_callback,
+            device.c_int(),
+        ));
+        Ok(v)
+    }
+
+    /// Loads some named tensors from a zip file
+    ///
+    /// The expected file format is a zip archive containing a data.pkl file describing
+    /// the embedded tensors. These are commonly used with the .bin extension to export
+    /// PyTorch models and weights using the Python api.
+    pub fn loadz_multi<T: AsRef<Path>>(path: T) -> Result<Vec<(String, Tensor)>, TchError> {
+        let path = path_to_cstring(path)?;
+        let mut v: Vec<(String, Tensor)> = vec![];
+        unsafe_torch_err!(at_loadz_callback(
+            path.as_ptr(),
+            &mut v as *mut _ as *mut c_void,
+            add_callback
+        ));
+        Ok(v)
+    }
+
+    /// Loads some named tensors from a zip file to a given device
+    ///
+    /// The expected file format is a zip archive containing a data.pkl file describing
+    /// the embedded tensors. These are commonly used with the .bin extension to export
+    /// PyTorch models and weights using the Python api.
+    pub fn loadz_multi_with_device<T: AsRef<Path>>(
+        path: T,
+        device: Device,
+    ) -> Result<Vec<(String, Tensor)>, TchError> {
+        let path = path_to_cstring(path)?;
+        let mut v: Vec<(String, Tensor)> = vec![];
+        unsafe_torch_err!(at_loadz_callback_with_device(
             path.as_ptr(),
             &mut v as *mut _ as *mut c_void,
             add_callback,

--- a/torch-sys/libtch/torch_api.h
+++ b/torch-sys/libtch/torch_api.h
@@ -84,6 +84,8 @@ void at_load_multi(tensor *tensors, char **tensor_names, int ntensors, char *fil
 /* [at_load_multi_] takes as input an array of allocation [tensors]. */
 void at_load_multi_(tensor *tensors, char **tensor_names, int ntensors, char *filename);
 
+void at_loadz_callback(char *filename, void *data, void (*f)(void *, char *, tensor));
+void at_loadz_callback_with_device(char *filename, void *data, void (*f)(void *, char *, tensor), int device_id);
 void at_load_callback(char *filename, void *data, void (*f)(void *, char *, tensor));
 void at_load_callback_with_device(char *filename, void *data, void (*f)(void *, char *, tensor), int device_id);
 void at_load_from_stream_callback(void *stream_ptr, void *data, void (*f)(void *, char *, tensor), bool enable_device_id, int device_id);

--- a/torch-sys/src/lib.rs
+++ b/torch-sys/src/lib.rs
@@ -106,6 +106,17 @@ extern "C" {
         n: c_int,
         stream_ptr: *mut c_void,
     );
+    pub fn at_loadz_callback(
+        filename: *const c_char,
+        data: *mut c_void,
+        f: extern "C" fn(*mut c_void, name: *const c_char, t: *mut C_tensor),
+    );
+    pub fn at_loadz_callback_with_device(
+        filename: *const c_char,
+        data: *mut c_void,
+        f: extern "C" fn(*mut c_void, name: *const c_char, t: *mut C_tensor),
+        device_id: c_int,
+    );
     pub fn at_load_callback(
         filename: *const c_char,
         data: *mut c_void,


### PR DESCRIPTION
Add some functions to import the named tensors stored in the files generated by `torch.save` on the Python side.
Use these functions in the `tensor-tools` utility, both for `ls` and `cp`.