### PR TITLE
Add an export script for dinov2 weights.

### DIFF
--- a/examples/pretrained-models/main.rs
+++ b/examples/pretrained-models/main.rs
@@ -20,7 +20,8 @@
 // https://github.com/LaurentMazare/ocaml-torch/releases/download/v0.1-unstable/efficientnet-b4.safetensors
 // https://github.com/LaurentMazare/ocaml-torch/releases/download/v0.1-unstable/convmixer1536_20.ot
 // https://github.com/LaurentMazare/ocaml-torch/releases/download/v0.1-unstable/convmixer1024_20.ot
-// https://github.com/LaurentMazare/ocaml-torch/releases/download/v0.1-unstable/dinov2_vits14.safetensors
+// In order to obtain the dinov2 weights, e.g. dinov2_vits14.safetensors, run the
+// src/vision/export_dinov2.py
 use anyhow::{bail, Context, Result};
 use tch::nn::ModuleT;
 use tch::vision::{

--- a/src/vision/dinov2.rs
+++ b/src/vision/dinov2.rs
@@ -1,5 +1,7 @@
 //! DINOv2: Learning Robust Visual Features without Supervision
 //! https://github.com/facebookresearch/dinov2
+//! The weights can be extracted from pre-trained Python models
+//! using `python src/vision/export_dinov2.py`.
 // TODO: use swiglu.
 use crate::{nn, IndexOp, Kind, Tensor};
 

--- a/src/vision/export_dinov2.py
+++ b/src/vision/export_dinov2.py
@@ -1,0 +1,15 @@
+import torch
+from safetensors.torch import save_file
+
+def normalize_key(k):
+    if k.startswith("backbone."):
+        k = k[9:]
+    if k.startswith("linear_head."):
+        k = k[7:]
+    return k
+
+dinov2_vits14 = torch.hub.load('facebookresearch/dinov2', 'dinov2_vits14_lc', layers=1)
+print(dinov2_vits14)
+weights = dinov2_vits14.state_dict()
+weights = {normalize_key(k): v for k, v in weights.items()}
+save_file(weights, "dinov2_vits14.safetensors")


### PR DESCRIPTION
Use a python script to export the dino-v2 pretrained weights in the safetensors format.