### PR TITLE
Use PyPi API to get url for the prebuilt macOS M1 python wheel

### DIFF
--- a/torch-sys/Cargo.toml
+++ b/torch-sys/Cargo.toml
@@ -18,11 +18,13 @@ libc = "0.2.0"
 [build-dependencies]
 anyhow = "1.0"
 cc = "1.0"
-ureq = { version = "2.6", optional = true }
+ureq = { version = "2.6", optional = true, features = ["json"] }
+serde_json= { version = "1.0", optional = true }
+serde = { version = "1.0", optional = true, features = ["derive"] }
 zip = "0.6"
 
 [features]
-download-libtorch = ["ureq"]
+download-libtorch = ["ureq", "serde", "serde_json"]
 doc-only = []
 
 [package.metadata.docs.rs]

--- a/torch-sys/build.rs
+++ b/torch-sys/build.rs
@@ -164,7 +164,14 @@ fn prepare_libtorch_dir() -> PathBuf {
                 ),
                 "macos" => {
                     if env::var("CARGO_CFG_TARGET_ARCH") == Ok(String::from("aarch64")) {
-                        get_pypi_wheel_url_for_aarch64_macosx().expect("Failed to python wheel url from pypi")
+                        get_pypi_wheel_url_for_aarch64_macosx().expect(
+                            "Failed to retrieve torch from pypi.  Pre-built version of libtorch for apple silicon are not available.
+                            You can install torch manually following the indications from https://github.com/LaurentMazare/tch-rs/issues/629
+                            pip3 install torch=={TORCH_VERSION}
+                            Then update the following environment variables:
+                            export LIBTORCH=$(python3 -c 'import torch; from pathlib import Path; print(Path(torch.__file__).parent)')
+                            export DYLD_LIBRARY_PATH=${{LIBTORCH}}/lib
+                            ")
                     } else {
                         format!("https://download.pytorch.org/libtorch/cpu/libtorch-macos-{TORCH_VERSION}.zip")
                     }

--- a/torch-sys/build.rs
+++ b/torch-sys/build.rs
@@ -46,7 +46,7 @@ struct PyPiPackageUrl {
 #[cfg(feature = "download-libtorch")]
 #[derive(serde::Deserialize, Debug)]
 struct PyPiPackage {
-    urls: Vec<PyPiPackageUrl>
+    urls: Vec<PyPiPackageUrl>,
 }
 #[cfg(feature = "download-libtorch")]
 fn get_pypi_wheel_url_for_aarch64_macosx() -> anyhow::Result<String> {
@@ -56,10 +56,10 @@ fn get_pypi_wheel_url_for_aarch64_macosx() -> anyhow::Result<String> {
     if response_code != 200 {
         anyhow::bail!("Unexpected response code {} for {}", response_code, pypi_url)
     }
-    let pypi_package : PyPiPackage = response.into_json()?;
+    let pypi_package: PyPiPackage = response.into_json()?;
     let urls = pypi_package.urls;
     let url = urls.iter().find_map(|pipi_url: &PyPiPackageUrl| {
-        if pipi_url.filename == format!("torch-{TORCH_VERSION}-cp311-none-macosx_11_0_arm64.whl"){
+        if pipi_url.filename == format!("torch-{TORCH_VERSION}-cp311-none-macosx_11_0_arm64.whl") {
             Some(pipi_url.url.clone())
         } else {
             None
@@ -99,7 +99,7 @@ fn extract<P: AsRef<Path>>(filename: P, outpath: P) -> anyhow::Result<()> {
 
     // This is is if we're unzipping a python wheel.
     if outpath.as_ref().join("torch").exists() {
-        let _ = fs::rename(outpath.as_ref().join("torch"), outpath.as_ref().join("libtorch"))?;
+        fs::rename(outpath.as_ref().join("torch"), outpath.as_ref().join("libtorch"))?;
     }
     Ok(())
 }


### PR DESCRIPTION
I was curious how python wheels were compressed/bundled. Turns out it's a [zip file](https://peps.python.org/pep-0427/#abstract) so I figured I'd show the viability of using the PyPi API to get the build for arm64 macOS.

I'm not in love with it as it's kind of a hack. Here are the two issues:
* The wheel unzips to `torch` rather than `libtorch` so the extract function has to handle this.
* The `find_map` string, `torch-{TORCH_VERSION}-cp311-none-macosx_11_0_arm64.whl` is likely to change a bit in future releases. I was tempted to use `filename.contains("arm64") && filename.contains("macosx")` but that is still [8 different wheels (python 3.8 to 3.11 on macOS 11 and macOS 10.9)](https://pypi.org/project/torch/2.0.0/#files).

In theory, this closes #629.

Let me know if this seems like a reasonable path forward.