### PR TITLE
Change Linear::forward() to match pytorch

### DIFF
--- a/src/nn/linear.rs
+++ b/src/nn/linear.rs
@@ -46,10 +46,27 @@ pub fn linear<'a, T: Borrow<super::Path<'a>>>(
 
 impl super::module::Module for Linear {
     fn forward(&self, xs: &Tensor) -> Tensor {
-        if let Some(bias) = &self.bs {
-            xs.matmul(&self.ws.tr()) + bias
-        } else {
-            xs.matmul(&self.ws.tr())
-        }
+        xs.linear(&self.ws, self.bs.as_ref())
     }
+}
+
+#[test]
+/// To run this test, generate test tensors:
+///
+/// ```shell
+/// cd tests/linear
+/// python gen-test-data.py
+/// ```
+#[ignore]
+fn matches_pytorch() {
+    use crate::nn::Module;
+
+    let input = Tensor::read_npy("tests/linear/in.npy").unwrap();
+    let expected_output = Tensor::read_npy("tests/linear/out.npy").unwrap();
+    let ws = Tensor::read_npy("tests/linear/ws.npy").unwrap();
+    let bs = Tensor::read_npy("tests/linear/bs.npy").unwrap();
+
+    let linear = Linear { ws, bs: Some(bs) };
+    let output = linear.forward(&input);
+    assert!(output.allclose(&expected_output, 1e-5, 1e-8, false));
 }

--- a/tests/linear/gen-test-data.py
+++ b/tests/linear/gen-test-data.py
@@ -1,0 +1,12 @@
+import numpy as np
+import torch
+
+SIZE=512
+
+linear = torch.nn.Linear(SIZE, SIZE)
+input = torch.rand(SIZE, SIZE)
+
+np.save('ws.npy', linear.weight.data)
+np.save('bs.npy', linear.bias.data)
+np.save('in.npy', input.data)
+np.save('out.npy', linear(input).data)


### PR DESCRIPTION
The current implementation of `Linear::forward()` is valid and correct; however it produces outputs
that are similar but not numerically identical to `torch.nn.Linear` in PyTorch. This commit replaces
the implementation with `Tensor::linear()`, which matches the PyTorch outputs exactly.

A Python script is included which generates a random linear layer and input tensor, then writes the
tensors and their expected output to disk. A Rust unit test then confirms that `tch-rs` produces the
same output. The test is marked `#[ignore]`, because the tensors themselves are not committed (they
would be about 3M, which feels a little large; if it's fine then they can be committed).
