### PR TITLE
Support safetensors format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Cargo.lock
 __pycache__
 *~
 .*~
+.vscode/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ thiserror = "1"
 torch-sys = { version = "0.10.0", path = "torch-sys" }
 zip = "0.6"
 half = "1.6"
+safetensors = "0.2.8"
 
 cpython = { version = "0.2.0", optional = true }
 regex = { version = "1.6.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,8 @@ thiserror = "1"
 torch-sys = { version = "0.10.0", path = "torch-sys" }
 zip = "0.6"
 half = "1.6"
-safetensors = "0.2.8"
+safetensors = "0.3.0"
+
 
 cpython = { version = "0.2.0", optional = true }
 regex = { version = "1.6.0", optional = true }

--- a/src/nn/var_store.rs
+++ b/src/nn/var_store.rs
@@ -173,6 +173,7 @@ impl VarStore {
     ) -> Result<HashMap<String, Tensor>, TchError> {
         let named_tensors = match path.as_ref().extension().and_then(|x| x.to_str()) {
             Some("bin") | Some("pt") => Tensor::loadz_multi_with_device(&path, self.device),
+            Some("safetensors") => Tensor::read_safetensors(path),
             Some(_) | None => Tensor::load_multi_with_device(&path, self.device),
         };
         Ok(named_tensors?.into_iter().collect())

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -7,6 +7,7 @@ pub mod display;
 pub mod index;
 mod iter;
 mod npy;
+mod safetensors;
 mod ops;
 
 pub use super::wrappers::tensor::{

--- a/src/tensor/safetensors.rs
+++ b/src/tensor/safetensors.rs
@@ -1,0 +1,103 @@
+//! Safetensors support for tensors.
+//!
+//! Format spec:
+//! https://github.com/huggingface/safetensors
+use crate::{Kind, TchError, Tensor};
+
+use std::path::Path;
+use std::collections::BTreeMap;
+
+use safetensors::tensor::{SafeTensors, Dtype, SafeTensorError, TensorView};
+use safetensors::tensor;
+
+
+impl crate::Tensor {
+    pub fn dtype_to_kind(dtype: safetensors::tensor::Dtype) -> Result<Kind, TchError> {
+        let kind =  match dtype {
+            Dtype::BOOL => Kind::Bool,
+            Dtype::U8 => Kind::Uint8,
+            Dtype::I8 => Kind::Int8,
+            Dtype::I16 => Kind::Int16,
+            Dtype::I32 => Kind::Int,
+            Dtype::I64 => Kind::Int64,
+            Dtype::BF16 => Kind::BFloat16,
+            Dtype::F16 => Kind::Half,
+            Dtype::F32 => Kind::Float,
+            Dtype::F64 => Kind::Double,
+            _ => return Err(TchError::Convert(format!("unsupported dtype in safetensor file"))),
+        };
+        Ok(kind)
+    }
+
+    pub fn kind_to_dtype(kind: Kind) -> Result<Dtype, TchError> {
+        let dtype = match kind {
+            Kind::Bool => Dtype::BOOL,
+            Kind::Uint8 => Dtype::U8,
+            Kind::Int8 => Dtype::I8,
+            Kind::Int16 => Dtype::I16,
+            Kind::Int => Dtype::I32,
+            Kind::Int64 => Dtype::I64,
+            Kind::BFloat16 => Dtype::BF16,
+            Kind::Half => Dtype::F16,
+            Kind::Float => Dtype::F32,
+            Kind::Double => Dtype::F64,
+            _ => return Err(TchError::Convert(format!("unsupported kind in safetensor file"))),
+        };
+        Ok(dtype)
+    }
+
+    /// Reads a safetensors file and returns some named tensors.
+    pub fn read_safetensors<T: AsRef<Path>>(path: T) -> Result<Vec<(String, Tensor)>, TchError> {
+        let file = std::fs::read(&path)?;
+
+        let safetensors = match SafeTensors::deserialize(&file) {
+            Ok(value) => value,
+            Err(e) => match e {
+                SafeTensorError::IoError(e) => return Err(TchError::Io(e)),
+                _ => return Err(TchError::FileFormat(format!("unable to load safetensor file"))),
+            },
+        };
+
+        let mut result = vec![];
+        for safetensor in safetensors.tensors() {
+            let view = safetensor.1;
+
+            let size: Vec<i64> = view.shape().iter().map(|&x| x as i64).collect();
+
+            let kind = Self::dtype_to_kind(view.dtype())?;
+            let tensor = Tensor::f_of_data_size(view.data(), &size, kind)?;
+            result.push((safetensor.0, tensor));
+        }
+
+        Ok(result)
+    }
+
+    /// Writes a tensor in the safetensors format.
+    pub fn write_safetensors<S: AsRef<str>, T: AsRef<Tensor>, P: AsRef<Path>>(
+        ts: &[(S, T)],
+        path: P,
+    ) -> Result<(), TchError> {
+
+        let mut tensors: BTreeMap<String, TensorView> = BTreeMap::new();
+        for (name, tensor) in ts.iter() {
+            let t = tensor.as_ref();
+
+            let shape: Vec<usize> = t.size().iter().map(|&x| x as usize).collect();
+
+            let kind = t.f_kind()?;
+            let dtype = Self::kind_to_dtype(kind)?;
+
+            let numel = t.numel();
+
+            let mut content = vec![0u8; numel * kind.elt_size_in_bytes()];
+            t.f_copy_data_u8(&mut content, numel)?;
+
+            let view = TensorView::new(dtype, shape, &content);
+            tensors.insert(name.as_ref().to_string(), view);
+        }
+
+        // tensor::serialize_to_file(&tensors, &None, path.as_ref());
+
+        Ok(())
+    }
+}

--- a/src/tensor/safetensors.rs
+++ b/src/tensor/safetensors.rs
@@ -4,32 +4,16 @@
 //! https://github.com/huggingface/safetensors
 use crate::{Kind, TchError, Tensor};
 
+use std::borrow::Cow;
+use std::convert::{TryFrom, TryInto};
 use std::path::Path;
-use std::collections::BTreeMap;
 
-use safetensors::tensor::{SafeTensors, Dtype, SafeTensorError, TensorView};
 use safetensors::tensor;
+use safetensors::tensor::{Dtype, SafeTensorError, SafeTensors, TensorView, View};
 
-
-impl crate::Tensor {
-    pub fn dtype_to_kind(dtype: safetensors::tensor::Dtype) -> Result<Kind, TchError> {
-        let kind =  match dtype {
-            Dtype::BOOL => Kind::Bool,
-            Dtype::U8 => Kind::Uint8,
-            Dtype::I8 => Kind::Int8,
-            Dtype::I16 => Kind::Int16,
-            Dtype::I32 => Kind::Int,
-            Dtype::I64 => Kind::Int64,
-            Dtype::BF16 => Kind::BFloat16,
-            Dtype::F16 => Kind::Half,
-            Dtype::F32 => Kind::Float,
-            Dtype::F64 => Kind::Double,
-            _ => return Err(TchError::Convert(format!("unsupported dtype in safetensor file"))),
-        };
-        Ok(kind)
-    }
-
-    pub fn kind_to_dtype(kind: Kind) -> Result<Dtype, TchError> {
+impl TryFrom<Kind> for Dtype {
+    type Error = TchError;
+    fn try_from(kind: Kind) -> Result<Self, Self::Error> {
         let dtype = match kind {
             Kind::Bool => Dtype::BOOL,
             Kind::Uint8 => Dtype::U8,
@@ -41,11 +25,88 @@ impl crate::Tensor {
             Kind::Half => Dtype::F16,
             Kind::Float => Dtype::F32,
             Kind::Double => Dtype::F64,
-            _ => return Err(TchError::Convert(format!("unsupported kind in safetensor file"))),
+            kind => return Err(TchError::Convert(format!("unsupported kind ({kind:?})"))),
         };
         Ok(dtype)
     }
+}
 
+impl TryFrom<Dtype> for Kind {
+    type Error = TchError;
+    fn try_from(dtype: Dtype) -> Result<Self, Self::Error> {
+        let kind = match dtype {
+            Dtype::BOOL => Kind::Bool,
+            Dtype::U8 => Kind::Uint8,
+            Dtype::I8 => Kind::Int8,
+            Dtype::I16 => Kind::Int16,
+            Dtype::I32 => Kind::Int,
+            Dtype::I64 => Kind::Int64,
+            Dtype::BF16 => Kind::BFloat16,
+            Dtype::F16 => Kind::Half,
+            Dtype::F32 => Kind::Float,
+            Dtype::F64 => Kind::Double,
+            dtype => return Err(TchError::Convert(format!("unsupported dtype {dtype:?}"))),
+        };
+        Ok(kind)
+    }
+}
+
+impl<'a> TryFrom<TensorView<'a>> for Tensor {
+    type Error = TchError;
+    fn try_from(view: TensorView<'a>) -> Result<Self, Self::Error> {
+        let size: Vec<i64> = view.shape().iter().map(|&x| x as i64).collect();
+        let kind: Kind = view.dtype().try_into()?;
+        Tensor::f_of_data_size(view.data(), &size, kind)
+    }
+}
+
+struct SafeView<'a> {
+    tensor: &'a Tensor,
+    shape: Vec<usize>,
+    dtype: Dtype,
+}
+
+impl<'a> TryFrom<&'a Tensor> for SafeView<'a> {
+    type Error = TchError;
+
+    fn try_from(tensor: &'a Tensor) -> Result<Self, Self::Error> {
+        if tensor.is_sparse() {
+            return Err(TchError::Convert("Cannot save sparse tensors".to_string()));
+        }
+
+        if !tensor.is_contiguous() {
+            return Err(TchError::Convert("Cannot save non contiguous tensors".to_string()));
+        }
+        // TODO here it would be better to know if tensors `is_contiguous` which
+        // doesn't seem available.
+        let dtype = tensor.kind().try_into()?;
+        let shape: Vec<usize> = tensor.size().iter().map(|&x| x as usize).collect();
+        Ok(Self { tensor, shape, dtype })
+    }
+}
+
+impl<'a> View for SafeView<'a> {
+    fn dtype(&self) -> Dtype {
+        self.dtype
+    }
+    fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+
+    fn data(&self) -> Cow<[u8]> {
+        let mut data = vec![0; self.data_len()];
+        let numel = self.tensor.numel();
+        self.tensor.f_copy_data_u8(&mut data, numel).unwrap();
+        data.into()
+    }
+
+    fn data_len(&self) -> usize {
+        let numel = self.tensor.numel();
+        numel * self.tensor.kind().elt_size_in_bytes()
+    }
+}
+
+impl crate::Tensor {
     /// Reads a safetensors file and returns some named tensors.
     pub fn read_safetensors<T: AsRef<Path>>(path: T) -> Result<Vec<(String, Tensor)>, TchError> {
         let file = std::fs::read(&path)?;
@@ -54,50 +115,72 @@ impl crate::Tensor {
             Ok(value) => value,
             Err(e) => match e {
                 SafeTensorError::IoError(e) => return Err(TchError::Io(e)),
-                _ => return Err(TchError::FileFormat(format!("unable to load safetensor file"))),
+                // Always reoutput the error message from the underlying error
+                // For easier debugging
+                e => {
+                    return Err(TchError::FileFormat(format!(
+                        "unable to load safetensor file : {e}"
+                    )))
+                }
             },
         };
 
-        let mut result = vec![];
-        for safetensor in safetensors.tensors() {
-            let view = safetensor.1;
-
-            let size: Vec<i64> = view.shape().iter().map(|&x| x as i64).collect();
-
-            let kind = Self::dtype_to_kind(view.dtype())?;
-            let tensor = Tensor::f_of_data_size(view.data(), &size, kind)?;
-            result.push((safetensor.0, tensor));
-        }
-
-        Ok(result)
+        safetensors
+            .tensors()
+            .into_iter()
+            .map(|(name, view)| -> Result<(String, Tensor), TchError> {
+                let tensor: Tensor = view.try_into()?;
+                Ok((name, tensor))
+            })
+            .collect()
     }
 
     /// Writes a tensor in the safetensors format.
     pub fn write_safetensors<S: AsRef<str>, T: AsRef<Tensor>, P: AsRef<Path>>(
-        ts: &[(S, T)],
+        tensors: &[(S, T)],
         path: P,
     ) -> Result<(), TchError> {
+        let views: Result<Vec<_>, TchError> = tensors
+            .into_iter()
+            .map(|(name, tensor)| -> Result<(&str, SafeView), TchError> {
+                let name = name.as_ref();
+                let tensor = tensor.as_ref();
+                let view: SafeView = tensor.try_into()?;
+                Ok((name, view))
+            })
+            .collect();
+        let views = views?;
 
-        let mut tensors: BTreeMap<String, TensorView> = BTreeMap::new();
-        for (name, tensor) in ts.iter() {
-            let t = tensor.as_ref();
-
-            let shape: Vec<usize> = t.size().iter().map(|&x| x as usize).collect();
-
-            let kind = t.f_kind()?;
-            let dtype = Self::kind_to_dtype(kind)?;
-
-            let numel = t.numel();
-
-            let mut content = vec![0u8; numel * kind.elt_size_in_bytes()];
-            t.f_copy_data_u8(&mut content, numel)?;
-
-            let view = TensorView::new(dtype, shape, &content);
-            tensors.insert(name.as_ref().to_string(), view);
-        }
-
-        // tensor::serialize_to_file(&tensors, &None, path.as_ref());
+        tensor::serialize_to_file(views, &None, path.as_ref())
+            .map_err(|e| TchError::Convert(format!("Error while saving safetensor file {e}")))?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{convert::TryInto};
+
+    use safetensors::Dtype;
+    use crate::{Kind};
+
+    #[test]
+    fn parse() {
+        // From Kind to Dtype
+        assert_eq!(TryInto::<Dtype>::try_into(Kind::Double).unwrap(), Dtype::F64);
+        assert_eq!(TryInto::<Dtype>::try_into(Kind::Float).unwrap(), Dtype::F32);
+        assert_eq!(TryInto::<Dtype>::try_into(Kind::Half).unwrap(), Dtype::F16);
+
+        assert_eq!(TryInto::<Dtype>::try_into(Kind::Int8).unwrap(), Dtype::I8);
+        assert_eq!(TryInto::<Dtype>::try_into(Kind::Uint8).unwrap(), Dtype::U8);
+
+        // From Dtype to Kind
+        assert_eq!(TryInto::<Kind>::try_into(Dtype::F64).unwrap(), Kind::Double);
+        assert_eq!(TryInto::<Kind>::try_into(Dtype::F32).unwrap(), Kind::Float);
+        assert_eq!(TryInto::<Kind>::try_into(Dtype::F16).unwrap(), Kind::Half);
+
+        assert_eq!(TryInto::<Kind>::try_into(Dtype::I8).unwrap(), Kind::Int8);
+        assert_eq!(TryInto::<Kind>::try_into(Dtype::U8).unwrap(), Kind::Uint8);
     }
 }

--- a/src/wrappers/tensor.rs
+++ b/src/wrappers/tensor.rs
@@ -269,6 +269,11 @@ impl Tensor {
         unsafe_torch!(at_is_sparse(self.c_tensor) != 0)
     }
 
+    // Returns true if the tensor if contiguous
+    pub fn is_contiguous(&self) -> bool {
+        unsafe_torch!(at_is_contiguous(self.c_tensor) != 0)
+    }
+
     /// Zeroes the gradient tensor attached to this tensor if defined.
     pub fn zero_grad(&mut self) {
         let mut grad = self.grad();

--- a/tests/serialization_tests.rs
+++ b/tests/serialization_tests.rs
@@ -155,3 +155,38 @@ fn save_and_load_npy() {
     assert_eq!(pi.size(), [3, 1, 2]);
     assert_eq!(Vec::<f64>::from(pi.flatten(0, -1)), [3.0, 1.0, 4.0, 1.0, 5.0, 9.0]);
 }
+
+#[test]
+fn save_and_load_safetensors() {
+    let tmp_file = TmpFile::create("save-and-load-safetensors");
+    let pi = Tensor::of_slice(&[3.0, 1.0, 4.0, 1.0, 5.0]);
+    let e = Tensor::of_slice(&[2, 7, 1, 8, 2, 8, 1, 8, 2, 8, 4, 6]);
+    Tensor::write_safetensors(&[(&"pi", &pi), (&"e", &e)], &tmp_file).unwrap();
+    let named_tensors = Tensor::read_safetensors(&tmp_file).unwrap();
+    assert_eq!(named_tensors.len(), 2); 
+    for (name, tensor) in named_tensors {
+        match name.as_str() {
+            "pi" => assert_eq!(i64::from(&tensor.sum(tch::Kind::Float)), 14),
+            "e" => assert_eq!(i64::from(&tensor.sum(tch::Kind::Float)), 57),
+            _ => panic!("unknow name tensors"),
+        }
+    }
+}
+
+#[test]
+fn save_and_load_safetensors_half() {
+    let tmp_file = TmpFile::create("save-and-load-safetensors-half");
+    let pi = Tensor::of_slice(&[3.0, 1.0, 4.0, 1.0, 5.0]).to_dtype(Kind::Half, true, false);
+    let e =
+        Tensor::of_slice(&[2, 7, 1, 8, 2, 8, 1, 8, 2, 8, 4, 6]).to_dtype(Kind::Half, true, false);
+    Tensor::write_safetensors(&[(&"pi", &pi), (&"e", &e)], &tmp_file).unwrap();
+    let named_tensors = Tensor::read_safetensors(&tmp_file).unwrap();
+    assert_eq!(named_tensors.len(), 2); 
+    for (name, tensor) in named_tensors {
+        match name.as_str() {
+            "pi" => assert_eq!(i64::from(&tensor.sum(tch::Kind::Float)), 14),
+            "e" => assert_eq!(i64::from(&tensor.sum(tch::Kind::Float)), 57),
+            _ => panic!("unknow name tensors"),
+        }
+    }
+}

--- a/torch-sys/libtch/torch_api.cpp
+++ b/torch-sys/libtch/torch_api.cpp
@@ -125,6 +125,11 @@ int at_is_sparse(tensor t) {
   return -1;
 }
 
+int at_is_contiguous(tensor t) {
+  PROTECT(return t->is_contiguous();)
+  return -1;
+}
+
 size_t at_dim(tensor t) {
   PROTECT(return t->dim();)
   return -1;

--- a/torch-sys/libtch/torch_api.h
+++ b/torch-sys/libtch/torch_api.h
@@ -37,6 +37,7 @@ void *at_data_ptr(tensor);
 int at_defined(tensor);
 int at_is_mkldnn(tensor);
 int at_is_sparse(tensor);
+int at_is_contiguous(tensor);
 int at_device(tensor);
 size_t at_dim(tensor);
 void at_shape(tensor, int64_t *);

--- a/torch-sys/src/lib.rs
+++ b/torch-sys/src/lib.rs
@@ -30,6 +30,7 @@ extern "C" {
     pub fn at_defined(arg: *mut C_tensor) -> c_int;
     pub fn at_is_sparse(arg: *mut C_tensor) -> c_int;
     pub fn at_is_mkldnn(arg: *mut C_tensor) -> c_int;
+    pub fn at_is_contiguous(args: *mut C_tensor) -> c_int;
     pub fn at_backward(arg: *mut C_tensor, keep_graph: c_int, create_graph: c_int);
     pub fn at_print(arg: *mut C_tensor);
     pub fn at_to_string(arg: *mut C_tensor, line_size: c_int) -> *mut c_char;


### PR DESCRIPTION
This is a mostly the same as #633, but there are some key differences:

* The safetensors version is newer this PR. This allow to remove an unsafe part.
* Some unit tests were made.
* Add `is_contiguous` function