### PR TITLE
Add escape to "_" in no_grad_guard documentation

### DIFF
--- a/src/wrappers/tensor.rs
+++ b/src/wrappers/tensor.rs
@@ -831,7 +831,7 @@ pub struct NoGradGuard {
 /// Disables gradient tracking, this will be enabled back when the
 /// returned value gets deallocated.
 /// Note that it is important to bind this to a name like "_guard"
-/// and not to "_" as these two would have different semantics.
+/// and not to "\_" as these two would have different semantics.
 /// See https://internals.rust-lang.org/t/pre-rfc-must-bind/12658/46
 /// for more details.
 pub fn no_grad_guard() -> NoGradGuard {


### PR DESCRIPTION
The underscore was not being rendered in the rustdoc documentation due to markdown semantics.