### PR TITLE
Add the Vulkan device.

### DIFF
--- a/examples/basics.rs
+++ b/examples/basics.rs
@@ -30,6 +30,7 @@ fn main() {
     println!("{:?} {}", t.size(), t.double_value(&[1]));
     grad_example();
     println!("has_mps: {}", tch::utils::has_mps());
+    println!("has_vulkan: {}", tch::utils::has_vulkan());
     println!("version_cudnn: {}", tch::utils::version_cudnn());
     println!("version_cudart: {}", tch::utils::version_cudart());
 }

--- a/src/wrappers/device.rs
+++ b/src/wrappers/device.rs
@@ -9,6 +9,8 @@ pub enum Device {
     Cuda(usize),
     /// The main MPS device.
     Mps,
+    /// The main Vulkan device.
+    Vulkan,
 }
 
 /// Cuda related helper functions.
@@ -86,6 +88,7 @@ impl Device {
             Device::Cpu => -1,
             Device::Cuda(device_index) => device_index as libc::c_int,
             Device::Mps => -2,
+            Device::Vulkan => -3,
         }
     }
 
@@ -93,6 +96,7 @@ impl Device {
         match v {
             -1 => Device::Cpu,
             -2 => Device::Mps,
+            -3 => Device::Vulkan,
             index if index >= 0 => Device::Cuda(index as usize),
             _ => panic!("unexpected device {v}"),
         }
@@ -110,8 +114,7 @@ impl Device {
     pub fn is_cuda(self) -> bool {
         match self {
             Device::Cuda(_) => true,
-            Device::Cpu => false,
-            Device::Mps => false,
+            Device::Cpu | Device::Mps | Device::Vulkan => false,
         }
     }
 }

--- a/src/wrappers/utils.rs
+++ b/src/wrappers/utils.rs
@@ -130,6 +130,13 @@ pub fn version_cudart() -> i64 {
     unsafe_torch!(torch_sys::at_context_version_cudart())
 }
 
+/// Check whether the vulkan backend is available. None that this
+/// backend is not included by default as of PyTorch 2.0.0.
+/// https://pytorch.org/tutorials/prototype/vulkan_workflow.html#building-pytorch-with-vulkan-backend
+pub fn has_vulkan() -> bool {
+    crate::Tensor::is_vulkan_available()
+}
+
 /// Quantization engines
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/torch-sys/libtch/torch_api.cpp
+++ b/torch-sys/libtch/torch_api.cpp
@@ -50,6 +50,7 @@ c10::List<c10::optional<torch::Tensor>> of_carray_tensor_opt(torch::Tensor **vs,
 }
 
 at::Device device_of_int(int d) {
+    if (d == -3) return at::Device(at::kVulkan);
     if (d == -2) return at::Device(at::kMPS);
     if (d < 0) return at::Device(at::kCPU);
     return at::Device(at::kCUDA, /*index=*/d);
@@ -202,6 +203,8 @@ int at_device(tensor t) {
   PROTECT(
     auto device = t->device();
     if (device.type() == at::kCPU) return -1;
+    if (device.type() == at::kMPS) return -2;
+    if (device.type() == at::kVulkan) return -3;
     if (device.type() == at::kCUDA) return device.index();
   )
   return -2;


### PR DESCRIPTION
Add support for the vulkan device as suggested in #432. Note that vulkan support is not included by default or in prebuilt binaries, see [the PyTorch website](https://pytorch.org/tutorials/prototype/vulkan_workflow.html#building-pytorch-with-vulkan-backend) on how to build libtorch with Vulkan support.