### PR TITLE
Initial changes for iOS support

### DIFF
--- a/examples/basics.rs
+++ b/examples/basics.rs
@@ -15,9 +15,10 @@ fn grad_example() {
 }
 
 fn main() {
-    println!("Cuda available: {}", tch::Cuda::is_available());
-    println!("Cudnn available: {}", tch::Cuda::cudnn_is_available());
-    let device = tch::Device::cuda_if_available();
+    //println!("Cuda available: {}", tch::Cuda::is_available());
+    //println!("Cudnn available: {}", tch::Cuda::cudnn_is_available());
+    //TODO: Fix this for ios and non-ios.
+    let device = tch::Device::Mps;
     let t = Tensor::of_slice(&[3, 1, 4, 1, 5]).to(device);
     t.print();
     let t = Tensor::randn(&[5, 4], kind::FLOAT_CPU);

--- a/torch-sys/build.rs
+++ b/torch-sys/build.rs
@@ -178,7 +178,7 @@ fn make<P: AsRef<Path>>(libtorch: P, use_cuda: bool, use_hip: bool) {
     println!("cargo:rerun-if-changed=libtch/stb_image_resize.h");
     println!("cargo:rerun-if-changed=libtch/stb_image.h");
     match os.as_str() {
-        "linux" | "macos" => {
+        "linux" | "macos" | "ios" => {
             let libtorch_cxx11_abi =
                 env_var_rerun("LIBTORCH_CXX11_ABI").unwrap_or_else(|_| "1".to_owned());
             cc::Build::new()
@@ -257,11 +257,18 @@ fn main() {
         println!("cargo:rustc-link-lib=torch_cpu");
         println!("cargo:rustc-link-lib=torch");
         println!("cargo:rustc-link-lib=c10");
+
         if use_hip {
             println!("cargo:rustc-link-lib=c10_hip");
         }
 
         let target = env::var("TARGET").unwrap();
+
+        if target.contains("ios") {
+            println!("cargo:rustc-link-lib=cpuinfo");
+            println!("cargo:rustc-link-lib=clog");
+            println!("cargo:rustc-link-lib=pthreadpool");
+        }
 
         if !target.contains("msvc") && !target.contains("apple") {
             println!("cargo:rustc-link-lib=gomp");


### PR DESCRIPTION
I figured I'd give iOS building a shot. To even get started, one must [build the iOS library for PyTorch](https://pytorch.org/mobile/ios/#build-libtorch-lite-for-ios-simulators). Make sure the [`TORCH_VERSION` from `torch-sys`](https://github.com/LaurentMazare/tch-rs/blob/b3acdbbabd63004647f1f6ed74c20380fe12af00/torch-sys/build.rs#L14) matches the PyTorch checkout.

For `aarch64-apple-ios-sim` you want to run `BUILD_PYTORCH_MOBILE=1 IOS_PLATFORM=SIMULATOR IOS_ARCH=arm64 ./scripts/build_ios.sh`.
For `aarch64-apple-ios` you want `BUILD_PYTORCH_MOBILE=1 IOS_ARCH=arm64 ./scripts/build_ios.sh`
It's unclear how to get `x86_64-apple-ios` (the x86-64 iOS simulator).

Once you've got that built, `IPHONEOS_DEPLOYMENT_TARGET=16.1 LIBTORCH=$PWD/pytorch-checkout/build_ios/install cargo build --target aarch64-apple-ios-sim --example basics`


TODO:

 - [ ] Figure out why  `tch::Cuda::is_available` and `tch::Cuda::cudnn_is_available` result in unknown symbols when linking
 - [ ] Docs?
 - [ ] Figure out why there's a runtime exception at [`Exception raised from findSchemaOrThrow at /Users/simlay/projects/torch-sys-source/pytorch/aten/src/ATen/core/dispatch/Dispatcher.cpp:131`](https://github.com/pytorch/pytorch/blob/c263bd43e8e8502d4726643bc6fd046f0130ac0e/aten/src/ATen/core/dispatch/Dispatcher.cpp#L131)

Here's the runtime error I'm seeing when I run the basics example in the iOS simulator:
```sh
"Could not find schema for aten::zeros.
Exception raised from findSchemaOrThrow at /Users/simlay/projects/torch-sys-source/pytorch/aten/src/ATen/core/dispatch/Dispatcher.cpp:131 (most recent call first):
frame #0: _ZN3c106detail14torchCheckFailEPKcS2_jRKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEE + 92 (0x100a7aa1c in basics)
frame #1: _ZN3c1010Dispatcher17findSchemaOrThrowEPKcS2_ + 516 (0x100a37234 in basics)
frame #2: _ZN2at4_opsL25create_zeros_typed_handleEv + 48 (0x100a138f0 in basics)
frame #3: _ZN2at4_ops5zeros4callEN3c108ArrayRefINS2_6SymIntEEENS2_8optionalINS2_10ScalarTypeEEENS6_INS2_6LayoutEEENS6_INS2_6DeviceEEENS6_IbEE + 176 (0x100a1387c in basics)
frame #4: _ZN2at5zerosEN3c108ArrayRefIxEENS0_13TensorOptionsE + 248 (0x1009ce27c in basics)
frame #5: _ZN5torch5zerosEN3c108ArrayRefIxEENS0_13TensorOptionsE + 136 (0x1009c592c in basics)
frame #6: at_tensor_of_data + 124 (0x1009c56c8 in basics)
frame #7: _ZN3tch8wrappers6tensor6Tensor10f_of_slice17h8c301062d1683d0dE + 136 (0x1009bdae4 in basics)
frame #8: _ZN3tch8wrappers6tensor6Tensor8of_slice17h3ef2e65ed55dda2cE + 36 (0x1009bdbd0 in basics)
frame #9: _ZN6basics4main17h4585665960def4e9E + 44 (0x1009be1ac in basics)
frame #10: _ZN4core3ops8function6FnOnce9call_once17h166a604c999bde6cE + 20 (0x1009bdd94 in basics)
frame #11: _ZN3std10sys_common9backtrace28__rust_begin_short_backtrace17h133407b50aa38c1eE + 24 (0x1009bdd38 in basics)
frame #12: _ZN3std2rt10lang_start28_$u7b$$u7b$closure$u7d$$u7d$17h8df4dd181cd92464E + 28 (0x1009bde84 in basics)
frame #13: _ZN3std2rt19lang_start_internal17h75a83dce357f8b7cE + 380 (0x1009f350c in basics)
frame #14: _ZN3std2rt10lang_start17h53972f716e62a038E + 84 (0x1009bde50 in basics)
frame #15: main + 36 (0x1009be614 in basics)
frame #16: start_sim + 20 (0x100c59fa0 in dyld)
frame #17: 0x0 + 4308835920 (0x100d39e50 in ???)
frame #18: 0x0 + 5216716480866942976 (0x4865800000000000 in ???)
")', /Users/simlay/projects/tch-rs/src/wrappers/tensor.rs:447:32
```