### PR TITLE
No download by default

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -37,7 +37,7 @@ jobs:
           override: true
       - uses: actions-rs/cargo@v1
         with:
-          command: test
+          command: test --features download-libtorch
 
   fmt:
     name: Rustfmt

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -37,7 +37,8 @@ jobs:
           override: true
       - uses: actions-rs/cargo@v1
         with:
-          command: test --features download-libtorch
+          command: test
+          args: --features download-libtorch
 
   fmt:
     name: Rustfmt

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
+          args: --features download-libtorch
 
   test:
     name: Test Suite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v0.13.0 - unreleased yet
 ### Added
+- Make the libtorch download opt-in rather than a default behavior. The libtorch
+  library download can still be triggered by enabling the `download-libtorch`
+  feature, [707](https://github.com/LaurentMazare/tch-rs/pull/707).
 - Rename the `of_...` conversion functions to `from_...` so as to be closer to
   the Rust best practices,
   [706](https://github.com/LaurentMazare/tch-rs/pull/706). This is a breaking

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,9 @@ anyhow = "1"
 members = ["torch-sys", "examples/python-extension"]
 
 [features]
-default = ["torch-sys/download-libtorch"]
+download-libtorch = ["torch-sys/download-libtorch"]
 python-extension = ["torch-sys/python-extension"]
-rl_python = ["cpython"]
+rl-python = ["cpython"]
 doc-only = ["torch-sys/doc-only"]
 cuda-tests = []
 
@@ -49,7 +49,7 @@ features = [ "doc-only" ]
 
 [[example]]
 name = "reinforcement-learning"
-required-features = ["rl_python"]
+required-features = ["rl-python"]
 
 [[example]]
 name = "stable-diffusion"

--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ your system. You can either:
 - Install libtorch manually and let the build script know about it via the `LIBTORCH` environment variable.
 - Use a Python PyTorch install, to do this set `LIBTORCH_USE_PYTORCH=1`.
 - When a system-wide libtorch can't be found and `LIBTORCH` is not set, the
-  build script will download a pre-built binary version of libtorch. By default
-  a CPU version is used. The `TORCH_CUDA_VERSION` environment variable can be
-  set to `cu117` in order to get a pre-built binary using CUDA 11.7.
+  build script can download a pre-built binary version of libtorch by using
+  the `download-libtorch` feature. By default a CPU version is used. The
+  `TORCH_CUDA_VERSION` environment variable can be set to `cu117` in order to
+  get a pre-built binary using CUDA 11.7.
 
 ### System-wide Libtorch
 

--- a/torch-sys/build.rs
+++ b/torch-sys/build.rs
@@ -27,6 +27,16 @@ import sysconfig
 print('PYTHON_INCLUDE:', sysconfig.get_path('include'))
 ";
 
+const NO_DOWNLOAD_ERROR_MESSAGE: &str = r"
+Cannot find a libtorch install, you can either:
+- Install libtorch manually and set the LIBTORCH environment variable to appropriate path.
+- Use a system wide install in /usr/lib/libtorch.so.
+- Use a Python environment with PyTorch installed by setting LIBTORCH_USE_PYTORCH=1
+
+See the readme for more details:
+https://github.com/LaurentMazare/tch-rs/blob/main/README.md
+";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Os {
     Linux,
@@ -233,6 +243,10 @@ impl SystemInfo {
         } else if let Some(pathbuf) = Self::check_system_location(os) {
             Ok(pathbuf)
         } else {
+            if !cfg!(feature = "download-libtorch") {
+                anyhow::bail!(NO_DOWNLOAD_ERROR_MESSAGE)
+            }
+
             let device = match env_var_rerun("TORCH_CUDA_VERSION") {
                 Ok(cuda_env) => match os {
                     Os::Linux | Os::Windows => cuda_env


### PR DESCRIPTION
When the build script cannot locate a proper libtorch install, it defaults to downloading it from the main PyTorch website. One drawback is that this happens silently so may well happen when rust-analyzer starts etc.
Instead this turns the libtorch download to an opt-in feature.

Similar to #458 but adapted to the latest build script (that can use a PyTorch Python install), provide some detailed error message, and fixes the CI.