### PR TITLE
Rename the of_ functions to from_.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## v0.13.0 - unreleased yet
 ### Added
 - Rename the `of_...` conversion functions to `from_...` so as to be closer to
-  the Rust best practices.
-  [706](https://github.com/LaurentMazare/tch-rs/pull/706).
+  the Rust best practices,
+  [706](https://github.com/LaurentMazare/tch-rs/pull/706). This is a breaking
+  change and will require modifying calls such as `of_slice` to be `from_slice`
+  instead.
 - Expose some functions so that Python extensions that operates on PyTorch
   tensors can be written with `tch`,
   [704](https://github.com/LaurentMazare/tch-rs/pull/704).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v0.13.0 - unreleased yet
 ### Added
+- Rename the `of_...` conversion functions to `from_...` so as to be closer to
+  the Rust best practices.
+  [706](https://github.com/LaurentMazare/tch-rs/pull/706).
 - Expose some functions so that Python extensions that operates on PyTorch
   tensors can be written with `tch`,
   [704](https://github.com/LaurentMazare/tch-rs/pull/704).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tch"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Laurent Mazare <lmazare@gmail.com>"]
 edition = "2021"
 build = "build.rs"
@@ -22,7 +22,7 @@ libc = "0.2.0"
 ndarray = "0.15"
 rand = "0.8"
 thiserror = "1"
-torch-sys = { version = "0.12.0", path = "torch-sys" }
+torch-sys = { version = "0.13.0", path = "torch-sys" }
 zip = "0.6"
 half = "2"
 safetensors = "0.3.0"

--- a/examples/basics.rs
+++ b/examples/basics.rs
@@ -18,13 +18,13 @@ fn main() {
     println!("Cuda available: {}", tch::Cuda::is_available());
     println!("Cudnn available: {}", tch::Cuda::cudnn_is_available());
     let device = tch::Device::cuda_if_available();
-    let t = Tensor::of_slice(&[3, 1, 4, 1, 5]).to(device);
+    let t = Tensor::from_slice(&[3, 1, 4, 1, 5]).to(device);
     t.print();
     let t = Tensor::randn([5, 4], kind::FLOAT_CPU);
     t.print();
     (&t + 1.5).print();
     (&t + 2.5).print();
-    let mut t = Tensor::of_slice(&[1.1f32, 2.1, 3.1]);
+    let mut t = Tensor::from_slice(&[1.1f32, 2.1, 3.1]);
     t += 42;
     t.print();
     println!("{:?} {}", t.size(), t.double_value(&[1]));

--- a/examples/memory_test.rs
+++ b/examples/memory_test.rs
@@ -13,7 +13,7 @@ fn main() {
     };
     let slice = vec![0; 1_000_000];
     for i in 1..1_000_000 {
-        let t = Tensor::of_slice(&slice).to_device(device);
+        let t = Tensor::from_slice(&slice).to_device(device);
         println!("{} {:?}", i, t.size())
     }
 }

--- a/examples/reinforcement-learning/gym_env.rs
+++ b/examples/reinforcement-learning/gym_env.rs
@@ -50,7 +50,7 @@ impl GymEnv {
         let gil = Python::acquire_gil();
         let py = gil.python();
         let obs = self.env.call_method(py, "reset", NoArgs, None)?;
-        Ok(Tensor::of_slice(&obs.extract::<Vec<f32>>(py)?))
+        Ok(Tensor::from_slice(&obs.extract::<Vec<f32>>(py)?))
     }
 
     /// Applies an environment step using the specified action.
@@ -59,7 +59,7 @@ impl GymEnv {
         let py = gil.python();
         let step = self.env.call_method(py, "step", (action,), None)?;
         Ok(Step {
-            obs: Tensor::of_slice(&step.get_item(py, 0)?.extract::<Vec<f32>>(py)?),
+            obs: Tensor::from_slice(&step.get_item(py, 0)?.extract::<Vec<f32>>(py)?),
             reward: step.get_item(py, 1)?.extract(py)?,
             is_done: step.get_item(py, 2)?.extract(py)?,
             action,

--- a/examples/reinforcement-learning/policy_gradient.rs
+++ b/examples/reinforcement-learning/policy_gradient.rs
@@ -68,9 +68,9 @@ pub fn run() -> cpython::PyResult<()> {
         // Train the model via policy gradient on the rollout data.
         let batch_size = steps.len() as i64;
         let actions: Vec<i64> = steps.iter().map(|s| s.action).collect();
-        let actions = Tensor::of_slice(&actions).unsqueeze(1);
+        let actions = Tensor::from_slice(&actions).unsqueeze(1);
         let rewards = accumulate_rewards(&steps);
-        let rewards = Tensor::of_slice(&rewards).to_kind(Float);
+        let rewards = Tensor::from_slice(&rewards).to_kind(Float);
         let action_mask =
             Tensor::zeros([batch_size, 2], tch::kind::FLOAT_CPU).scatter_value(1, &actions, 1.0);
         let obs: Vec<Tensor> = steps.into_iter().map(|s| s.obs).collect();

--- a/examples/reinforcement-learning/vec_gym_env.rs
+++ b/examples/reinforcement-learning/vec_gym_env.rs
@@ -38,7 +38,7 @@ impl VecGymEnv {
         let py = gil.python();
         let obs = self.env.call_method(py, "reset", NoArgs, None)?;
         let obs = obs.call_method(py, "flatten", NoArgs, None)?;
-        let obs = Tensor::of_slice(&obs.extract::<Vec<f32>>(py)?);
+        let obs = Tensor::from_slice(&obs.extract::<Vec<f32>>(py)?);
         Ok(obs.view_(&self.observation_space))
     }
 
@@ -50,9 +50,9 @@ impl VecGymEnv {
         let obs_buffer = PyBuffer::get(py, &obs)?;
         let obs_vec: Vec<u8> = obs_buffer.to_vec(py)?;
         let obs =
-            Tensor::of_slice(&obs_vec).view_(&self.observation_space).to_kind(tch::Kind::Float);
-        let reward = Tensor::of_slice(&step.get_item(py, 1)?.extract::<Vec<f32>>(py)?);
-        let is_done = Tensor::of_slice(&step.get_item(py, 2)?.extract::<Vec<f32>>(py)?);
+            Tensor::from_slice(&obs_vec).view_(&self.observation_space).to_kind(tch::Kind::Float);
+        let reward = Tensor::from_slice(&step.get_item(py, 1)?.extract::<Vec<f32>>(py)?);
+        let is_done = Tensor::from_slice(&step.get_item(py, 2)?.extract::<Vec<f32>>(py)?);
         Ok(Step { obs, reward, is_done })
     }
 

--- a/examples/stable-diffusion/main.rs
+++ b/examples/stable-diffusion/main.rs
@@ -2470,10 +2470,10 @@ fn main() -> anyhow::Result<()> {
     let str = tokenizer.decode(&tokens);
     println!("Str: {str}");
     let tokens: Vec<i64> = tokens.iter().map(|x| *x as i64).collect();
-    let tokens = Tensor::of_slice(&tokens).view((1, -1)).to(device);
+    let tokens = Tensor::from_slice(&tokens).view((1, -1)).to(device);
     let uncond_tokens = tokenizer.encode("", Some(MAX_POSITION_EMBEDDINGS))?;
     let uncond_tokens: Vec<i64> = uncond_tokens.iter().map(|x| *x as i64).collect();
-    let uncond_tokens = Tensor::of_slice(&uncond_tokens).view((1, -1)).to(device);
+    let uncond_tokens = Tensor::from_slice(&uncond_tokens).view((1, -1)).to(device);
     println!("Tokens: {tokens:?}");
 
     let no_grad_guard = tch::no_grad_guard();

--- a/examples/translation/main.rs
+++ b/examples/translation/main.rs
@@ -106,7 +106,7 @@ impl Model {
         Model {
             encoder: Encoder::new(&vs / "enc", ilang.len(), hidden_dim),
             decoder: Decoder::new(&vs / "dec", hidden_dim, olang.len()),
-            decoder_start: Tensor::of_slice(&[olang.sos_token() as i64]).to_device(vs.device()),
+            decoder_start: Tensor::from_slice(&[olang.sos_token() as i64]).to_device(vs.device()),
             decoder_eos: olang.eos_token(),
             device: vs.device(),
         }
@@ -117,7 +117,7 @@ impl Model {
         let mut state = self.encoder.gru.zero_state(1);
         let mut enc_outputs = vec![];
         for &s in input_.iter() {
-            let s = Tensor::of_slice(&[s as i64]).to_device(self.device);
+            let s = Tensor::from_slice(&[s as i64]).to_device(self.device);
             let (out, state_) = self.encoder.forward(&s, &state);
             enc_outputs.push(out);
             state = state_;
@@ -129,7 +129,7 @@ impl Model {
         for &s in target.iter() {
             let (output, state_) = self.decoder.forward(&prev, &state, &enc_outputs, true);
             state = state_;
-            let target_tensor = Tensor::of_slice(&[s as i64]).to_device(self.device);
+            let target_tensor = Tensor::from_slice(&[s as i64]).to_device(self.device);
             loss = loss + output.nll_loss(&target_tensor);
             let (_, output) = output.topk(1, -1, true, true);
             if self.decoder_eos == i64::try_from(&output).unwrap() as usize {
@@ -144,7 +144,7 @@ impl Model {
         let mut state = self.encoder.gru.zero_state(1);
         let mut enc_outputs = vec![];
         for &s in input_.iter() {
-            let s = Tensor::of_slice(&[s as i64]).to_device(self.device);
+            let s = Tensor::from_slice(&[s as i64]).to_device(self.device);
             let (out, state_) = self.encoder.forward(&s, &state);
             enc_outputs.push(out);
             state = state_;

--- a/examples/yolo/darknet.rs
+++ b/examples/yolo/darknet.rs
@@ -222,7 +222,7 @@ fn detect(xs: &Tensor, image_height: i64, classes: i64, anchors: &Vec<(i64, i64)
         .flat_map(|&(x, y)| vec![x as f32 / stride as f32, y as f32 / stride as f32].into_iter())
         .collect();
     let anchors =
-        Tensor::of_slice(&anchors).view((-1, 2)).repeat([grid_size * grid_size, 1]).unsqueeze(0);
+        Tensor::from_slice(&anchors).view((-1, 2)).repeat([grid_size * grid_size, 1]).unsqueeze(0);
     slice_apply_and_set(&mut xs, 0, 2, |xs| xs.sigmoid() + xy_offset);
     slice_apply_and_set(&mut xs, 4, 1 + classes, Tensor::sigmoid);
     slice_apply_and_set(&mut xs, 2, 2, |xs| xs.exp() * anchors);

--- a/examples/yolo/main.rs
+++ b/examples/yolo/main.rs
@@ -54,7 +54,7 @@ fn iou(b1: &Bbox, b2: &Bbox) -> f64 {
 
 // Assumes x1 <= x2 and y1 <= y2
 pub fn draw_rect(t: &mut Tensor, x1: i64, x2: i64, y1: i64, y2: i64) {
-    let color = Tensor::of_slice(&[0., 0., 1.]).view([3, 1, 1]);
+    let color = Tensor::from_slice(&[0., 0., 1.]).view([3, 1, 1]);
     t.narrow(2, x1, x2 - x1).narrow(1, y1, y2 - y1).copy_(&color)
 }
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -143,7 +143,7 @@ impl TextData {
             })
         }
 
-        Ok(TextData { data: Tensor::of_slice(&buffer), char_for_label, label_for_char })
+        Ok(TextData { data: Tensor::from_slice(&buffer), char_for_label, label_for_char })
     }
 
     /// Returns the number of different characters/labels used by the dataset.

--- a/src/tensor/convert.rs
+++ b/src/tensor/convert.rs
@@ -145,7 +145,7 @@ where
         let slice = value
             .as_slice()
             .ok_or_else(|| TchError::Convert("cannot convert to slice".to_string()))?;
-        let tn = Self::f_of_slice(slice)?;
+        let tn = Self::f_from_slice(slice)?;
         let shape: Vec<i64> = value.shape().iter().map(|s| *s as i64).collect();
         tn.f_reshape(shape)
     }
@@ -168,7 +168,7 @@ impl<T: Element> TryFrom<&Vec<T>> for Tensor {
     type Error = TchError;
 
     fn try_from(value: &Vec<T>) -> Result<Self, Self::Error> {
-        Self::f_of_slice(value.as_slice())
+        Self::f_from_slice(value.as_slice())
     }
 }
 

--- a/src/tensor/index.rs
+++ b/src/tensor/index.rs
@@ -9,7 +9,7 @@
 //!
 //! ```ignore
 //! use crate::tch::{IndexOp, Tensor};
-//! let tensor = Tensor::of_slice(&[1, 2, 3, 4, 5, 6]).view((2, 3));
+//! let tensor = Tensor::from_slice(&[1, 2, 3, 4, 5, 6]).view((2, 3));
 //! let t = tensor.i(1);
 //! let t = tensor.i((.., -2));
 //! ```
@@ -18,7 +18,7 @@
 //!
 //! ```ignore
 //! use crate::tch::{IndexOp, Tensor};
-//! let tensor = Tensor::of_slice(&[1, 2, 3, 4, 5, 6]).view((2, 3));
+//! let tensor = Tensor::from_slice(&[1, 2, 3, 4, 5, 6]).view((2, 3));
 //! let t = tensor.i((.., 1..));
 //! assert_eq!(t.size(), [2, 2]);
 //! assert_eq!(Vec::<i64>::from(t.contiguous().view(-1)), [2, 3, 5, 6]);
@@ -37,7 +37,7 @@
 //!
 //! ```ignore
 //! use crate::tch::{IndexOp, NewAxis, Tensor};
-//! let tensor = Tensor::of_slice(&[1, 2, 3, 4, 5, 6]).view((2, 3));
+//! let tensor = Tensor::from_slice(&[1, 2, 3, 4, 5, 6]).view((2, 3));
 //! let t = tensor.i((NewAxis,));
 //! assert_eq!(t.size(), &[1, 2, 3]);
 //! let t = tensor.i((.., .., NewAxis));
@@ -89,7 +89,7 @@ impl From<&[i64]> for TensorIndexer {
 
 impl From<Vec<i64>> for TensorIndexer {
     fn from(index: Vec<i64>) -> Self {
-        let tensor = Tensor::of_slice(&index);
+        let tensor = Tensor::from_slice(&index);
         TensorIndexer::IndexSelect(tensor)
     }
 }

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -137,13 +137,13 @@ impl Tensor {
 
 impl<T: crate::kind::Element> From<&[T]> for Tensor {
     fn from(v: &[T]) -> Tensor {
-        Tensor::of_slice(v)
+        Tensor::from_slice(v)
     }
 }
 
 impl<T: crate::kind::Element> From<T> for Tensor {
     fn from(v: T) -> Tensor {
-        Tensor::of_slice(&[v]).view(())
+        Tensor::from_slice(&[v]).view(())
     }
 }
 impl Tensor {
@@ -238,12 +238,13 @@ impl Tensor {
         result
     }
 
-    pub fn of_slice2<T, U>(v: &[U]) -> Tensor
+    /// Copies the data from a two dimensional slice in a tensor object.
+    pub fn from_slice2<T, U>(v: &[U]) -> Tensor
     where
         T: crate::kind::Element,
         U: AsRef<[T]>,
     {
-        let inner: Vec<Tensor> = v.iter().map(|v| Tensor::of_slice(v.as_ref())).collect();
+        let inner: Vec<Tensor> = v.iter().map(|v| Tensor::from_slice(v.as_ref())).collect();
         Tensor::stack(&inner, 0)
     }
 

--- a/src/tensor/npy.rs
+++ b/src/tensor/npy.rs
@@ -177,7 +177,7 @@ impl crate::Tensor {
         }
         let mut data: Vec<u8> = vec![];
         reader.read_to_end(&mut data)?;
-        Tensor::f_of_data_size(&data, &header.shape, header.descr)
+        Tensor::f_from_data_size(&data, &header.shape, header.descr)
     }
 
     /// Reads a npz file and returns some named tensors.
@@ -198,7 +198,7 @@ impl crate::Tensor {
             }
             let mut data: Vec<u8> = vec![];
             reader.read_to_end(&mut data)?;
-            let tensor = Tensor::f_of_data_size(&data, &header.shape, header.descr)?;
+            let tensor = Tensor::f_from_data_size(&data, &header.shape, header.descr)?;
             result.push((name, tensor))
         }
         Ok(result)

--- a/src/tensor/safetensors.rs
+++ b/src/tensor/safetensors.rs
@@ -55,7 +55,7 @@ impl<'a> TryFrom<TensorView<'a>> for Tensor {
     fn try_from(view: TensorView<'a>) -> Result<Self, Self::Error> {
         let size: Vec<i64> = view.shape().iter().map(|&x| x as i64).collect();
         let kind: Kind = view.dtype().try_into()?;
-        Tensor::f_of_data_size(view.data(), &size, kind)
+        Tensor::f_from_data_size(view.data(), &size, kind)
     }
 }
 

--- a/src/vision/cifar.rs
+++ b/src/vision/cifar.rs
@@ -18,7 +18,7 @@ fn read_file_(filename: &std::path::Path) -> Result<(Tensor, Tensor)> {
     let mut buf_reader = BufReader::new(File::open(filename)?);
     let mut data = vec![0u8; (SAMPLES_PER_FILE * BYTES_PER_IMAGE) as usize];
     buf_reader.read_exact(&mut data)?;
-    let content = Tensor::of_slice(&data);
+    let content = Tensor::from_slice(&data);
     let images = Tensor::zeros([SAMPLES_PER_FILE, C, H, W], kind::FLOAT_CPU);
     let labels = Tensor::zeros([SAMPLES_PER_FILE], kind::INT64_CPU);
     for index in 0..SAMPLES_PER_FILE {

--- a/src/vision/imagenet.rs
+++ b/src/vision/imagenet.rs
@@ -7,9 +7,9 @@ use std::sync::Mutex;
 
 lazy_static! {
     static ref IMAGENET_MEAN: Mutex<Tensor> =
-        Mutex::new(Tensor::of_slice(&[0.485f32, 0.456, 0.406]).view((3, 1, 1)));
+        Mutex::new(Tensor::from_slice(&[0.485f32, 0.456, 0.406]).view((3, 1, 1)));
     static ref IMAGENET_STD: Mutex<Tensor> =
-        Mutex::new(Tensor::of_slice(&[0.229f32, 0.224, 0.225]).view((3, 1, 1)));
+        Mutex::new(Tensor::from_slice(&[0.229f32, 0.224, 0.225]).view((3, 1, 1)));
 }
 
 pub fn normalize(tensor: &Tensor) -> Result<Tensor, TchError> {

--- a/src/vision/mnist.rs
+++ b/src/vision/mnist.rs
@@ -32,7 +32,7 @@ fn read_labels_(filename: &std::path::Path) -> Result<Tensor> {
     let samples = read_u32(&mut buf_reader)?;
     let mut data = vec![0u8; samples as usize];
     buf_reader.read_exact(&mut data)?;
-    Ok(Tensor::of_slice(&data).to_kind(Kind::Int64))
+    Ok(Tensor::from_slice(&data).to_kind(Kind::Int64))
 }
 
 fn read_images_(filename: &std::path::Path) -> Result<Tensor> {
@@ -44,7 +44,7 @@ fn read_images_(filename: &std::path::Path) -> Result<Tensor> {
     let data_len = samples * rows * cols;
     let mut data = vec![0u8; data_len as usize];
     buf_reader.read_exact(&mut data)?;
-    let tensor = Tensor::of_slice(&data)
+    let tensor = Tensor::from_slice(&data)
         .view((i64::from(samples), i64::from(rows * cols)))
         .to_kind(Kind::Float);
     Ok(tensor / 255.)

--- a/src/vision/rust_image.rs
+++ b/src/vision/rust_image.rs
@@ -31,7 +31,7 @@ impl<'i> TryFrom<&'i GrayImage> for Tensor {
     ///  `h * w` => `1 * 1 * h * w`
     fn try_from(gray: &'i GrayImage) -> Result<Self, Self::Error> {
         let size = &[gray.height() as i64, gray.width() as i64, 1];
-        let tensor = Tensor::f_of_data_size(gray.as_bytes(), size, Kind::Uint8)?;
+        let tensor = Tensor::f_from_data_size(gray.as_bytes(), size, Kind::Uint8)?;
         Ok(hwc_to_chw(&tensor))
     }
 }
@@ -42,7 +42,7 @@ impl<'i> TryFrom<&'i GrayAlphaImage> for Tensor {
     ///  `2 * h * w` => `1 * 2 * h * w`
     fn try_from(gray: &'i GrayAlphaImage) -> Result<Self, Self::Error> {
         let size = &[gray.height() as i64, gray.width() as i64, 2];
-        let tensor = Tensor::f_of_data_size(gray.as_bytes(), size, Kind::Uint8)?;
+        let tensor = Tensor::f_from_data_size(gray.as_bytes(), size, Kind::Uint8)?;
         Ok(hwc_to_chw(&tensor))
     }
 }
@@ -53,7 +53,7 @@ impl<'i> TryFrom<&'i RgbImage> for Tensor {
     /// `h * w * 3` => `1 * 3 * h * w`
     fn try_from(rgb: &'i RgbImage) -> Result<Self, Self::Error> {
         let size = &[rgb.height() as i64, rgb.width() as i64, 3];
-        let tensor = Tensor::f_of_data_size(rgb.as_raw(), size, Kind::Uint8)?;
+        let tensor = Tensor::f_from_data_size(rgb.as_raw(), size, Kind::Uint8)?;
         Ok(hwc_to_chw(&tensor))
     }
 }
@@ -65,7 +65,7 @@ impl<'i> TryFrom<&'i RgbaImage> for Tensor {
     fn try_from(rgb: &'i RgbaImage) -> Result<Self, Self::Error> {
         let kind = Kind::Uint8;
         let size = &[rgb.height() as i64, rgb.width() as i64, 4];
-        let tensor = Tensor::f_of_data_size(rgb.as_raw(), size, kind)?;
+        let tensor = Tensor::f_from_data_size(rgb.as_raw(), size, kind)?;
         Ok(hwc_to_chw(&tensor))
     }
 }
@@ -93,7 +93,7 @@ impl<'i> TryFrom<&'i Rgb32FImage> for Tensor {
     fn try_from(rgb: &'i Rgb32FImage) -> Result<Self, Self::Error> {
         let kind = Kind::Float;
         let size = &[rgb.height() as i64, rgb.width() as i64, 3];
-        let tensor = Tensor::f_of_data_size(rgb.as_bytes(), size, kind)?;
+        let tensor = Tensor::f_from_data_size(rgb.as_bytes(), size, kind)?;
         Ok(hwc_to_chw(&tensor))
     }
 }
@@ -105,7 +105,7 @@ impl<'i> TryFrom<&'i Rgba32FImage> for Tensor {
     fn try_from(rgb: &'i Rgba32FImage) -> Result<Self, Self::Error> {
         let kind = Kind::Float;
         let size = &[rgb.height() as i64, rgb.width() as i64, 4];
-        let tensor = Tensor::f_of_data_size(rgb.as_bytes(), size, kind)?;
+        let tensor = Tensor::f_from_data_size(rgb.as_bytes(), size, kind)?;
         Ok(hwc_to_chw(&tensor))
     }
 }

--- a/src/wrappers/device.rs
+++ b/src/wrappers/device.rs
@@ -89,7 +89,7 @@ impl Device {
         }
     }
 
-    pub(super) fn of_c_int(v: libc::c_int) -> Self {
+    pub(super) fn from_c_int(v: libc::c_int) -> Self {
         match v {
             -1 => Device::Cpu,
             -2 => Device::Mps,

--- a/src/wrappers/kind.rs
+++ b/src/wrappers/kind.rs
@@ -47,7 +47,7 @@ impl Kind {
         }
     }
 
-    pub(super) fn of_c_int(v: libc::c_int) -> Result<Kind, crate::TchError> {
+    pub(super) fn from_c_int(v: libc::c_int) -> Result<Kind, crate::TchError> {
         match v {
             0 => Ok(Kind::Uint8),
             1 => Ok(Kind::Int8),

--- a/src/wrappers/tensor.rs
+++ b/src/wrappers/tensor.rs
@@ -195,7 +195,7 @@ impl Tensor {
     /// an error on undefined tensors and unsupported data types.
     pub fn f_kind(&self) -> Result<Kind, TchError> {
         let kind = unsafe_torch!(at_scalar_type(self.c_tensor));
-        Kind::of_c_int(kind)
+        Kind::from_c_int(kind)
     }
 
     /// Returns the kind of elements stored in the input tensor. Panics
@@ -207,7 +207,7 @@ impl Tensor {
     /// Returns the device on which the input tensor is located.
     pub fn device(&self) -> Device {
         let device = unsafe_torch!(at_device(self.c_tensor));
-        Device::of_c_int(device)
+        Device::from_c_int(device)
     }
 
     /// Prints the input tensor.
@@ -429,7 +429,7 @@ impl Tensor {
 
     // This is similar to vec_... but faster as it directly blits the data.
     /// Converts a slice to a tensor.
-    pub fn f_of_slice<T: kind::Element>(data: &[T]) -> Result<Tensor, TchError> {
+    pub fn f_from_slice<T: kind::Element>(data: &[T]) -> Result<Tensor, TchError> {
         let data_len = data.len();
         let data = data.as_ptr() as *const c_void;
         let c_tensor = unsafe_torch_err!(at_tensor_of_data(
@@ -443,12 +443,12 @@ impl Tensor {
     }
 
     /// Converts a slice to a tensor.
-    pub fn of_slice<T: kind::Element>(data: &[T]) -> Tensor {
-        Self::f_of_slice(data).unwrap()
+    pub fn from_slice<T: kind::Element>(data: &[T]) -> Tensor {
+        Self::f_from_slice(data).unwrap()
     }
 
     /// Converts some byte data to a tensor with some specified kind and shape.
-    pub fn f_of_data_size(data: &[u8], size: &[i64], kind: Kind) -> Result<Tensor, TchError> {
+    pub fn f_from_data_size(data: &[u8], size: &[i64], kind: Kind) -> Result<Tensor, TchError> {
         let data = data.as_ptr() as *const c_void;
         let elt_size_in_bytes = kind.elt_size_in_bytes();
         let c_tensor = unsafe_torch_err!(at_tensor_of_data(
@@ -465,7 +465,7 @@ impl Tensor {
     /// Resize operations are now allowed on this tensor without copying the data first.
     /// # Safety
     ///   This will panic if `data` points to invalid data.
-    pub unsafe fn f_of_blob(
+    pub unsafe fn f_from_blob(
         data: *const u8,
         size: &[i64],
         strides: &[i64],
@@ -490,19 +490,19 @@ impl Tensor {
     /// Resize operations are now allowed on this tensor without copying the data first.
     /// # Safety
     ///   This will panic if `data` points to invalid data.
-    pub unsafe fn of_blob(
+    pub unsafe fn from_blob(
         data: *const u8,
         size: &[i64],
         strides: &[i64],
         kind: Kind,
         device: Device,
     ) -> Tensor {
-        Self::f_of_blob(data, size, strides, kind, device).unwrap()
+        Self::f_from_blob(data, size, strides, kind, device).unwrap()
     }
 
     /// Converts some byte data to a tensor with some specified kind and shape.
-    pub fn of_data_size(data: &[u8], size: &[i64], kind: Kind) -> Tensor {
-        Self::f_of_data_size(data, size, kind).unwrap()
+    pub fn from_data_size(data: &[u8], size: &[i64], kind: Kind) -> Tensor {
+        Self::f_from_data_size(data, size, kind).unwrap()
     }
 
     /// Returns a new tensor that share storage with the input tensor.

--- a/tests/data_tests.rs
+++ b/tests/data_tests.rs
@@ -8,8 +8,8 @@ use test_utils::*;
 fn iter2() {
     let bsize: usize = 4;
     let vs: Vec<i64> = (0..1337).collect();
-    let xs = Tensor::of_slice(&vs);
-    let ys = Tensor::of_slice(&vs.iter().map(|x| x * 2).collect::<Vec<_>>());
+    let xs = Tensor::from_slice(&vs);
+    let ys = Tensor::from_slice(&vs.iter().map(|x| x * 2).collect::<Vec<_>>());
     for (batch_xs, batch_ys) in data::Iter2::new(&xs, &ys, bsize as i64) {
         let xs = vec_i64_from(&batch_xs);
         let ys = vec_i64_from(&batch_ys);

--- a/tests/device_tests.rs
+++ b/tests/device_tests.rs
@@ -2,6 +2,6 @@ use tch::{Device, Tensor};
 
 #[test]
 fn tensor_device() {
-    let t = Tensor::of_slice(&[3, 1, 4]);
+    let t = Tensor::from_slice(&[3, 1, 4]);
     assert_eq!(t.device(), Device::Cpu)
 }

--- a/tests/display_tests.rs
+++ b/tests/display_tests.rs
@@ -23,10 +23,10 @@ fn display_scalar() {
 
 #[test]
 fn display_vector() {
-    let t = Tensor::of_slice::<i64>(&[]);
+    let t = Tensor::from_slice::<i64>(&[]);
     let s = format!("{t}");
     assert_eq!(&s, "[]\nTensor[[0], Int64]");
-    let t = Tensor::of_slice(&[0.1234567, 1.0, -1.2, 4.1, f64::NAN]);
+    let t = Tensor::from_slice(&[0.1234567, 1.0, -1.2, 4.1, f64::NAN]);
     let s = format!("{t}");
     assert_eq!(&s, "[ 0.1235,  1.0000, -1.2000,  4.1000,     NaN]\nTensor[[5], Double]");
     let t = Tensor::ones([50], kind::FLOAT_CPU) * 42;

--- a/tests/jit_tests.rs
+++ b/tests/jit_tests.rs
@@ -6,8 +6,8 @@ use test_utils::*;
 
 #[test]
 fn jit() {
-    let x = Tensor::of_slice(&[3, 1, 4, 1, 5]).to_kind(Kind::Float);
-    let y = Tensor::of_slice(&[7]).to_kind(Kind::Float);
+    let x = Tensor::from_slice(&[3, 1, 4, 1, 5]).to_kind(Kind::Float);
+    let y = Tensor::from_slice(&[7]).to_kind(Kind::Float);
     // The JIT module is created in create_jit_models.py
     let mod_ = tch::CModule::load("tests/foo.pt").unwrap();
     let result = mod_.forward_ts(&[&x, &y]).unwrap();
@@ -17,8 +17,8 @@ fn jit() {
 
 #[test]
 fn jit_data() {
-    let x = Tensor::of_slice(&[3, 1, 4, 1, 5]).to_kind(Kind::Float);
-    let y = Tensor::of_slice(&[7]).to_kind(Kind::Float);
+    let x = Tensor::from_slice(&[3, 1, 4, 1, 5]).to_kind(Kind::Float);
+    let y = Tensor::from_slice(&[7]).to_kind(Kind::Float);
     let mut file = std::fs::File::open("tests/foo.pt").unwrap();
     let mod_ = tch::CModule::load_data(&mut file).unwrap();
     let result = mod_.forward_ts(&[&x, &y]).unwrap();
@@ -62,7 +62,7 @@ fn jit2() {
 #[test]
 fn jit3() {
     let mod_ = tch::CModule::load("tests/foo3.pt").unwrap();
-    let xs = Tensor::of_slice(&[1.0, 2.0, 3.0, 4.0, 5.0]);
+    let xs = Tensor::from_slice(&[1.0, 2.0, 3.0, 4.0, 5.0]);
     let result = mod_.forward_ts(&[xs]).unwrap();
     assert_eq!(from::<f64>(&result), 120.0);
 }
@@ -119,12 +119,12 @@ fn jit5() {
 #[test]
 fn jit6() {
     let mod_ = tch::CModule::load("tests/foo6.pt").unwrap();
-    let xs = Tensor::of_slice(&[3.0, 4.0, 5.0]);
+    let xs = Tensor::from_slice(&[3.0, 4.0, 5.0]);
     let result = mod_.forward_is(&[IValue::Tensor(xs)]).unwrap();
 
     let obj = tch::jit::Object::try_from(result).unwrap();
     let result = obj.method_is::<IValue>("y", &[]).unwrap();
-    assert_eq!(result, IValue::Tensor(Tensor::of_slice(&[6.0, 8.0, 10.0])));
+    assert_eq!(result, IValue::Tensor(Tensor::from_slice(&[6.0, 8.0, 10.0])));
 }
 
 #[test]
@@ -144,8 +144,8 @@ fn create_traced() {
     let filename = std::env::temp_dir().join(format!("tch-modl-{}", std::process::id()));
     modl.save(&filename).unwrap();
     let modl = tch::CModule::load(&filename).unwrap();
-    let xs = Tensor::of_slice(&[1.0, 2.0, 3.0, 4.0, 5.0]);
-    let ys = Tensor::of_slice(&[41.0, 1335.0, std::f64::consts::PI - 3., 4.0, 5.0]);
+    let xs = Tensor::from_slice(&[1.0, 2.0, 3.0, 4.0, 5.0]);
+    let ys = Tensor::from_slice(&[41.0, 1335.0, std::f64::consts::PI - 3., 4.0, 5.0]);
     let result = modl.method_ts("MyFn", &[xs, ys]).unwrap();
     assert_eq!(
         Vec::<f64>::try_from(&result).unwrap(),
@@ -160,8 +160,8 @@ fn jit_double_free() {
     let input = mod_.method_is(
         "make_input_object",
         &[
-            &Tensor::of_slice(&[1_f32, 2_f32, 3_f32]).into(),
-            &Tensor::of_slice(&[4_f32, 5_f32, 6_f32]).into(),
+            &Tensor::from_slice(&[1_f32, 2_f32, 3_f32]).into(),
+            &Tensor::from_slice(&[4_f32, 5_f32, 6_f32]).into(),
         ],
     );
     let result = mod_.method_is("add_them", &[&input.unwrap()]);
@@ -177,10 +177,10 @@ fn jit_double_free() {
 fn specialized_dict() {
     let mod_ = tch::CModule::load("tests/foo8.pt").unwrap();
     let input = IValue::GenericDict(vec![
-        (IValue::String("bar".to_owned()), IValue::Tensor(Tensor::of_slice(&[1_f32, 7_f32]))),
+        (IValue::String("bar".to_owned()), IValue::Tensor(Tensor::from_slice(&[1_f32, 7_f32]))),
         (
             IValue::String("foo".to_owned()),
-            IValue::Tensor(Tensor::of_slice(&[1_f32, 2_f32, 3_f32])),
+            IValue::Tensor(Tensor::from_slice(&[1_f32, 2_f32, 3_f32])),
         ),
     ]);
     let result = mod_.method_is("generate", &[input]).unwrap();

--- a/tests/nn_tests.rs
+++ b/tests/nn_tests.rs
@@ -9,7 +9,7 @@ use test_utils::*;
 fn optimizer_test() {
     tch::manual_seed(42);
     // Create some linear data.
-    let xs = Tensor::of_slice(&(1..15).collect::<Vec<_>>()).to_kind(Kind::Float).view([-1, 1]);
+    let xs = Tensor::from_slice(&(1..15).collect::<Vec<_>>()).to_kind(Kind::Float).view([-1, 1]);
     let ys = &xs * 0.42 + 1.337;
 
     // Fit a linear model (with deterministic initialization) on the data.
@@ -181,7 +181,7 @@ fn group_norm_test() {
 fn layer_norm_parameters_test() {
     tch::manual_seed(42);
     // Create some linear data.
-    let xs = Tensor::of_slice(&[42.0, 42.0, 42.0, 24.0]).to_kind(Kind::Float).view([-1, 2]);
+    let xs = Tensor::from_slice(&[42.0, 42.0, 42.0, 24.0]).to_kind(Kind::Float).view([-1, 2]);
     let ys = &xs * 0.42 + 1.337;
 
     // Fit a layer normalization layer (with deterministic initialization) on the data.
@@ -299,7 +299,7 @@ fn embedding_test(embedding_config: nn::EmbeddingConfig) {
     } else {
         embedding_config.padding_idx
     };
-    let input = Tensor::of_slice(&[padding_idx]);
+    let input = Tensor::from_slice(&[padding_idx]);
     let output = embeddings.forward(&input);
     assert_eq!(output.size(), [1, output_dim]);
     assert_eq!(output.get(0), embeddings.ws.get(padding_idx));
@@ -349,15 +349,15 @@ fn linear() {
 
 #[test]
 fn pad() {
-    let xs = Tensor::of_slice(&[1., 2., 3.]);
+    let xs = Tensor::from_slice(&[1., 2., 3.]);
     let padded = nn::PaddingMode::Zeros.pad(&xs, &[1, 1]);
     assert_eq!(vec_f32_from(&padded), [0., 1., 2., 3., 0.]);
 
-    let xs = Tensor::of_slice(&[1., 2., 3.]).view([1, 3]);
+    let xs = Tensor::from_slice(&[1., 2., 3.]).view([1, 3]);
     let padded = nn::PaddingMode::Zeros.pad(&xs, &[1, 1]);
     assert_eq!(vec_f32_from(&padded.reshape(-1)), [0., 1., 2., 3., 0.]);
 
-    let xs = Tensor::of_slice(&[1., 2., 3., 4.]).view([1, 2, 2]);
+    let xs = Tensor::from_slice(&[1., 2., 3., 4.]).view([1, 2, 2]);
     let padded = nn::PaddingMode::Reflect.pad(&xs, &[1, 1, 1, 1]);
     assert_eq!(
         vec_f32_from(&padded.reshape(-1)),
@@ -387,7 +387,7 @@ fn apply_conv(xs: &Tensor, padding_mode: nn::PaddingMode) -> Tensor {
 
 #[test]
 fn conv() {
-    let xs = Tensor::of_slice(&[1f32, 2., 3., 4.]).view([1, 1, 2, 2]); // NCHW
+    let xs = Tensor::from_slice(&[1f32, 2., 3., 4.]).view([1, 1, 2, 2]); // NCHW
 
     let conved = apply_conv(&xs, nn::PaddingMode::Zeros);
     assert_eq!(vec_f32_from(&conved.reshape(-1)), &[10.0, 10.0, 10.0, 10.0]);

--- a/tests/serialization_tests.rs
+++ b/tests/serialization_tests.rs
@@ -33,7 +33,7 @@ impl Drop for TmpFile {
 fn save_and_load() {
     let tmp_file = TmpFile::create("save-and-load");
     let vec = [3.0, 1.0, 4.0, 1.0, 5.0].to_vec();
-    let t1 = Tensor::of_slice(&vec);
+    let t1 = Tensor::from_slice(&vec);
     t1.save(&tmp_file).unwrap();
     let t2 = Tensor::load(&tmp_file).unwrap();
     assert_eq!(vec_f64_from(&t2), vec)
@@ -43,7 +43,7 @@ fn save_and_load() {
 fn save_to_stream_and_load() {
     let tmp_file = TmpFile::create("write-stream");
     let vec = [3.0, 1.0, 4.0, 1.0, 5.0].to_vec();
-    let t1 = Tensor::of_slice(&vec);
+    let t1 = Tensor::from_slice(&vec);
     t1.save_to_stream(std::fs::File::create(&tmp_file).unwrap()).unwrap();
     let t2 = Tensor::load(&tmp_file).unwrap();
     assert_eq!(vec_f64_from(&t2), vec)
@@ -53,7 +53,7 @@ fn save_to_stream_and_load() {
 fn save_and_load_from_stream() {
     let tmp_file = TmpFile::create("read-stream");
     let vec = [3.0, 1.0, 4.0, 1.0, 5.0].to_vec();
-    let t1 = Tensor::of_slice(&vec);
+    let t1 = Tensor::from_slice(&vec);
     t1.save(&tmp_file).unwrap();
     let reader = std::io::BufReader::new(std::fs::File::open(&tmp_file).unwrap());
     let t2 = Tensor::load_from_stream(reader).unwrap();
@@ -63,8 +63,8 @@ fn save_and_load_from_stream() {
 #[test]
 fn save_and_load_multi() {
     let tmp_file = TmpFile::create("save-and-load-multi");
-    let pi = Tensor::of_slice(&[3.0, 1.0, 4.0, 1.0, 5.0]);
-    let e = Tensor::of_slice(&[2, 7, 1, 8, 2, 8, 1, 8, 2, 8, 4, 6]);
+    let pi = Tensor::from_slice(&[3.0, 1.0, 4.0, 1.0, 5.0]);
+    let e = Tensor::from_slice(&[2, 7, 1, 8, 2, 8, 1, 8, 2, 8, 4, 6]);
     Tensor::save_multi(&[(&"pi", &pi), (&"e", &e)], &tmp_file).unwrap();
     let named_tensors = Tensor::load_multi(&tmp_file).unwrap();
     assert_eq!(named_tensors.len(), 2);
@@ -76,8 +76,8 @@ fn save_and_load_multi() {
 #[test]
 fn save_to_stream_and_load_multi() {
     let tmp_file = TmpFile::create("save-to-stream-and-load-multi");
-    let pi = Tensor::of_slice(&[3.0, 1.0, 4.0, 1.0, 5.0]);
-    let e = Tensor::of_slice(&[2, 7, 1, 8, 2, 8, 1, 8, 2, 8, 4, 6]);
+    let pi = Tensor::from_slice(&[3.0, 1.0, 4.0, 1.0, 5.0]);
+    let e = Tensor::from_slice(&[2, 7, 1, 8, 2, 8, 1, 8, 2, 8, 4, 6]);
     Tensor::save_multi_to_stream(
         &[(&"pi", &pi), (&"e", &e)],
         std::fs::File::create(&tmp_file).unwrap(),
@@ -93,8 +93,8 @@ fn save_to_stream_and_load_multi() {
 #[test]
 fn save_and_load_multi_from_stream() {
     let tmp_file = TmpFile::create("save-and-load-multi-from-stream");
-    let pi = Tensor::of_slice(&[3.0, 1.0, 4.0, 1.0, 5.0]);
-    let e = Tensor::of_slice(&[2, 7, 1, 8, 2, 8, 1, 8, 2, 8, 4, 6]);
+    let pi = Tensor::from_slice(&[3.0, 1.0, 4.0, 1.0, 5.0]);
+    let e = Tensor::from_slice(&[2, 7, 1, 8, 2, 8, 1, 8, 2, 8, 4, 6]);
     Tensor::save_multi(&[(&"pi", &pi), (&"e", &e)], &tmp_file).unwrap();
     let reader = std::io::BufReader::new(std::fs::File::open(&tmp_file).unwrap());
     let named_tensors = Tensor::load_multi_from_stream(reader).unwrap();
@@ -107,8 +107,8 @@ fn save_and_load_multi_from_stream() {
 #[test]
 fn save_and_load_npz() {
     let tmp_file = TmpFile::create("save-and-load-npz");
-    let pi = Tensor::of_slice(&[3.0, 1.0, 4.0, 1.0, 5.0]);
-    let e = Tensor::of_slice(&[2, 7, 1, 8, 2, 8, 1, 8, 2, 8, 4, 6]);
+    let pi = Tensor::from_slice(&[3.0, 1.0, 4.0, 1.0, 5.0]);
+    let e = Tensor::from_slice(&[2, 7, 1, 8, 2, 8, 1, 8, 2, 8, 4, 6]);
     Tensor::write_npz(&[(&"pi", &pi), (&"e", &e)], &tmp_file).unwrap();
     let named_tensors = Tensor::read_npz(&tmp_file).unwrap();
     assert_eq!(named_tensors.len(), 2);
@@ -120,9 +120,9 @@ fn save_and_load_npz() {
 #[test]
 fn save_and_load_npz_half() {
     let tmp_file = TmpFile::create("save-and-load-npz-half");
-    let pi = Tensor::of_slice(&[3.0, 1.0, 4.0, 1.0, 5.0]).to_dtype(Kind::Half, true, false);
+    let pi = Tensor::from_slice(&[3.0, 1.0, 4.0, 1.0, 5.0]).to_dtype(Kind::Half, true, false);
     let e =
-        Tensor::of_slice(&[2, 7, 1, 8, 2, 8, 1, 8, 2, 8, 4, 6]).to_dtype(Kind::Half, true, false);
+        Tensor::from_slice(&[2, 7, 1, 8, 2, 8, 1, 8, 2, 8, 4, 6]).to_dtype(Kind::Half, true, false);
     Tensor::write_npz(&[(&"pi", &pi), (&"e", &e)], &tmp_file).unwrap();
     let named_tensors = Tensor::read_npz(&tmp_file).unwrap();
     assert_eq!(named_tensors.len(), 2);
@@ -134,9 +134,9 @@ fn save_and_load_npz_half() {
 #[test]
 fn save_and_load_npz_byte() {
     let tmp_file = TmpFile::create("save-and-load-npz-byte");
-    let pi = Tensor::of_slice(&[3.0, 1.0, 4.0, 1.0, 5.0]).to_dtype(Kind::Int8, true, false);
+    let pi = Tensor::from_slice(&[3.0, 1.0, 4.0, 1.0, 5.0]).to_dtype(Kind::Int8, true, false);
     let e =
-        Tensor::of_slice(&[2, 7, 1, 8, 2, 8, 1, 8, 2, 8, 4, 6]).to_dtype(Kind::Int8, true, false);
+        Tensor::from_slice(&[2, 7, 1, 8, 2, 8, 1, 8, 2, 8, 4, 6]).to_dtype(Kind::Int8, true, false);
     Tensor::write_npz(&[(&"pi", &pi), (&"e", &e)], &tmp_file).unwrap();
     let named_tensors = Tensor::read_npz(&tmp_file).unwrap();
     assert_eq!(named_tensors.len(), 2);
@@ -148,7 +148,7 @@ fn save_and_load_npz_byte() {
 #[test]
 fn save_and_load_npy() {
     let tmp_file = TmpFile::create("save-and-load-npy");
-    let pi = Tensor::of_slice(&[3.0, 1.0, 4.0, 1.0, 5.0, 9.0]);
+    let pi = Tensor::from_slice(&[3.0, 1.0, 4.0, 1.0, 5.0, 9.0]);
     pi.write_npy(&tmp_file).unwrap();
     let pi = Tensor::read_npy(&tmp_file).unwrap();
     assert_eq!(vec_f64_from(&pi), [3.0, 1.0, 4.0, 1.0, 5.0, 9.0]);
@@ -162,8 +162,8 @@ fn save_and_load_npy() {
 #[test]
 fn save_and_load_safetensors() {
     let tmp_file = TmpFile::create("save-and-load-safetensors");
-    let pi = Tensor::of_slice(&[3.0, 1.0, 4.0, 1.0, 5.0]);
-    let e = Tensor::of_slice(&[2, 7, 1, 8, 2, 8, 1, 8, 2, 8, 4, 6]);
+    let pi = Tensor::from_slice(&[3.0, 1.0, 4.0, 1.0, 5.0]);
+    let e = Tensor::from_slice(&[2, 7, 1, 8, 2, 8, 1, 8, 2, 8, 4, 6]);
     Tensor::write_safetensors(&[(&"pi", &pi), (&"e", &e)], &tmp_file).unwrap();
     let named_tensors = Tensor::read_safetensors(&tmp_file).unwrap();
     assert_eq!(named_tensors.len(), 2);
@@ -179,9 +179,9 @@ fn save_and_load_safetensors() {
 #[test]
 fn save_and_load_safetensors_half() {
     let tmp_file = TmpFile::create("save-and-load-safetensors-half");
-    let pi = Tensor::of_slice(&[3.0, 1.0, 4.0, 1.0, 5.0]).to_dtype(Kind::Half, true, false);
+    let pi = Tensor::from_slice(&[3.0, 1.0, 4.0, 1.0, 5.0]).to_dtype(Kind::Half, true, false);
     let e =
-        Tensor::of_slice(&[2, 7, 1, 8, 2, 8, 1, 8, 2, 8, 4, 6]).to_dtype(Kind::Half, true, false);
+        Tensor::from_slice(&[2, 7, 1, 8, 2, 8, 1, 8, 2, 8, 4, 6]).to_dtype(Kind::Half, true, false);
     Tensor::write_safetensors(&[(&"pi", &pi), (&"e", &e)], &tmp_file).unwrap();
     let named_tensors = Tensor::read_safetensors(&tmp_file).unwrap();
     assert_eq!(named_tensors.len(), 2);

--- a/tests/tensor_indexing.rs
+++ b/tests/tensor_indexing.rs
@@ -124,7 +124,7 @@ fn complex_index() {
 #[test]
 fn index_3d() {
     let values: Vec<i64> = (0..24).collect();
-    let tensor = tch::Tensor::of_slice(&values).view((2, 3, 4));
+    let tensor = tch::Tensor::from_slice(&values).view((2, 3, 4));
     assert_eq!(vec_i64_from(&tensor.i((0, 0, 0))), &[0]);
     assert_eq!(vec_i64_from(&tensor.i((1, 0, 0))), &[12]);
     assert_eq!(vec_i64_from(&tensor.i((0..2, 0, 0))), &[0, 12]);
@@ -133,8 +133,8 @@ fn index_3d() {
 #[test]
 fn tensor_index() {
     let t = Tensor::arange(6, (Kind::Int64, Device::Cpu)).view((2, 3));
-    let rows_select = Tensor::of_slice(&[0i64, 1, 0]);
-    let column_select = Tensor::of_slice(&[1i64, 2, 2]);
+    let rows_select = Tensor::from_slice(&[0i64, 1, 0]);
+    let column_select = Tensor::from_slice(&[1i64, 2, 2]);
 
     let selected = t.index(&[Some(rows_select), Some(column_select)]);
     assert_eq!(selected.size(), &[3]);
@@ -148,8 +148,8 @@ fn tensor_index2() {
     let selected = t.index(&[
         Some(Tensor::from(0i64)),
         Some(Tensor::from(1i64)),
-        Some(Tensor::of_slice(&[1i64, 2, 3])),
-        Some(Tensor::of_slice(&[5i64, 6, 7])),
+        Some(Tensor::from_slice(&[1i64, 2, 3])),
+        Some(Tensor::from_slice(&[5i64, 6, 7])),
     ]);
     assert_eq!(selected.size(), &[3]);
     // 115 = 0 * 200 + 1 * 100 + 1 * 10 + 5
@@ -162,8 +162,8 @@ fn tensor_index2() {
 fn tensor_multi_index() {
     let t = Tensor::arange(6, (Kind::Int64, Device::Cpu)).view((2, 3));
 
-    let select_1 = Tensor::of_slice(&[0i64, 1, 0]);
-    let select_2 = Tensor::of_slice(&[1i64, 0, 0]);
+    let select_1 = Tensor::from_slice(&[0i64, 1, 0]);
+    let select_2 = Tensor::from_slice(&[1i64, 0, 0]);
     let select_final = Tensor::stack(&[select_1, select_2], 0);
     assert_eq!(select_final.size(), &[2, 3]);
 
@@ -176,9 +176,9 @@ fn tensor_multi_index() {
 #[test]
 fn tensor_put() {
     let t = Tensor::arange(6, (Kind::Int64, Device::Cpu)).view((2, 3));
-    let rows_select = Tensor::of_slice(&[0i64, 1, 0]);
-    let column_select = Tensor::of_slice(&[1i64, 2, 2]);
-    let values = Tensor::of_slice(&[10i64, 12, 24]);
+    let rows_select = Tensor::from_slice(&[0i64, 1, 0]);
+    let column_select = Tensor::from_slice(&[1i64, 2, 2]);
+    let values = Tensor::from_slice(&[10i64, 12, 24]);
 
     let updated = t.index_put(&[Some(rows_select), Some(column_select)], &values, false);
     assert_eq!(vec_i64_from(&updated), &[0i64, 10, 24, 3, 4, 12]); // after flattening
@@ -186,13 +186,13 @@ fn tensor_put() {
 
 #[test]
 fn indexing_doc() {
-    let tensor = Tensor::of_slice(&[1, 2, 3, 4, 5, 6]).view((2, 3));
+    let tensor = Tensor::from_slice(&[1, 2, 3, 4, 5, 6]).view((2, 3));
     let t = tensor.i(1);
     assert_eq!(vec_i64_from(&t), [4, 5, 6]);
     let t = tensor.i((.., -2));
     assert_eq!(vec_i64_from(&t), [2, 5]);
 
-    let tensor = Tensor::of_slice(&[1, 2, 3, 4, 5, 6]).view((2, 3));
+    let tensor = Tensor::from_slice(&[1, 2, 3, 4, 5, 6]).view((2, 3));
     let t = tensor.i((.., 1..));
     assert_eq!(t.size(), [2, 2]);
     assert_eq!(vec_i64_from(&t.contiguous().view(-1)), [2, 3, 5, 6]);
@@ -206,7 +206,7 @@ fn indexing_doc() {
     assert_eq!(t.size(), [2, 2]);
     assert_eq!(vec_i64_from(&t.contiguous().view(-1)), [2, 3, 5, 6]);
 
-    let tensor = Tensor::of_slice(&[1, 2, 3, 4, 5, 6]).view((2, 3));
+    let tensor = Tensor::from_slice(&[1, 2, 3, 4, 5, 6]).view((2, 3));
     let t = tensor.i((NewAxis,));
     assert_eq!(t.size(), &[1, 2, 3]);
     let t = tensor.i((.., .., NewAxis));

--- a/tests/tensor_tests.rs
+++ b/tests/tensor_tests.rs
@@ -10,14 +10,14 @@ use test_utils::*;
 #[test]
 #[cfg(feature = "cuda-tests")]
 fn amp_non_finite_check_and_unscale() {
-    let mut u = Tensor::of_slice(&[10f32, 20f32]).to_device(Device::Cuda(0));
-    let mut found_inf = Tensor::of_slice(&[0f32]).to_device(Device::Cuda(0));
-    let inv_scale = Tensor::of_slice(&[0.1f32]).to_device(Device::Cuda(0));
+    let mut u = Tensor::from_slice(&[10f32, 20f32]).to_device(Device::Cuda(0));
+    let mut found_inf = Tensor::from_slice(&[0f32]).to_device(Device::Cuda(0));
+    let inv_scale = Tensor::from_slice(&[0.1f32]).to_device(Device::Cuda(0));
     u.internal_amp_non_finite_check_and_unscale(&mut found_inf, &inv_scale);
     assert_eq!(vec_f32_from(&u), &[1f32, 2f32]);
     assert_eq!(vec_f32_from(&found_inf), [0f32]);
 
-    let mut v = Tensor::of_slice(&[1f32, f32::INFINITY]).to_device(Device::Cuda(0));
+    let mut v = Tensor::from_slice(&[1f32, f32::INFINITY]).to_device(Device::Cuda(0));
     v.internal_amp_non_finite_check_and_unscale(&mut found_inf, &inv_scale);
     assert_eq!(vec_f32_from(&v), &[0.1, f32::INFINITY]);
     assert_eq!(vec_f32_from(&found_inf), [1f32]);
@@ -30,7 +30,7 @@ fn amp_non_finite_check_and_unscale() {
 
 #[test]
 fn assign_ops() {
-    let mut t = Tensor::of_slice(&[3, 1, 4, 1, 5]);
+    let mut t = Tensor::from_slice(&[3, 1, 4, 1, 5]);
     t += 1;
     t *= 2;
     t -= 1;
@@ -39,7 +39,7 @@ fn assign_ops() {
 
 #[test]
 fn constant_ops() {
-    let mut t = Tensor::of_slice(&[7i64, 3, 9, 3, 11]);
+    let mut t = Tensor::from_slice(&[7i64, 3, 9, 3, 11]);
     t = -t;
     assert_eq!(vec_i64_from(&t), [-7, -3, -9, -3, -11]);
     t = 1 - t;
@@ -47,17 +47,17 @@ fn constant_ops() {
     t = 2 * t;
     assert_eq!(vec_i64_from(&t), [16, 8, 20, 8, 24]);
 
-    let mut t = Tensor::of_slice(&[0.2f64, 0.1]);
+    let mut t = Tensor::from_slice(&[0.2f64, 0.1]);
     t = 2 / t;
     assert_eq!(vec_f64_from(&t), [10.0, 20.0]);
 }
 
 #[test]
 fn iter() {
-    let t = Tensor::of_slice(&[7i64, 3, 9, 3, 11]);
+    let t = Tensor::from_slice(&[7i64, 3, 9, 3, 11]);
     let v = t.iter::<i64>().unwrap().collect::<Vec<_>>();
     assert_eq!(v, [7, 3, 9, 3, 11]);
-    let t = Tensor::of_slice(&[std::f64::consts::PI, 15.926, 5.3589, 79.0]);
+    let t = Tensor::from_slice(&[std::f64::consts::PI, 15.926, 5.3589, 79.0]);
     let v = t.iter::<f64>().unwrap().collect::<Vec<_>>();
     assert_eq!(v, [std::f64::consts::PI, 15.926, 5.3589, 79.0]);
 }
@@ -65,7 +65,7 @@ fn iter() {
 #[test]
 fn array_conversion() {
     let vec: Vec<_> = (0..6).map(|x| (x * x) as f64).collect();
-    let t = Tensor::of_slice(&vec);
+    let t = Tensor::from_slice(&vec);
     assert_eq!(vec_f64_from(&t), [0.0, 1.0, 4.0, 9.0, 16.0, 25.0]);
     let t = t.view([3, 2]);
     assert_eq!(from::<Vec::<Vec<f64>>>(&t), [[0.0, 1.0], [4.0, 9.0], [16.0, 25.0]]);
@@ -75,7 +75,7 @@ fn array_conversion() {
 
 #[test]
 fn binary_ops() {
-    let t = Tensor::of_slice(&[3.0, 1.0, 4.0, 1.0, 5.0]);
+    let t = Tensor::from_slice(&[3.0, 1.0, 4.0, 1.0, 5.0]);
     let t = (&t * &t) + &t - 1.5;
     assert_eq!(vec_f64_from(&t), [10.5, 0.5, 18.5, 0.5, 28.5]);
 }
@@ -114,17 +114,17 @@ fn grad_without_requires() {
 
 #[test]
 fn cat_and_stack() {
-    let t = Tensor::of_slice(&[13.0, 37.0]);
+    let t = Tensor::from_slice(&[13.0, 37.0]);
     let t = Tensor::cat(&[&t, &t, &t], 0);
     assert_eq!(t.size(), [6]);
     assert_eq!(vec_f64_from(&t), [13.0, 37.0, 13.0, 37.0, 13.0, 37.0]);
 
-    let t = Tensor::of_slice(&[13.0, 37.0]);
+    let t = Tensor::from_slice(&[13.0, 37.0]);
     let t = Tensor::stack(&[&t, &t, &t], 0);
     assert_eq!(t.size(), [3, 2]);
     assert_eq!(vec_f64_from(&t), [13.0, 37.0, 13.0, 37.0, 13.0, 37.0]);
 
-    let t = Tensor::of_slice(&[13.0, 37.0]);
+    let t = Tensor::from_slice(&[13.0, 37.0]);
     let t = Tensor::stack(&[&t, &t, &t], 1);
     assert_eq!(t.size(), [2, 3]);
     assert_eq!(vec_f64_from(&t), [13.0, 13.0, 13.0, 37.0, 37.0, 37.0]);
@@ -132,7 +132,7 @@ fn cat_and_stack() {
 
 #[test]
 fn onehot() {
-    let xs = Tensor::of_slice(&[0, 1, 2, 3]);
+    let xs = Tensor::from_slice(&[0, 1, 2, 3]);
     let onehot = xs.onehot(4);
     assert_eq!(
         vec_f64_from(&onehot),
@@ -145,14 +145,14 @@ fn onehot() {
 fn fallible() {
     // Try to compare two tensors with incompatible dimensions and check that this returns an
     // error.
-    let xs = Tensor::of_slice(&[0, 1, 2, 3]);
-    let ys = Tensor::of_slice(&[0, 1, 2, 3, 4]);
+    let xs = Tensor::from_slice(&[0, 1, 2, 3]);
+    let ys = Tensor::from_slice(&[0, 1, 2, 3, 4]);
     assert!(xs.f_eq_tensor(&ys).is_err())
 }
 
 #[test]
 fn chunk() {
-    let xs = Tensor::of_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    let xs = Tensor::from_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
     let tensors = xs.chunk(3, 0);
     assert_eq!(tensors.len(), 3);
     assert_eq!(vec_i64_from(&tensors[0]), vec![0, 1, 2, 3]);
@@ -162,7 +162,7 @@ fn chunk() {
 
 #[test]
 fn broadcast() {
-    let xs = Tensor::of_slice(&[4, 5, 3]);
+    let xs = Tensor::from_slice(&[4, 5, 3]);
     let ys = Tensor::from(42);
     let tensors = Tensor::broadcast_tensors(&[xs, ys]);
     assert_eq!(tensors.len(), 2);
@@ -172,13 +172,13 @@ fn broadcast() {
 
 #[test]
 fn eq() {
-    let t = Tensor::of_slice(&[3, 1, 4, 1, 5]);
+    let t = Tensor::from_slice(&[3, 1, 4, 1, 5]);
     let u = &t + 1 - 1;
     assert_eq!(t, u);
     assert!(t == u);
     assert!(t != u - 1);
 
-    let t = Tensor::of_slice(&[std::f64::consts::PI]);
+    let t = Tensor::from_slice(&[std::f64::consts::PI]);
     let u = Tensor::from(std::f64::consts::PI);
     // The tensor shape is important for equality.
     assert!(t != u);
@@ -201,14 +201,14 @@ fn values_at_index() {
 
 #[test]
 fn into_ndarray_f64() {
-    let tensor = Tensor::of_slice(&[1., 2., 3., 4.]);
+    let tensor = Tensor::from_slice(&[1., 2., 3., 4.]);
     let nd: ndarray::ArrayD<f64> = (&tensor).try_into().unwrap();
     assert_eq!(vec_f64_from(&tensor).as_slice(), nd.as_slice().unwrap());
 }
 
 #[test]
 fn into_ndarray_i64() {
-    let tensor = Tensor::of_slice(&[1, 2, 3, 4]);
+    let tensor = Tensor::from_slice(&[1, 2, 3, 4]);
     let nd: ndarray::ArrayD<i64> = (&tensor).try_into().unwrap();
     assert_eq!(vec_i64_from(&tensor).as_slice(), nd.as_slice().unwrap());
 }
@@ -297,19 +297,19 @@ fn test_device() {
 
 #[test]
 fn where_() {
-    let t1 = Tensor::of_slice(&[3, 1, 4, 1, 5, 9]);
-    let t2 = Tensor::of_slice(&[2, 7, 1, 8, 2, 8]);
+    let t1 = Tensor::from_slice(&[3, 1, 4, 1, 5, 9]);
+    let t2 = Tensor::from_slice(&[2, 7, 1, 8, 2, 8]);
     let t = t1.where_self(&t1.lt(4), &t2);
     assert_eq!(vec_i64_from(&t), [3, 1, 1, 1, 2, 8]);
 }
 
 #[test]
 fn bool_tensor() {
-    let t1 = Tensor::of_slice(&[true, true, false]);
+    let t1 = Tensor::from_slice(&[true, true, false]);
     assert_eq!(vec_i64_from(&t1), [1, 1, 0]);
     assert_eq!(vec_bool_from(&t1), [true, true, false]);
-    let t1 = Tensor::of_slice(&[0, 1, 0]).to_kind(tch::Kind::Bool);
-    let t2 = Tensor::of_slice(&[1, 1, 1]).to_kind(tch::Kind::Bool);
+    let t1 = Tensor::from_slice(&[0, 1, 0]).to_kind(tch::Kind::Bool);
+    let t2 = Tensor::from_slice(&[1, 1, 1]).to_kind(tch::Kind::Bool);
     let t1_any = t1.any();
     let t2_any = t2.any();
     let t1_all = t1.all();
@@ -340,18 +340,18 @@ fn mkldnn() {
 
 #[test]
 fn sparse() {
-    let t = Tensor::of_slice(&[1, 2, 3]);
+    let t = Tensor::from_slice(&[1, 2, 3]);
     assert!(!t.is_sparse());
 }
 
 #[test]
 fn einsum() {
     // Element-wise squaring of a vector.
-    let t = Tensor::of_slice(&[1.0, 2.0, 3.0]);
+    let t = Tensor::from_slice(&[1.0, 2.0, 3.0]);
     let t = Tensor::einsum("i, i -> i", &[&t, &t], None::<i64>);
     assert_eq!(vec_f64_from(&t), [1.0, 4.0, 9.0]);
     // Matrix transpose
-    let t = Tensor::of_slice(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).reshape([2, 3]);
+    let t = Tensor::from_slice(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).reshape([2, 3]);
     let t = Tensor::einsum("ij -> ji", &[t], None::<i64>);
     assert_eq!(vec_f64_from(&t), [1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
     // Sum all elements
@@ -361,13 +361,13 @@ fn einsum() {
 
 #[test]
 fn vec2() {
-    let tensor = Tensor::of_slice(&[1., 2., 3., 4., 5., 6.]).reshape([2, 3]);
+    let tensor = Tensor::from_slice(&[1., 2., 3., 4., 5., 6.]).reshape([2, 3]);
     assert_eq!(Vec::<Vec::<f64>>::try_from(tensor).unwrap(), [[1., 2., 3.], [4., 5., 6.]])
 }
 
 #[test]
 fn upsample1d() {
-    let tensor = Tensor::of_slice(&[1., 2., 3., 4., 5., 6.]).reshape([2, 3, 1]);
+    let tensor = Tensor::from_slice(&[1., 2., 3., 4., 5., 6.]).reshape([2, 3, 1]);
     let up1 = tensor.upsample_linear1d([2], false, 1.);
     assert_eq!(
         // Exclude the last element because of some numerical instability.
@@ -380,7 +380,7 @@ fn upsample1d() {
 
 #[test]
 fn argmax() {
-    let tensor = Tensor::of_slice(&[7., 2., 3., 4., 5., 6.]).reshape([2, 3]);
+    let tensor = Tensor::from_slice(&[7., 2., 3., 4., 5., 6.]).reshape([2, 3]);
     let argmax = tensor.argmax(None, false);
     assert_eq!(vec_i64_from(&argmax), [0],);
     let argmax = tensor.argmax(0, false);
@@ -415,14 +415,14 @@ fn strides() {
 #[test]
 fn nested_tensor() {
     let vec: Vec<Vec<i32>> = vec![vec![1, 2], vec![1, 2], vec![4, 5]];
-    let t = Tensor::of_slice2(&vec);
+    let t = Tensor::from_slice2(&vec);
     assert_eq!(t.size(), [3, 2]);
     assert_eq!(vec_i32_from(&t.view([-1])), [1, 2, 1, 2, 4, 5]);
 }
 
 #[test]
 fn quantized() {
-    let t = Tensor::of_slice(&[-1f32, 0., 1., 2., 120., 0.42]);
+    let t = Tensor::from_slice(&[-1f32, 0., 1., 2., 120., 0.42]);
     let t = t.quantize_per_tensor(0.1, 10, tch::Kind::QUInt8);
     let t = t.dequantize();
     assert_eq!(vec_f32_from(&t), [-1f32, 0., 1., 2., 24.5, 0.4]);
@@ -431,18 +431,18 @@ fn quantized() {
 #[test]
 fn nll_loss() {
     let input = Tensor::randn([3, 5], (tch::Kind::Float, Device::Cpu)).set_requires_grad(true);
-    let target = Tensor::of_slice(&[1i64, 0, 4]);
+    let target = Tensor::from_slice(&[1i64, 0, 4]);
     let output = input.nll_loss(&target);
     output.backward();
 
-    let weights = Tensor::of_slice(&[1f32, 2.0, 2.0, 1.0, 1.0]);
+    let weights = Tensor::from_slice(&[1f32, 2.0, 2.0, 1.0, 1.0]);
     // This used to segfault, see https://github.com/LaurentMazare/tch-rs/issues/366
     let _output = input.g_nll_loss(&target, Some(weights), tch::Reduction::Mean, -100);
 }
 
 #[test]
 fn allclose() {
-    let t = Tensor::of_slice(&[-1f32, 0., 1., 2., 120., 0.42]);
+    let t = Tensor::from_slice(&[-1f32, 0., 1., 2., 120., 0.42]);
     let t = t.quantize_per_tensor(0.1, 10, tch::Kind::QUInt8);
     let t = t.dequantize();
     assert!(!t.allclose(&(&t + 0.1), 1e-5, 1e-8, false));
@@ -451,38 +451,38 @@ fn allclose() {
 
 #[test]
 fn set_data() {
-    let mut t = Tensor::of_slice(&[-1f32, 0., 1., 2., 120., 0.42]);
+    let mut t = Tensor::from_slice(&[-1f32, 0., 1., 2., 120., 0.42]);
     t.set_data(&t.to_kind(tch::Kind::BFloat16));
     assert_eq!(t.kind(), tch::Kind::BFloat16);
 }
 
 #[test]
 fn convert_vec() {
-    let t_1d = Tensor::of_slice(&[0, 1, 2, 3, 4, 5]);
+    let t_1d = Tensor::from_slice(&[0, 1, 2, 3, 4, 5]);
     let vec: Vec<i64> = Vec::try_from(t_1d).unwrap();
     assert_eq!(vec, vec![0, 1, 2, 3, 4, 5]);
 
-    let t_2d = Tensor::of_slice(&[0, 1, 2, 3, 4, 5]).view((2, 3));
+    let t_2d = Tensor::from_slice(&[0, 1, 2, 3, 4, 5]).view((2, 3));
     let vec: Result<Vec<i64>, TchError> = Vec::try_from(t_2d);
     assert!(matches!(vec, Err(TchError::Convert(msg)) if msg==
              "Attempting to convert a Tensor with 2 dimensions to flat vector"));
 
-    let t_2d = Tensor::of_slice(&[0, 1, 2, 3, 4, 5]).view((2, 3));
+    let t_2d = Tensor::from_slice(&[0, 1, 2, 3, 4, 5]).view((2, 3));
     let vec: Vec<Vec<i64>> = Vec::try_from(t_2d).unwrap();
     assert_eq!(vec, vec![vec![0, 1, 2], vec![3, 4, 5]]);
 }
 
 #[test]
 fn convert_ndarray() {
-    let t_1d = Tensor::of_slice(&[0, 1, 2, 3, 4, 5]);
+    let t_1d = Tensor::from_slice(&[0, 1, 2, 3, 4, 5]);
     let array_1d: ndarray::ArrayD<i64> = t_1d.as_ref().try_into().unwrap();
     assert_eq!(array_1d.as_slice(), ndarray::array![0, 1, 2, 3, 4, 5].as_slice());
 
-    let t_2d = Tensor::of_slice(&[0, 1, 2, 3, 4, 5]).view((2, 3));
+    let t_2d = Tensor::from_slice(&[0, 1, 2, 3, 4, 5]).view((2, 3));
     let array_2d: ndarray::ArrayD<i64> = t_2d.as_ref().try_into().unwrap();
     assert_eq!(array_2d.as_slice(), ndarray::array![[0, 1, 2], [3, 4, 5]].as_slice());
 
-    let t_3d = Tensor::of_slice(&[0, 1, 2, 3, 4, 5, 6, 7]).view((2, 2, 2));
+    let t_3d = Tensor::from_slice(&[0, 1, 2, 3, 4, 5, 6, 7]).view((2, 2, 2));
     let array_3d: ndarray::ArrayD<i64> = t_3d.as_ref().try_into().unwrap();
     assert_eq!(array_3d.as_slice(), ndarray::array![[[0, 1], [2, 3]], [[4, 5], [6, 7]]].as_slice());
 }

--- a/torch-sys/Cargo.toml
+++ b/torch-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "torch-sys"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Laurent Mazare <lmazare@gmail.com>"]
 edition = "2021"
 build = "build.rs"


### PR DESCRIPTION
The goal is to be closer to the rust best practices, see #537.
This is a breaking change for a lot of code as `of_slice` got renamed to `from_slice`.