### PR TITLE
Use snprintf to remove sprintf deprecation warning

### DIFF
--- a/torch-sys/libtch/stb_image_write.h
+++ b/torch-sys/libtch/stb_image_write.h
@@ -739,7 +739,7 @@ static int stbi_write_hdr_core(stbi__write_context *s, int x, int y, int comp, f
 #ifdef STBI_MSC_SECURE_CRT
       len = sprintf_s(buffer, "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
 #else
-      len = sprintf(buffer, "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
+      len = snprintf(buffer, 127, "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
 #endif
       s->func(s->context, buffer, len);
 


### PR DESCRIPTION
On macOS 13.2.1 with Xcode 14.1 , building torch-sys, I see this warning:

```
$ cargo build --example basics
   Compiling torch-sys v0.11.0 (/Users/simlay/projects/tch-rs/torch-sys)
warning: clang: warning: -Wl,-rpath=/opt/homebrew/lib/python3.11/site-packages/torch/lib: 'linker' input unused [-Wunused-command-line-argument]cargo:warning=clang: warning: -Wl,-rpath=/opt/homebrew/lib/python3.11/site-packages/torch/lib: 'linker' input unused [-Wunused-command-line-argument]
warning: In file included from libtch/torch_api.cpp:20:
warning: libtch/stb_image_write.h:742:13: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
warning:       len = sprintf(buffer, "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
warning:             ^
warning: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
warning: __deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
warning: ^
warning: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
warning:         #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
warning:                                                       ^
warning: 1 warning generated.
   Compiling tch v0.11.0 (/Users/simlay/projects/tch-rs)
    Finished dev [unoptimized + debuginfo] target(s) in 8.13s
```

It's been a few years since I've written C++, but I think I read [`snprintf(3)`](https://linux.die.net/man/3/snprintf) correctly. As I don't have a windows box, I elected not to do the bit in the `STBI_MSC_SECURE_CRT` section.