### PR TITLE
Refactor the efficientnet models.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ __pycache__
 *~
 .*~
 .vscode/
+
+*.ot
+*.safetensors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This documents the main changes to the `tch` crate.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.12.0 - unreleased
+### Changed
+EfficientNet models have been reworked, [679](https://github.com/LaurentMazare/tch-rs/pull/679).
+
 ## v0.11.0 - 2023-03-20
 ### Added
 - Adapt to C++ PyTorch library (`libtorch`) version `v2.0.0`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tch"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Laurent Mazare <lmazare@gmail.com>"]
 edition = "2021"
 build = "build.rs"

--- a/examples/pretrained-models/main.rs
+++ b/examples/pretrained-models/main.rs
@@ -13,14 +13,14 @@
 // https://github.com/LaurentMazare/tch-rs/releases/download/mw/alexnet.ot
 // https://github.com/LaurentMazare/tch-rs/releases/download/mw/inception-v3.ot
 // https://github.com/LaurentMazare/tch-rs/releases/download/mw/mobilenet-v2.ot
-// https://github.com/LaurentMazare/ocaml-torch/releases/download/v0.1-unstable/efficientnet-b0.ot
-// https://github.com/LaurentMazare/ocaml-torch/releases/download/v0.1-unstable/efficientnet-b1.ot
-// https://github.com/LaurentMazare/ocaml-torch/releases/download/v0.1-unstable/efficientnet-b2.ot
-// https://github.com/LaurentMazare/ocaml-torch/releases/download/v0.1-unstable/efficientnet-b3.ot
-// https://github.com/LaurentMazare/ocaml-torch/releases/download/v0.1-unstable/efficientnet-b4.ot
+// https://github.com/LaurentMazare/ocaml-torch/releases/download/v0.1-unstable/efficientnet-b0.safetensors
+// https://github.com/LaurentMazare/ocaml-torch/releases/download/v0.1-unstable/efficientnet-b1.safetensors
+// https://github.com/LaurentMazare/ocaml-torch/releases/download/v0.1-unstable/efficientnet-b2.safetensors
+// https://github.com/LaurentMazare/ocaml-torch/releases/download/v0.1-unstable/efficientnet-b3.safetensors
+// https://github.com/LaurentMazare/ocaml-torch/releases/download/v0.1-unstable/efficientnet-b4.safetensors
 // https://github.com/LaurentMazare/ocaml-torch/releases/download/v0.1-unstable/convmixer1536_20.ot
 // https://github.com/LaurentMazare/ocaml-torch/releases/download/v0.1-unstable/convmixer1024_20.ot
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use tch::nn::ModuleT;
 use tch::vision::{
     alexnet, convmixer, densenet, efficientnet, imagenet, inception, mobilenet, resnet, squeezenet,
@@ -38,31 +38,32 @@ pub fn main() -> Result<()> {
 
     // Create the model and load the weights from the file.
     let mut vs = tch::nn::VarStore::new(tch::Device::Cpu);
-    let net: Box<dyn ModuleT> = match weights.file_name().unwrap().to_str().unwrap() {
-        "resnet18.ot" => Box::new(resnet::resnet18(&vs.root(), imagenet::CLASS_COUNT)),
-        "resnet34.ot" => Box::new(resnet::resnet34(&vs.root(), imagenet::CLASS_COUNT)),
-        "densenet121.ot" => Box::new(densenet::densenet121(&vs.root(), imagenet::CLASS_COUNT)),
-        "vgg13.ot" => Box::new(vgg::vgg13(&vs.root(), imagenet::CLASS_COUNT)),
-        "vgg16.ot" => Box::new(vgg::vgg16(&vs.root(), imagenet::CLASS_COUNT)),
-        "vgg19.ot" => Box::new(vgg::vgg19(&vs.root(), imagenet::CLASS_COUNT)),
-        "squeezenet1_0.ot" => Box::new(squeezenet::v1_0(&vs.root(), imagenet::CLASS_COUNT)),
-        "squeezenet1_1.ot" => Box::new(squeezenet::v1_1(&vs.root(), imagenet::CLASS_COUNT)),
-        "alexnet.ot" => Box::new(alexnet::alexnet(&vs.root(), imagenet::CLASS_COUNT)),
-        "inception-v3.ot" => Box::new(inception::v3(&vs.root(), imagenet::CLASS_COUNT)),
-        "mobilenet-v2.ot" => Box::new(mobilenet::v2(&vs.root(), imagenet::CLASS_COUNT)),
-        "efficientnet-b0.ot" => Box::new(efficientnet::b0(&vs.root(), imagenet::CLASS_COUNT)),
-        // Maybe the higher resolution models should be handled differently.
-        "efficientnet-b1.ot" => Box::new(efficientnet::b1(&vs.root(), imagenet::CLASS_COUNT)),
-        "efficientnet-b2.ot" => Box::new(efficientnet::b2(&vs.root(), imagenet::CLASS_COUNT)),
-        "efficientnet-b3.ot" => Box::new(efficientnet::b3(&vs.root(), imagenet::CLASS_COUNT)),
-        "efficientnet-b4.ot" => Box::new(efficientnet::b4(&vs.root(), imagenet::CLASS_COUNT)),
-        "efficientnet-b5.ot" => Box::new(efficientnet::b5(&vs.root(), imagenet::CLASS_COUNT)),
-        "efficientnet-b6.ot" => Box::new(efficientnet::b6(&vs.root(), imagenet::CLASS_COUNT)),
-        "efficientnet-b7.ot" => Box::new(efficientnet::b7(&vs.root(), imagenet::CLASS_COUNT)),
-        "convmixer1536_20.ot" => Box::new(convmixer::c1536_20(&vs.root(), imagenet::CLASS_COUNT)),
-        "convmixer1024_20.ot" => Box::new(convmixer::c1024_20(&vs.root(), imagenet::CLASS_COUNT)),
-        _ => bail!("unknown model, use a weight file named e.g. resnet18.ot"),
-    };
+    let net: Box<dyn ModuleT> =
+        match weights.file_stem().context("no stem")?.to_str().context("invalid stem")? {
+            "resnet18" => Box::new(resnet::resnet18(&vs.root(), imagenet::CLASS_COUNT)),
+            "resnet34" => Box::new(resnet::resnet34(&vs.root(), imagenet::CLASS_COUNT)),
+            "densenet121" => Box::new(densenet::densenet121(&vs.root(), imagenet::CLASS_COUNT)),
+            "vgg13" => Box::new(vgg::vgg13(&vs.root(), imagenet::CLASS_COUNT)),
+            "vgg16" => Box::new(vgg::vgg16(&vs.root(), imagenet::CLASS_COUNT)),
+            "vgg19" => Box::new(vgg::vgg19(&vs.root(), imagenet::CLASS_COUNT)),
+            "squeezenet1_0" => Box::new(squeezenet::v1_0(&vs.root(), imagenet::CLASS_COUNT)),
+            "squeezenet1_1" => Box::new(squeezenet::v1_1(&vs.root(), imagenet::CLASS_COUNT)),
+            "alexnet" => Box::new(alexnet::alexnet(&vs.root(), imagenet::CLASS_COUNT)),
+            "inception-v3" => Box::new(inception::v3(&vs.root(), imagenet::CLASS_COUNT)),
+            "mobilenet-v2" => Box::new(mobilenet::v2(&vs.root(), imagenet::CLASS_COUNT)),
+            "efficientnet-b0" => Box::new(efficientnet::b0(&vs.root(), imagenet::CLASS_COUNT)),
+            // Maybe the higher resolution models should be handled differently.
+            "efficientnet-b1" => Box::new(efficientnet::b1(&vs.root(), imagenet::CLASS_COUNT)),
+            "efficientnet-b2" => Box::new(efficientnet::b2(&vs.root(), imagenet::CLASS_COUNT)),
+            "efficientnet-b3" => Box::new(efficientnet::b3(&vs.root(), imagenet::CLASS_COUNT)),
+            "efficientnet-b4" => Box::new(efficientnet::b4(&vs.root(), imagenet::CLASS_COUNT)),
+            "efficientnet-b5" => Box::new(efficientnet::b5(&vs.root(), imagenet::CLASS_COUNT)),
+            "efficientnet-b6" => Box::new(efficientnet::b6(&vs.root(), imagenet::CLASS_COUNT)),
+            "efficientnet-b7" => Box::new(efficientnet::b7(&vs.root(), imagenet::CLASS_COUNT)),
+            "convmixer1536_20" => Box::new(convmixer::c1536_20(&vs.root(), imagenet::CLASS_COUNT)),
+            "convmixer1024_20" => Box::new(convmixer::c1024_20(&vs.root(), imagenet::CLASS_COUNT)),
+            s => bail!("unknown model for {s}, use a weight file named e.g. resnet18.ot"),
+        };
     vs.load(weights)?;
 
     // Apply the forward pass of the model to get the logits.

--- a/src/vision/efficientnet.rs
+++ b/src/vision/efficientnet.rs
@@ -5,67 +5,309 @@ use crate::Tensor;
 const BATCH_NORM_MOMENTUM: f64 = 0.99;
 const BATCH_NORM_EPSILON: f64 = 1e-3;
 
+// Based on the Python version from torchvision.
+// https://github.com/pytorch/vision/blob/0d75d9e5516f446c9c0ef93bd4ed9fea13992d06/torchvision/models/efficientnet.py#L47
 #[derive(Debug, Clone, Copy)]
-pub struct BlockArgs {
-    kernel_size: i64,
-    num_repeat: i64,
-    input_filters: i64,
-    output_filters: i64,
-    expand_ratio: i64,
-    se_ratio: Option<f64>,
+pub struct MBConvConfig {
+    expand_ratio: f64,
+    kernel: i64,
     stride: i64,
+    input_channels: i64,
+    out_channels: i64,
+    num_layers: usize,
 }
 
-#[allow(clippy::many_single_char_names)]
-fn ba(k: i64, r: i64, i: i64, o: i64, er: i64, sr: f64, s: i64) -> BlockArgs {
-    BlockArgs {
-        kernel_size: k,
-        num_repeat: r,
-        input_filters: i,
-        output_filters: o,
-        expand_ratio: er,
-        se_ratio: Some(sr),
-        stride: s,
+fn make_divisible(v: f64, divisor: i64) -> i64 {
+    let min_value = divisor;
+    let new_v = i64::max(min_value, (v + divisor as f64 * 0.5) as i64 / divisor * divisor);
+    if (new_v as f64) < 0.9 * v {
+        new_v + divisor
+    } else {
+        new_v
     }
 }
 
-fn block_args() -> Vec<BlockArgs> {
+fn bneck_confs(width_mult: f64, depth_mult: f64) -> Vec<MBConvConfig> {
+    let bneck_conf = |e, k, s, i, o, n| {
+        let input_channels = make_divisible(i as f64 * width_mult, 8);
+        let out_channels = make_divisible(o as f64 * width_mult, 8);
+        let num_layers = (n as f64 * depth_mult).ceil() as usize;
+        MBConvConfig {
+            expand_ratio: e,
+            kernel: k,
+            stride: s,
+            input_channels,
+            out_channels,
+            num_layers,
+        }
+    };
     vec![
-        ba(3, 1, 32, 16, 1, 0.25, 1),
-        ba(3, 2, 16, 24, 6, 0.25, 2),
-        ba(5, 2, 24, 40, 6, 0.25, 2),
-        ba(3, 3, 40, 80, 6, 0.25, 2),
-        ba(5, 3, 80, 112, 6, 0.25, 1),
-        ba(5, 4, 112, 192, 6, 0.25, 2),
-        ba(3, 1, 192, 320, 6, 0.25, 1),
+        bneck_conf(1., 3, 1, 32, 16, 1),
+        bneck_conf(6., 3, 2, 16, 24, 2),
+        bneck_conf(6., 5, 2, 24, 40, 2),
+        bneck_conf(6., 3, 2, 40, 80, 3),
+        bneck_conf(6., 5, 1, 80, 112, 3),
+        bneck_conf(6., 5, 2, 112, 192, 4),
+        bneck_conf(6., 3, 1, 192, 320, 1),
     ]
 }
 
-#[derive(Debug, Clone, Copy)]
-struct Params {
-    width: f64,
-    depth: f64,
-}
-
-impl Params {
-    fn round_repeats(&self, repeats: i64) -> i64 {
-        (self.depth * repeats as f64).ceil() as i64
+impl MBConvConfig {
+    fn b0() -> Vec<Self> {
+        bneck_confs(1.0, 1.0)
     }
-
-    fn round_filters(&self, filters: i64) -> i64 {
-        let divisor = 8;
-        let filters = self.width * filters as f64;
-        let filters_ = (filters + divisor as f64 / 2.) as i64;
-        let new_filters = i64::max(divisor, filters_ / divisor * divisor);
-        if (new_filters as f64) < 0.9 * filters {
-            new_filters + divisor
-        } else {
-            new_filters
-        }
+    fn b1() -> Vec<Self> {
+        bneck_confs(1.0, 1.1)
+    }
+    fn b2() -> Vec<Self> {
+        bneck_confs(1.1, 1.2)
+    }
+    fn b3() -> Vec<Self> {
+        bneck_confs(1.2, 1.4)
+    }
+    fn b4() -> Vec<Self> {
+        bneck_confs(1.4, 1.8)
+    }
+    fn b5() -> Vec<Self> {
+        bneck_confs(1.6, 2.2)
+    }
+    fn b6() -> Vec<Self> {
+        bneck_confs(1.8, 2.6)
+    }
+    fn b7() -> Vec<Self> {
+        bneck_confs(2.0, 3.1)
     }
 }
 
 /// Conv2D with same padding.
+#[derive(Debug)]
+struct Conv2DSame {
+    conv2d: nn::Conv2D,
+    s: i64,
+    k: i64,
+}
+
+impl Conv2DSame {
+    fn new(vs: nn::Path, i: i64, o: i64, k: i64, stride: i64, groups: i64, b: bool) -> Self {
+        let conv_config = nn::ConvConfig { stride, groups, bias: b, ..Default::default() };
+        let conv2d = nn::conv2d(vs, i, o, k, conv_config);
+        Self { conv2d, s: stride, k }
+    }
+}
+
+impl Module for Conv2DSame {
+    fn forward(&self, xs: &Tensor) -> Tensor {
+        let s = self.s;
+        let k = self.k;
+        let size = xs.size();
+        let ih = size[2];
+        let iw = size[3];
+        let oh = (ih + s - 1) / s;
+        let ow = (iw + s - 1) / s;
+        let pad_h = i64::max((oh - 1) * s + k - ih, 0);
+        let pad_w = i64::max((ow - 1) * s + k - iw, 0);
+        if pad_h > 0 || pad_w > 0 {
+            xs.zero_pad2d(pad_w / 2, pad_w - pad_w / 2, pad_h / 2, pad_h - pad_h / 2)
+                .apply(&self.conv2d)
+        } else {
+            xs.apply(&self.conv2d)
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ConvNormActivation {
+    conv2d: Conv2DSame,
+    bn2d: nn::BatchNorm,
+    activation: bool,
+}
+
+impl ConvNormActivation {
+    fn new(vs: nn::Path, i: i64, o: i64, k: i64, stride: i64, groups: i64) -> Self {
+        let conv2d = Conv2DSame::new(&vs / 0, i, o, k, stride, groups, false);
+        let bn_config = nn::BatchNormConfig {
+            momentum: 1.0 - BATCH_NORM_MOMENTUM,
+            eps: BATCH_NORM_EPSILON,
+            ..Default::default()
+        };
+        let bn2d = nn::batch_norm2d(&vs / 1, o, bn_config);
+        Self { conv2d, bn2d, activation: true }
+    }
+
+    fn no_activation(self) -> Self {
+        Self { activation: false, ..self }
+    }
+}
+
+impl ModuleT for ConvNormActivation {
+    fn forward_t(&self, xs: &Tensor, t: bool) -> Tensor {
+        let xs = xs.apply(&self.conv2d).apply_t(&self.bn2d, t);
+        if self.activation {
+            xs.swish()
+        } else {
+            xs
+        }
+    }
+}
+
+#[derive(Debug)]
+struct SqueezeExcitation {
+    fc1: Conv2DSame,
+    fc2: Conv2DSame,
+}
+
+impl SqueezeExcitation {
+    fn new(vs: nn::Path, input_channels: i64, squeeze_channels: i64) -> Self {
+        let fc1 = Conv2DSame::new(&vs / "fc1", input_channels, squeeze_channels, 1, 1, 1, true);
+        let fc2 = Conv2DSame::new(&vs / "fc2", squeeze_channels, input_channels, 1, 1, 1, true);
+        Self { fc1, fc2 }
+    }
+}
+
+impl ModuleT for SqueezeExcitation {
+    fn forward_t(&self, xs: &Tensor, t: bool) -> Tensor {
+        let scale = xs
+            .adaptive_avg_pool2d(&[1, 1])
+            .apply_t(&self.fc1, t)
+            .swish()
+            .apply_t(&self.fc2, t)
+            .sigmoid();
+        scale * xs
+    }
+}
+
+#[derive(Debug)]
+struct MBConv {
+    expand_cna: Option<ConvNormActivation>,
+    depthwise_cna: ConvNormActivation,
+    squeeze_excitation: SqueezeExcitation,
+    project_cna: ConvNormActivation,
+    config: MBConvConfig,
+}
+
+impl MBConv {
+    fn new(vs: nn::Path, c: MBConvConfig) -> Self {
+        let vs = &vs / "block";
+        let exp = make_divisible(c.input_channels as f64 * c.expand_ratio, 8);
+        let expand_cna = if exp != c.input_channels {
+            Some(ConvNormActivation::new(&vs / 0, c.input_channels, exp, 1, 1, 1))
+        } else {
+            None
+        };
+        let start_index = if expand_cna.is_some() { 1 } else { 0 };
+        let depthwise_cna =
+            ConvNormActivation::new(&vs / start_index, exp, exp, c.kernel, c.stride, exp);
+        let squeeze_channels = i64::max(1, c.input_channels / 4);
+        let squeeze_excitation =
+            SqueezeExcitation::new(&vs / (start_index + 1), exp, squeeze_channels);
+        let project_cna =
+            ConvNormActivation::new(&vs / (start_index + 2), exp, c.out_channels, 1, 1, 1)
+                .no_activation();
+        Self { expand_cna, depthwise_cna, squeeze_excitation, project_cna, config: c }
+    }
+}
+
+impl ModuleT for MBConv {
+    fn forward_t(&self, xs: &Tensor, t: bool) -> Tensor {
+        let use_res_connect =
+            self.config.stride == 1 && self.config.input_channels == self.config.out_channels;
+        let ys = match &self.expand_cna {
+            Some(expand_cna) => xs.apply_t(expand_cna, t),
+            None => xs.shallow_clone(),
+        };
+        let ys = ys
+            .apply_t(&self.depthwise_cna, t)
+            .apply_t(&self.squeeze_excitation, t)
+            .apply_t(&self.project_cna, t);
+        if use_res_connect {
+            ys + xs
+        } else {
+            ys
+        }
+    }
+}
+
+impl Tensor {
+    fn swish(&self) -> Tensor {
+        self * self.sigmoid()
+    }
+}
+
+#[derive(Debug)]
+struct EfficientNet {
+    init_cna: ConvNormActivation,
+    blocks: Vec<MBConv>,
+    final_cna: ConvNormActivation,
+    classifier: nn::Linear,
+}
+
+impl EfficientNet {
+    fn new(p: &nn::Path, configs: Vec<MBConvConfig>, nclasses: i64) -> Self {
+        let f_p = p / "features";
+        let first_in_c = configs[0].input_channels;
+        let last_out_c = configs.last().unwrap().out_channels;
+        let final_out_c = 4 * last_out_c;
+        let init_cna = ConvNormActivation::new(&f_p / 0, 3, first_in_c, 3, 2, 1);
+        let nconfigs = configs.len();
+        let mut blocks = vec![];
+        for (index, cnf) in configs.into_iter().enumerate() {
+            let f_p = &f_p / (index + 1);
+            for r_index in 0..cnf.num_layers {
+                let cnf = if r_index == 0 {
+                    cnf
+                } else {
+                    MBConvConfig { input_channels: cnf.out_channels, stride: 1, ..cnf }
+                };
+                blocks.push(MBConv::new(&f_p / r_index, cnf))
+            }
+        }
+        let final_cna =
+            ConvNormActivation::new(&f_p / (nconfigs + 1), last_out_c, final_out_c, 1, 1, 1);
+        let classifier =
+            nn::linear(p / "classifier" / 1, final_out_c, nclasses, Default::default());
+        Self { init_cna, blocks, final_cna, classifier }
+    }
+}
+
+impl ModuleT for EfficientNet {
+    fn forward_t(&self, xs: &Tensor, t: bool) -> Tensor {
+        let mut xs = xs.apply_t(&self.init_cna, t);
+        for block in self.blocks.iter() {
+            xs = xs.apply_t(block, t)
+        }
+        xs.apply_t(&self.final_cna, t)
+            .adaptive_avg_pool2d(&[1, 1])
+            .squeeze_dim(-1)
+            .squeeze_dim(-1)
+            .apply(&self.classifier)
+    }
+}
+
+pub fn b0(p: &nn::Path, nclasses: i64) -> impl ModuleT {
+    EfficientNet::new(p, MBConvConfig::b0(), nclasses)
+}
+pub fn b1(p: &nn::Path, nclasses: i64) -> impl ModuleT {
+    EfficientNet::new(p, MBConvConfig::b1(), nclasses)
+}
+pub fn b2(p: &nn::Path, nclasses: i64) -> impl ModuleT {
+    EfficientNet::new(p, MBConvConfig::b2(), nclasses)
+}
+pub fn b3(p: &nn::Path, nclasses: i64) -> impl ModuleT {
+    EfficientNet::new(p, MBConvConfig::b3(), nclasses)
+}
+pub fn b4(p: &nn::Path, nclasses: i64) -> impl ModuleT {
+    EfficientNet::new(p, MBConvConfig::b4(), nclasses)
+}
+pub fn b5(p: &nn::Path, nclasses: i64) -> impl ModuleT {
+    EfficientNet::new(p, MBConvConfig::b5(), nclasses)
+}
+pub fn b6(p: &nn::Path, nclasses: i64) -> impl ModuleT {
+    EfficientNet::new(p, MBConvConfig::b6(), nclasses)
+}
+pub fn b7(p: &nn::Path, nclasses: i64) -> impl ModuleT {
+    EfficientNet::new(p, MBConvConfig::b7(), nclasses)
+}
+
 #[allow(clippy::many_single_char_names)]
 pub fn conv2d_same(vs: nn::Path, i: i64, o: i64, k: i64, c: ConvConfig) -> impl Module {
     let conv2d = nn::conv2d(vs, i, o, k, c);
@@ -84,170 +326,4 @@ pub fn conv2d_same(vs: nn::Path, i: i64, o: i64, k: i64, c: ConvConfig) -> impl 
             xs.apply(&conv2d)
         }
     })
-}
-
-impl Params {
-    fn of_tuple(width: f64, depth: f64) -> Params {
-        Params { width, depth }
-    }
-    fn b0() -> Params {
-        Params::of_tuple(1.0, 1.0)
-    }
-    fn b1() -> Params {
-        Params::of_tuple(1.0, 1.1)
-    }
-    fn b2() -> Params {
-        Params::of_tuple(1.1, 1.2)
-    }
-    fn b3() -> Params {
-        Params::of_tuple(1.2, 1.4)
-    }
-    fn b4() -> Params {
-        Params::of_tuple(1.4, 1.8)
-    }
-    fn b5() -> Params {
-        Params::of_tuple(1.6, 2.2)
-    }
-    fn b6() -> Params {
-        Params::of_tuple(1.8, 2.6)
-    }
-    fn b7() -> Params {
-        Params::of_tuple(2.0, 3.1)
-    }
-}
-
-impl Tensor {
-    fn swish(&self) -> Tensor {
-        self * self.sigmoid()
-    }
-}
-
-fn block(p: nn::Path, args: BlockArgs) -> impl ModuleT {
-    let inp = args.input_filters;
-    let oup = args.input_filters * args.expand_ratio;
-    let final_oup = args.output_filters;
-    let bn2d = nn::BatchNormConfig {
-        momentum: 1.0 - BATCH_NORM_MOMENTUM,
-        eps: BATCH_NORM_EPSILON,
-        ..Default::default()
-    };
-    let conv_no_bias = nn::ConvConfig { bias: false, ..Default::default() };
-    let depthwise_conv =
-        nn::ConvConfig { stride: args.stride, groups: oup, bias: false, ..Default::default() };
-
-    let expansion = if args.expand_ratio != 1 {
-        nn::seq_t()
-            .add(conv2d_same(&p / "_expand_conv", inp, oup, 1, conv_no_bias))
-            .add(nn::batch_norm2d(&p / "_bn0", oup, bn2d))
-            .add_fn(|xs| xs.swish())
-    } else {
-        nn::seq_t()
-    };
-    let depthwise_conv =
-        conv2d_same(&p / "_depthwise_conv", oup, oup, args.kernel_size, depthwise_conv);
-    let depthwise_bn = nn::batch_norm2d(&p / "_bn1", oup, bn2d);
-    let se = args.se_ratio.map(|se_ratio| {
-        let nsc = i64::max(1, (inp as f64 * se_ratio) as i64);
-        nn::seq_t()
-            .add(conv2d_same(&p / "_se_reduce", oup, nsc, 1, Default::default()))
-            .add_fn(|xs| xs.swish())
-            .add(conv2d_same(&p / "_se_expand", nsc, oup, 1, Default::default()))
-    });
-    let project_conv = conv2d_same(&p / "_project_conv", oup, final_oup, 1, conv_no_bias);
-    let project_bn = nn::batch_norm2d(&p / "_bn2", final_oup, bn2d);
-    nn::func_t(move |xs, train| {
-        let ys =
-            if args.expand_ratio != 1 { xs.apply_t(&expansion, train) } else { xs.shallow_clone() };
-        let ys = ys.apply(&depthwise_conv).apply_t(&depthwise_bn, train).swish();
-        let ys = match &se {
-            None => ys,
-            Some(seq) => ys.adaptive_avg_pool2d(&[1, 1]).apply_t(seq, train).sigmoid() * ys,
-        };
-        let ys = ys.apply(&project_conv).apply_t(&project_bn, train);
-        if args.stride == 1 && inp == final_oup {
-            // Maybe add a drop_connect layer here ?
-            ys + xs
-        } else {
-            ys
-        }
-    })
-}
-
-fn efficientnet(p: &nn::Path, params: Params, nclasses: i64) -> impl ModuleT {
-    let args = block_args();
-    let bn2d = nn::BatchNormConfig {
-        momentum: 1.0 - BATCH_NORM_MOMENTUM,
-        eps: BATCH_NORM_EPSILON,
-        ..Default::default()
-    };
-    let conv_no_bias = nn::ConvConfig { bias: false, ..Default::default() };
-    let conv_s2 = nn::ConvConfig { stride: 2, bias: false, ..Default::default() };
-    let out_c = params.round_filters(32);
-    let conv_stem = conv2d_same(p / "_conv_stem", 3, out_c, 3, conv_s2);
-    let bn0 = nn::batch_norm2d(p / "_bn0", out_c, bn2d);
-    let mut blocks = nn::seq_t();
-    let block_p = p / "_blocks";
-    let mut block_idx = 0;
-    for &arg in args.iter() {
-        let arg = BlockArgs {
-            input_filters: params.round_filters(arg.input_filters),
-            output_filters: params.round_filters(arg.output_filters),
-            ..arg
-        };
-        blocks = blocks.add(block(&block_p / block_idx, arg));
-        block_idx += 1;
-        let arg = BlockArgs { input_filters: arg.output_filters, stride: 1, ..arg };
-        for _i in 1..params.round_repeats(arg.num_repeat) {
-            blocks = blocks.add(block(&block_p / block_idx, arg));
-            block_idx += 1;
-        }
-    }
-    let in_channels = params.round_filters(args.last().unwrap().output_filters);
-    let out_c = params.round_filters(1280);
-    let conv_head = conv2d_same(p / "_conv_head", in_channels, out_c, 1, conv_no_bias);
-    let bn1 = nn::batch_norm2d(p / "_bn1", out_c, bn2d);
-    let classifier = nn::seq_t().add_fn_t(|xs, train| xs.dropout(0.2, train)).add(nn::linear(
-        p / "_fc",
-        out_c,
-        nclasses,
-        Default::default(),
-    ));
-    nn::func_t(move |xs, train| {
-        xs.apply(&conv_stem)
-            .apply_t(&bn0, train)
-            .swish()
-            .apply_t(&blocks, train)
-            .apply(&conv_head)
-            .apply_t(&bn1, train)
-            .swish()
-            .adaptive_avg_pool2d(&[1, 1])
-            .squeeze_dim(-1)
-            .squeeze_dim(-1)
-            .apply_t(&classifier, train)
-    })
-}
-
-pub fn b0(p: &nn::Path, nclasses: i64) -> impl ModuleT {
-    efficientnet(p, Params::b0(), nclasses)
-}
-pub fn b1(p: &nn::Path, nclasses: i64) -> impl ModuleT {
-    efficientnet(p, Params::b1(), nclasses)
-}
-pub fn b2(p: &nn::Path, nclasses: i64) -> impl ModuleT {
-    efficientnet(p, Params::b2(), nclasses)
-}
-pub fn b3(p: &nn::Path, nclasses: i64) -> impl ModuleT {
-    efficientnet(p, Params::b3(), nclasses)
-}
-pub fn b4(p: &nn::Path, nclasses: i64) -> impl ModuleT {
-    efficientnet(p, Params::b4(), nclasses)
-}
-pub fn b5(p: &nn::Path, nclasses: i64) -> impl ModuleT {
-    efficientnet(p, Params::b5(), nclasses)
-}
-pub fn b6(p: &nn::Path, nclasses: i64) -> impl ModuleT {
-    efficientnet(p, Params::b6(), nclasses)
-}
-pub fn b7(p: &nn::Path, nclasses: i64) -> impl ModuleT {
-    efficientnet(p, Params::b7(), nclasses)
 }

--- a/src/vision/export_model.py
+++ b/src/vision/export_model.py
@@ -1,11 +1,16 @@
-# This script exports pre-trained model weights in numpy format.
-# These weights can then be converted to the libtorch native format via:
-# cargo run --example tensor-tools -- cp resnet18.npz resnet18.ot
+# This script exports pre-trained model weights in the safetensors format.
 import numpy as np
 import torch
 import torchvision
+from safetensors import torch as stt
 
 m = torchvision.models.efficientnet_b0(pretrained=True)
-nps = {}
-for k, v in m.state_dict().items(): nps[k] = v.numpy()
-np.savez('efficientnet-b0.npz', **nps)
+stt.save_file(m.state_dict(), 'efficientnet-b0.safetensors')
+m = torchvision.models.efficientnet_b1(pretrained=True)
+stt.save_file(m.state_dict(), 'efficientnet-b1.safetensors')
+m = torchvision.models.efficientnet_b2(pretrained=True)
+stt.save_file(m.state_dict(), 'efficientnet-b2.safetensors')
+m = torchvision.models.efficientnet_b3(pretrained=True)
+stt.save_file(m.state_dict(), 'efficientnet-b3.safetensors')
+m = torchvision.models.efficientnet_b4(pretrained=True)
+stt.save_file(m.state_dict(), 'efficientnet-b4.safetensors')


### PR DESCRIPTION
The torchvision implementation of efficientnet model has significantly diverged, this makes it tricky to import the weights from these models. This PR provides a new implementation in line with the Python version, it also changes the expected weights to use safetensors which should provide better stability overall.
This should fix #603 