### PR TITLE
Add eps and amsgrad options to Adam Optimizer

### DIFF
--- a/examples/gan/main.rs
+++ b/examples/gan/main.rs
@@ -96,11 +96,11 @@ pub fn main() -> Result<()> {
 
     let mut generator_vs = nn::VarStore::new(device);
     let generator = generator(generator_vs.root());
-    let mut opt_g = nn::adam(0.5, 0.999, 0., 1e-8, false).build(&generator_vs, LEARNING_RATE)?;
+    let mut opt_g = nn::adam(0.5, 0.999, 0.).build(&generator_vs, LEARNING_RATE)?;
 
     let mut discriminator_vs = nn::VarStore::new(device);
     let discriminator = discriminator(discriminator_vs.root());
-    let mut opt_d = nn::adam(0.5, 0.999, 0., 1e-8, false).build(&discriminator_vs, LEARNING_RATE)?;
+    let mut opt_d = nn::adam(0.5, 0.999, 0.).build(&discriminator_vs, LEARNING_RATE)?;
 
     let fixed_noise = rand_latent();
 

--- a/examples/gan/main.rs
+++ b/examples/gan/main.rs
@@ -96,11 +96,11 @@ pub fn main() -> Result<()> {
 
     let mut generator_vs = nn::VarStore::new(device);
     let generator = generator(generator_vs.root());
-    let mut opt_g = nn::adam(0.5, 0.999, 0.).build(&generator_vs, LEARNING_RATE)?;
+    let mut opt_g = nn::adam(0.5, 0.999, 0., 1e-8, false).build(&generator_vs, LEARNING_RATE)?;
 
     let mut discriminator_vs = nn::VarStore::new(device);
     let discriminator = discriminator(discriminator_vs.root());
-    let mut opt_d = nn::adam(0.5, 0.999, 0.).build(&discriminator_vs, LEARNING_RATE)?;
+    let mut opt_d = nn::adam(0.5, 0.999, 0., 1e-8, false).build(&discriminator_vs, LEARNING_RATE)?;
 
     let fixed_noise = rand_latent();
 

--- a/src/nn/optimizer.rs
+++ b/src/nn/optimizer.rs
@@ -66,22 +66,24 @@ pub struct Adam {
     pub beta1: f64,
     pub beta2: f64,
     pub wd: f64,
+    pub eps: f64,
+    pub amsgrad: bool,
 }
 
 impl Default for Adam {
     fn default() -> Self {
-        Adam { beta1: 0.9, beta2: 0.999, wd: 0. }
+        Adam { beta1: 0.9, beta2: 0.999, wd: 0., eps: 1e-8, amsgrad: false }
     }
 }
 
 /// Creates the configuration for the Adam optimizer.
-pub fn adam(beta1: f64, beta2: f64, wd: f64) -> Adam {
-    Adam { beta1, beta2, wd }
+pub fn adam(beta1: f64, beta2: f64, wd: f64, eps: f64, amsgrad: bool) -> Adam {
+    Adam { beta1, beta2, wd, eps, amsgrad }
 }
 
 impl OptimizerConfig for Adam {
     fn build_copt(&self, lr: f64) -> Result<COptimizer, TchError> {
-        COptimizer::adam(lr, self.beta1, self.beta2, self.wd)
+        COptimizer::adam(lr, self.beta1, self.beta2, self.wd, self.eps, self.amsgrad)
     }
 }
 
@@ -91,22 +93,24 @@ pub struct AdamW {
     pub beta1: f64,
     pub beta2: f64,
     pub wd: f64,
+    pub eps: f64,
+    pub amsgrad: bool,
 }
 
 impl Default for AdamW {
     fn default() -> Self {
-        AdamW { beta1: 0.9, beta2: 0.999, wd: 0.01 }
+        AdamW { beta1: 0.9, beta2: 0.999, wd: 0.01, eps: 1e-8, amsgrad: false }
     }
 }
 
 /// Creates the configuration for the AdamW optimizer.
-pub fn adamw(beta1: f64, beta2: f64, wd: f64) -> AdamW {
-    AdamW { beta1, beta2, wd }
+pub fn adamw(beta1: f64, beta2: f64, wd: f64, eps: f64, amsgrad: bool) -> AdamW {
+    AdamW { beta1, beta2, wd, eps, amsgrad }
 }
 
 impl OptimizerConfig for AdamW {
     fn build_copt(&self, lr: f64) -> Result<COptimizer, TchError> {
-        COptimizer::adamw(lr, self.beta1, self.beta2, self.wd)
+        COptimizer::adamw(lr, self.beta1, self.beta2, self.wd, self.eps, self.amsgrad)
     }
 }
 

--- a/src/nn/optimizer.rs
+++ b/src/nn/optimizer.rs
@@ -77,8 +77,35 @@ impl Default for Adam {
 }
 
 /// Creates the configuration for the Adam optimizer.
-pub fn adam(beta1: f64, beta2: f64, wd: f64, eps: f64, amsgrad: bool) -> Adam {
-    Adam { beta1, beta2, wd, eps, amsgrad }
+pub fn adam(beta1: f64, beta2: f64, wd: f64) -> Adam {
+    Adam { beta1, beta2, wd, eps: 1e-8, amsgrad: false }
+}
+
+impl Adam {
+    pub fn beta1(mut self, b: f64) -> Self {
+        self.beta1 = b;
+        self
+    }
+
+    pub fn beta2(mut self, b: f64) -> Self {
+        self.beta2 = b;
+        self
+    }
+
+    pub fn wd(mut self, w: f64) -> Self {
+        self.wd = w;
+        self
+    }
+
+    pub fn eps(mut self, e: f64) -> Self {
+        self.eps = e;
+        self
+    }
+
+    pub fn amsgrad(mut self, a: bool) -> Self {
+        self.amsgrad = a;
+        self
+    }
 }
 
 impl OptimizerConfig for Adam {
@@ -104,8 +131,35 @@ impl Default for AdamW {
 }
 
 /// Creates the configuration for the AdamW optimizer.
-pub fn adamw(beta1: f64, beta2: f64, wd: f64, eps: f64, amsgrad: bool) -> AdamW {
-    AdamW { beta1, beta2, wd, eps, amsgrad }
+pub fn adamw(beta1: f64, beta2: f64, wd: f64) -> AdamW {
+    AdamW { beta1, beta2, wd, eps: 1e-8, amsgrad: false }
+}
+
+impl AdamW {
+    pub fn beta1(mut self, b: f64) -> Self {
+        self.beta1 = b;
+        self
+    }
+
+    pub fn beta2(mut self, b: f64) -> Self {
+        self.beta2 = b;
+        self
+    }
+
+    pub fn wd(mut self, w: f64) -> Self {
+        self.wd = w;
+        self
+    }
+
+    pub fn eps(mut self, e: f64) -> Self {
+        self.eps = e;
+        self
+    }
+
+    pub fn amsgrad(mut self, a: bool) -> Self {
+        self.amsgrad = a;
+        self
+    }
 }
 
 impl OptimizerConfig for AdamW {

--- a/src/wrappers/optimizer.rs
+++ b/src/wrappers/optimizer.rs
@@ -14,13 +14,13 @@ impl std::fmt::Debug for COptimizer {
 }
 
 impl COptimizer {
-    pub fn adam(lr: f64, beta1: f64, beta2: f64, wd: f64) -> Result<COptimizer, TchError> {
-        let c_optimizer = unsafe_torch_err!(torch_sys::ato_adam(lr, beta1, beta2, wd));
+    pub fn adam(lr: f64, beta1: f64, beta2: f64, wd: f64, eps: f64, amsgrad: bool) -> Result<COptimizer, TchError> {
+        let c_optimizer = unsafe_torch_err!(torch_sys::ato_adam(lr, beta1, beta2, wd, eps, amsgrad));
         Ok(COptimizer { c_optimizer })
     }
 
-    pub fn adamw(lr: f64, beta1: f64, beta2: f64, wd: f64) -> Result<COptimizer, TchError> {
-        let c_optimizer = unsafe_torch_err!(torch_sys::ato_adamw(lr, beta1, beta2, wd));
+    pub fn adamw(lr: f64, beta1: f64, beta2: f64, wd: f64, eps: f64, amsgrad: bool) -> Result<COptimizer, TchError> {
+        let c_optimizer = unsafe_torch_err!(torch_sys::ato_adamw(lr, beta1, beta2, wd, eps, amsgrad));
         Ok(COptimizer { c_optimizer })
     }
 

--- a/src/wrappers/optimizer.rs
+++ b/src/wrappers/optimizer.rs
@@ -14,13 +14,29 @@ impl std::fmt::Debug for COptimizer {
 }
 
 impl COptimizer {
-    pub fn adam(lr: f64, beta1: f64, beta2: f64, wd: f64, eps: f64, amsgrad: bool) -> Result<COptimizer, TchError> {
-        let c_optimizer = unsafe_torch_err!(torch_sys::ato_adam(lr, beta1, beta2, wd, eps, amsgrad));
+    pub fn adam(
+        lr: f64,
+        beta1: f64,
+        beta2: f64,
+        wd: f64,
+        eps: f64,
+        amsgrad: bool,
+    ) -> Result<COptimizer, TchError> {
+        let c_optimizer =
+            unsafe_torch_err!(torch_sys::ato_adam(lr, beta1, beta2, wd, eps, amsgrad));
         Ok(COptimizer { c_optimizer })
     }
 
-    pub fn adamw(lr: f64, beta1: f64, beta2: f64, wd: f64, eps: f64, amsgrad: bool) -> Result<COptimizer, TchError> {
-        let c_optimizer = unsafe_torch_err!(torch_sys::ato_adamw(lr, beta1, beta2, wd, eps, amsgrad));
+    pub fn adamw(
+        lr: f64,
+        beta1: f64,
+        beta2: f64,
+        wd: f64,
+        eps: f64,
+        amsgrad: bool,
+    ) -> Result<COptimizer, TchError> {
+        let c_optimizer =
+            unsafe_torch_err!(torch_sys::ato_adamw(lr, beta1, beta2, wd, eps, amsgrad));
         Ok(COptimizer { c_optimizer })
     }
 

--- a/torch-sys/libtch/torch_api.cpp
+++ b/torch-sys/libtch/torch_api.cpp
@@ -655,12 +655,16 @@ void at_run_backward(tensor *tensors,
 optimizer ato_adam(double learning_rate,
                    double beta1,
                    double beta2,
-                   double weight_decay) {
+                   double weight_decay,
+                   double eps,
+                   bool amsgrad) {
   PROTECT(
     auto options =
       torch::optim::AdamOptions(learning_rate)
         .betas(std::tuple<double, double>(beta1, beta2))
-        .weight_decay(weight_decay);
+        .weight_decay(weight_decay)
+        .eps(eps)
+        .amsgrad(amsgrad);
     return new torch::optim::Adam(vector<torch::Tensor>(), options);
   )
   return nullptr;
@@ -669,12 +673,16 @@ optimizer ato_adam(double learning_rate,
 optimizer ato_adamw(double learning_rate,
                     double beta1,
                     double beta2,
-                    double weight_decay) {
+                    double weight_decay,
+                    double eps,
+                    bool amsgrad) {
   PROTECT(
     auto options =
       torch::optim::AdamWOptions(learning_rate)
         .betas(std::tuple<double, double>(beta1, beta2))
-        .weight_decay(weight_decay);
+        .weight_decay(weight_decay)
+        .eps(eps)
+        .amsgrad(amsgrad);
     return new torch::optim::AdamW(vector<torch::Tensor>(), options);
   )
   return nullptr;

--- a/torch-sys/libtch/torch_api.h
+++ b/torch-sys/libtch/torch_api.h
@@ -113,11 +113,15 @@ void at_run_backward(tensor *tensors,
 optimizer ato_adam(double learning_rate,
                    double beta1,
                    double beta2,
-                   double weight_decay);
+                   double weight_decay,
+                   double eps,
+                   bool amsgrad);
 optimizer ato_adamw(double learning_rate,
                    double beta1,
                    double beta2,
-                   double weight_decay);
+                   double weight_decay,
+                   double eps,
+                   bool amsgrad);
 optimizer ato_rms_prop(double learning_rate,
                        double alpha,
                        double eps,

--- a/torch-sys/src/lib.rs
+++ b/torch-sys/src/lib.rs
@@ -155,8 +155,8 @@ pub struct C_optimizer {
 }
 
 extern "C" {
-    pub fn ato_adam(lr: f64, beta1: f64, beta2: f64, wd: f64) -> *mut C_optimizer;
-    pub fn ato_adamw(lr: f64, beta1: f64, beta2: f64, wd: f64) -> *mut C_optimizer;
+    pub fn ato_adam(lr: f64, beta1: f64, beta2: f64, wd: f64, eps: f64, amsgrad: bool) -> *mut C_optimizer;
+    pub fn ato_adamw(lr: f64, beta1: f64, beta2: f64, wd: f64, eps: f64, amsgrad: bool) -> *mut C_optimizer;
     pub fn ato_rms_prop(
         lr: f64,
         alpha: f64,

--- a/torch-sys/src/lib.rs
+++ b/torch-sys/src/lib.rs
@@ -155,8 +155,22 @@ pub struct C_optimizer {
 }
 
 extern "C" {
-    pub fn ato_adam(lr: f64, beta1: f64, beta2: f64, wd: f64, eps: f64, amsgrad: bool) -> *mut C_optimizer;
-    pub fn ato_adamw(lr: f64, beta1: f64, beta2: f64, wd: f64, eps: f64, amsgrad: bool) -> *mut C_optimizer;
+    pub fn ato_adam(
+        lr: f64,
+        beta1: f64,
+        beta2: f64,
+        wd: f64,
+        eps: f64,
+        amsgrad: bool,
+    ) -> *mut C_optimizer;
+    pub fn ato_adamw(
+        lr: f64,
+        beta1: f64,
+        beta2: f64,
+        wd: f64,
+        eps: f64,
+        amsgrad: bool,
+    ) -> *mut C_optimizer;
     pub fn ato_rms_prop(
         lr: f64,
         alpha: f64,


### PR DESCRIPTION
Expose more options in AdamOptions

Fix https://github.com/LaurentMazare/tch-rs/issues/145

However it will break the `adamw` and `adam` interface under `src/nn/optimizer.rs`. Should I create a new functions like `adam_new`?