### PR TITLE
Fix number of element calculation for `Vec<T>` conversion

### DIFF
--- a/src/tensor/convert.rs
+++ b/src/tensor/convert.rs
@@ -7,7 +7,7 @@ use std::convert::{TryFrom, TryInto};
 impl<T: Element + Copy> TryFrom<&Tensor> for Vec<T> {
     type Error = TchError;
     fn try_from(tensor: &Tensor) -> Result<Self, Self::Error> {
-        let num_elem = tensor.numel() as usize;
+        let num_elem = tensor.numel();
         let mut vec = vec![T::ZERO; num_elem];
         tensor.f_to_kind(T::KIND)?.f_copy_data(&mut vec, num_elem)?;
         Ok(vec)

--- a/src/tensor/convert.rs
+++ b/src/tensor/convert.rs
@@ -7,8 +7,7 @@ use std::convert::{TryFrom, TryInto};
 impl<T: Element + Copy> TryFrom<&Tensor> for Vec<T> {
     type Error = TchError;
     fn try_from(tensor: &Tensor) -> Result<Self, Self::Error> {
-        let s1 = tensor.size1()? as usize;
-        let num_elem = s1;
+        let num_elem = tensor.numel() as usize;
         let mut vec = vec![T::ZERO; num_elem];
         tensor.f_to_kind(T::KIND)?.f_copy_data(&mut vec, num_elem)?;
         Ok(vec)

--- a/tests/tensor_tests.rs
+++ b/tests/tensor_tests.rs
@@ -455,3 +455,18 @@ fn set_data() {
     t.set_data(&t.to_kind(tch::Kind::BFloat16));
     assert_eq!(t.kind(), tch::Kind::BFloat16);
 }
+
+#[test]
+fn convert_ndarray() {
+    let t_1d = Tensor::of_slice(&[0, 1, 2, 3, 4, 5]);
+    let array_1d: ndarray::ArrayD<i64> = t_1d.as_ref().try_into().unwrap();
+    assert_eq!(array_1d.as_slice(), ndarray::array![0, 1, 2, 3, 4, 5].as_slice());
+
+    let t_2d = Tensor::of_slice(&[0, 1, 2, 3, 4, 5]).view((3, 2));
+    let array_2d: ndarray::ArrayD<i64> = t_2d.as_ref().try_into().unwrap();
+    assert_eq!(array_2d.as_slice(), ndarray::array![[0, 1, 2], [3, 4, 5]].as_slice());
+
+    let t_3d = Tensor::of_slice(&[0, 1, 2, 3, 4, 5, 6, 7]).view((2, 2, 2));
+    let array_3d: ndarray::ArrayD<i64> = t_3d.as_ref().try_into().unwrap();
+    assert_eq!(array_3d.as_slice(), ndarray::array![[[0, 1], [2, 3]], [[4, 5], [6, 7]]].as_slice());
+}


### PR DESCRIPTION
Hello,

Recent changes for the conversion of tensors to vectors are leading to issues for the tensor to ndarray conversion.
The latter relies on an intermediate flat `Vec` representation (regardless of the original tensor dimension) stored alongside the size of the tensor to create the ndarray. However the updated method for converting a `Tensor` to a `Vec<T>` is only correct if the input tensor is also of dimension 1.

This small PR ensures converting a `Tensor` to a `Vec<T>` always leads to the correct number of elements. Converting a higher dimensionality Tensor to a `Vec<T>` will lead to flatten view of the same (as was the case previously).

I have added a small unit test to ensure support of the conversion of `Tensor` to `ndarray` for dimensions 1, 2 and 3