### PR TITLE
Updated zero_state method of RNNs to use Double type Tensor if needed.

### DIFF
--- a/src/nn/rnn.rs
+++ b/src/nn/rnn.rs
@@ -174,7 +174,7 @@ impl RNN for LSTM {
         let num_directions = if self.config.bidirectional { 2 } else { 1 };
         let layer_dim = self.config.num_layers * num_directions;
         let shape = [layer_dim, batch_dim, self.hidden_dim];
-        let zeros = Tensor::zeros(&shape, (Kind::Float, self.device));
+        let zeros = Tensor::zeros(&shape, (self.flat_weights[0].kind(), self.device));
         LSTMState((zeros.shallow_clone(), zeros.shallow_clone()))
     }
 
@@ -259,7 +259,7 @@ impl RNN for GRU {
         let num_directions = if self.config.bidirectional { 2 } else { 1 };
         let layer_dim = self.config.num_layers * num_directions;
         let shape = [layer_dim, batch_dim, self.hidden_dim];
-        GRUState(Tensor::zeros(&shape, (Kind::Float, self.device)))
+        GRUState(Tensor::zeros(&shape, (self.flat_weights[0].kind(), self.device)))
     }
 
     fn step(&self, input: &Tensor, in_state: &GRUState) -> GRUState {


### PR DESCRIPTION
zero_state method of LSTM and GRU now retrieve 'Kind' from the first Tensor of flat_weights. Previously was hardcoded as 'Kind::Float', which caused dtype mismatch error when weights were of Kind Double at that point.