### PR TITLE
Add some cuda graph api.

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,16 @@ See some details in [this thread](https://github.com/LaurentMazare/tch-rs/issues
 
 Check this [issue](https://github.com/LaurentMazare/tch-rs/issues/488).
 
+### What if I get some errors not finding `cuda_runtime_api.h`?
+
+This may be caused by the cuda headers not being in your default include paths.
+To get around this, you can try changing the `CPLUS_INCLUDE_PATH` environment
+variable pointing it at the appropriate directory, e.g.
+
+```bash
+CPLUS_INCLUDE_PATH=/usr/local/cuda/include:$CPLUS_INCLUDE_PATH
+```
+
 ## License
 `tch-rs` is distributed under the terms of both the MIT license
 and the Apache license (version 2.0), at your option.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod error;
 pub use error::TchError;
 
 pub(crate) mod wrappers;
+pub use wrappers::cuda_graph;
 pub use wrappers::device::{Cuda, Device};
 pub use wrappers::jit::{self, CModule, IValue, TrainableCModule};
 pub use wrappers::kind::{self, Kind};

--- a/src/wrappers/cuda_graph.rs
+++ b/src/wrappers/cuda_graph.rs
@@ -1,0 +1,43 @@
+//! CUDA Graph API.
+
+use crate::TchError;
+
+pub struct CudaGraph {
+    c_ptr: *mut torch_sys::cuda::CCudaGraph,
+}
+
+impl CudaGraph {
+    pub fn new() -> Result<Self, TchError> {
+        let c_ptr = unsafe_torch_err!(torch_sys::cuda::atcg_new());
+        if c_ptr.is_null() {
+            return Err(TchError::Torch("CudaGraph::new() returned null".to_string()));
+        }
+        Ok(Self { c_ptr })
+    }
+
+    pub fn capture_begin(&mut self) -> Result<(), TchError> {
+        unsafe_torch_err!(torch_sys::cuda::atcg_capture_begin(self.c_ptr));
+        Ok(())
+    }
+
+    pub fn capture_end(&mut self) -> Result<(), TchError> {
+        unsafe_torch_err!(torch_sys::cuda::atcg_capture_end(self.c_ptr));
+        Ok(())
+    }
+
+    pub fn replay(&mut self) -> Result<(), TchError> {
+        unsafe_torch_err!(torch_sys::cuda::atcg_replay(self.c_ptr));
+        Ok(())
+    }
+
+    pub fn reset(&mut self) -> Result<(), TchError> {
+        unsafe_torch_err!(torch_sys::cuda::atcg_reset(self.c_ptr));
+        Ok(())
+    }
+}
+
+impl Drop for CudaGraph {
+    fn drop(&mut self) {
+        unsafe_torch!(torch_sys::cuda::atcg_free(self.c_ptr))
+    }
+}

--- a/src/wrappers/mod.rs
+++ b/src/wrappers/mod.rs
@@ -6,6 +6,7 @@ pub use utils::{
     set_num_threads, QEngine,
 };
 
+pub mod cuda_graph;
 pub(crate) mod device;
 pub(crate) mod image;
 pub mod jit;

--- a/torch-sys/build.rs
+++ b/torch-sys/build.rs
@@ -151,7 +151,7 @@ fn make<P: AsRef<Path>>(libtorch: P, use_cuda: bool, use_hip: bool) {
         .unwrap_or_else(|_| libtorch.as_ref().to_owned());
 
     let cuda_dependency = if use_cuda || use_hip {
-        "libtch/dummy_cuda_dependency.cpp"
+        "libtch/cuda_dependency.cpp"
     } else {
         "libtch/fake_cuda_dependency.cpp"
     };
@@ -159,6 +159,9 @@ fn make<P: AsRef<Path>>(libtorch: P, use_cuda: bool, use_hip: bool) {
     println!("cargo:rerun-if-changed=libtch/torch_api.h");
     println!("cargo:rerun-if-changed=libtch/torch_api_generated.cpp.h");
     println!("cargo:rerun-if-changed=libtch/torch_api_generated.h");
+    println!("cargo:rerun-if-changed=libtch/cuda_dependency.cpp");
+    println!("cargo:rerun-if-changed=libtch/cuda_dependency.h");
+    println!("cargo:rerun-if-changed=libtch/fake_cuda_dependency.cpp");
     println!("cargo:rerun-if-changed=libtch/stb_image_write.h");
     println!("cargo:rerun-if-changed=libtch/stb_image_resize.h");
     println!("cargo:rerun-if-changed=libtch/stb_image.h");

--- a/torch-sys/libtch/cuda_dependency.cpp
+++ b/torch-sys/libtch/cuda_dependency.cpp
@@ -1,0 +1,64 @@
+#include "cuda_dependency.h"
+#include "torch_api.h"
+
+#include<stdio.h>
+#include<stdint.h>
+#include<stdexcept>
+#include<iostream>
+using namespace std;
+extern "C" {
+  void dummy_cuda_dependency();
+}
+
+struct cublasContext;
+
+namespace at {
+  namespace cuda {
+    cublasContext* getCurrentCUDABlasHandle();
+    int warp_size();
+  }
+}
+char * magma_strerror(int err);
+void dummy_cuda_dependency() {
+  try {
+    at::cuda::getCurrentCUDABlasHandle();
+    at::cuda::warp_size();
+  }
+  catch (std::exception &e) {
+    std::cerr << "error initializing cuda: " << e.what() << std::endl;
+  }
+}
+
+cuda_graph atcg_new() {
+  PROTECT(
+  return new at::cuda::CUDAGraph();
+  )
+  return nullptr;
+}
+
+void atcg_free(cuda_graph c) {
+  delete c;
+}
+void atcg_capture_begin(cuda_graph c) {
+  PROTECT(
+      c->capture_begin();
+  )
+}
+
+void atcg_capture_end(cuda_graph c) {
+  PROTECT(
+      c->capture_end();
+  )
+}
+
+void atcg_replay(cuda_graph c) {
+  PROTECT(
+      c->replay();
+  )
+}
+
+void atcg_reset(cuda_graph c) {
+  PROTECT(
+      c->reset();
+  )
+}

--- a/torch-sys/libtch/cuda_dependency.h
+++ b/torch-sys/libtch/cuda_dependency.h
@@ -1,0 +1,27 @@
+#ifndef __TCH_CUDA_DEPENDENCY_H__
+#define __TCH_CUDA_DEPENDENCY_H__
+
+#include<stdio.h>
+#include<stdint.h>
+
+#ifdef __cplusplus
+#include<ATen/cuda/CUDAGraph.h>
+extern "C" {
+typedef at::cuda::CUDAGraph *cuda_graph;
+#else
+typedef void *cuda_graph;
+#endif
+
+void dummy_cuda_dependency();
+cuda_graph atcg_new();
+void atcg_free(cuda_graph); 
+void atcg_capture_begin(cuda_graph);
+void atcg_capture_end(cuda_graph);
+void atcg_replay(cuda_graph);
+void atcg_reset(cuda_graph);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/torch-sys/libtch/fake_cuda_dependency.cpp
+++ b/torch-sys/libtch/fake_cuda_dependency.cpp
@@ -1,6 +1,14 @@
-extern "C" {
-    void dummy_cuda_dependency();
-}
+#include "cuda_dependency.h"
 
 void dummy_cuda_dependency() {
 }
+
+cuda_graph atcg_new() {
+  return nullptr;
+}
+
+void atcg_free(cuda_graph) {}
+void atcg_capture_begin(cuda_graph) {}
+void atcg_capture_end(cuda_graph) {}
+void atcg_replay(cuda_graph) {}
+void atcg_reset(cuda_graph) {}

--- a/torch-sys/libtch/torch_api.cpp
+++ b/torch-sys/libtch/torch_api.cpp
@@ -1,16 +1,3 @@
-#include<torch/csrc/autograd/engine.h>
-#include<torch/csrc/jit/frontend/tracer.h>
-#include<torch/csrc/jit/runtime/graph_executor.h>
-#include<torch/csrc/jit/passes/fixup_trace_scope_blocks.h>
-#include<torch/csrc/jit/passes/normalize_ops.h>
-#include<torch/csrc/jit/mobile/import_data.h>
-#include <torch/csrc/jit/runtime/graph_executor.h>
-#include<torch/torch.h>
-#include<ATen/autocast_mode.h>
-#include<torch/script.h>
-#include <torch/csrc/jit/passes/tensorexpr_fuser.h>
-#include<stdexcept>
-#include<vector>
 #include "torch_api.h"
 
 #define STB_IMAGE_IMPLEMENTATION
@@ -23,6 +10,7 @@
 #include "stb_image_resize.h"
 
 using namespace std;
+thread_local char *torch_last_err = nullptr;
 
 char *get_and_reset_last_err() {
     char *tmp = torch_last_err;

--- a/torch-sys/libtch/torch_api.h
+++ b/torch-sys/libtch/torch_api.h
@@ -3,7 +3,21 @@
 #include<stdint.h>
 
 #ifdef __cplusplus
-thread_local char *torch_last_err = nullptr;
+#include<stdexcept>
+#include<vector>
+#include<ATen/autocast_mode.h>
+#include<torch/csrc/autograd/engine.h>
+#include<torch/csrc/jit/frontend/tracer.h>
+#include<torch/csrc/jit/mobile/import_data.h>
+#include<torch/csrc/jit/passes/fixup_trace_scope_blocks.h>
+#include<torch/csrc/jit/passes/normalize_ops.h>
+#include<torch/csrc/jit/passes/tensorexpr_fuser.h>
+#include<torch/csrc/jit/runtime/graph_executor.h>
+#include<torch/csrc/jit/runtime/graph_executor.h>
+#include<torch/script.h>
+#include<torch/torch.h>
+
+extern thread_local char *torch_last_err;
 
 extern "C" {
 typedef torch::Tensor *tensor;

--- a/torch-sys/src/cuda.rs
+++ b/torch-sys/src/cuda.rs
@@ -1,5 +1,10 @@
 use libc::c_int;
 
+#[repr(C)]
+pub struct CCudaGraph {
+    _private: [u8; 0],
+}
+
 extern "C" {
     /// Returns the number of CUDA devices available.
     pub fn atc_cuda_device_count() -> c_int;
@@ -27,4 +32,11 @@ extern "C" {
 
     /// Sets CUDNN benchmark mode.
     pub fn atc_set_benchmark_cudnn(b: c_int);
+
+    pub fn atcg_new() -> *mut CCudaGraph;
+    pub fn atcg_free(arg: *mut CCudaGraph);
+    pub fn atcg_replay(arg: *mut CCudaGraph);
+    pub fn atcg_reset(arg: *mut CCudaGraph);
+    pub fn atcg_capture_begin(arg: *mut CCudaGraph);
+    pub fn atcg_capture_end(arg: *mut CCudaGraph);
 }


### PR DESCRIPTION
This PR adds an api for cuda graphs that is a simple wrapper around the C++ api as suggested in #631.
The C++ header file can be seen in the [pytorch repo](https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/cuda/CUDAGraph.h).