### PR TITLE
Switch to functions being fallible by default [wip]

### DIFF
--- a/gen/gen.ml
+++ b/gen/gen.ml
@@ -678,9 +678,12 @@ let write_fallible_wrapper funcs filename =
     pm "impl Tensor {";
     Map.iteri funcs ~f:(fun ~key:exported_name ~data:(func : Func.t) ->
       let rust_name = Func.rust_name exported_name in
+      let fallible_rust_name =
+        if Set.mem prefixed_functions func.name then "g_" ^ rust_name else rust_name
+      in
       let self, rust_args_list = Func.rust_typed_args_list func in
       pm "";
-      pm "    pub fn f_%s%s(" rust_name (Func.type_parameters func);
+      pm "    pub fn %s%s(" fallible_rust_name (Func.type_parameters func);
       pm "        %s" rust_args_list;
       pm "    )%s {" (Func.rust_return_type func ~fallible:true);
       List.iter func.args ~f:(fun arg ->
@@ -756,7 +759,7 @@ let write_wrapper funcs filename =
     pm "impl Tensor {";
     Map.iteri funcs ~f:(fun ~key:exported_name ~data:(func : Func.t) ->
       let rust_name = Func.rust_name exported_name in
-      let rust_name, fallible_rust_name =
+      let fallible_rust_name, rust_name =
         if Set.mem prefixed_functions func.name
         then "g_" ^ rust_name, "f_" ^ rust_name
         else rust_name, "f_" ^ rust_name

--- a/src/error.rs
+++ b/src/error.rs
@@ -65,10 +65,18 @@ pub enum TchError {
 }
 
 impl TchError {
+    /// Annotate an error with the related var-store path.
     pub fn path_context(&self, path_name: &str) -> Self {
         match self {
             TchError::Torch(error) => TchError::Torch(format!("{path_name}: {error}")),
             _ => unimplemented!(),
+        }
+    }
+
+    pub(crate) fn io_path_context(self, path: &std::path::Path) -> Self {
+        match self {
+            Self::Io(err) => Self::Io(std::io::Error::new(err.kind(), format!("{path:?} {err}"))),
+            otherwise => otherwise,
         }
     }
 }

--- a/src/nn/batch_norm.rs
+++ b/src/nn/batch_norm.rs
@@ -1,5 +1,5 @@
 //! A batch-normalization layer.
-use crate::Tensor;
+use crate::{TchError, Tensor};
 use std::borrow::Borrow;
 
 /// Batch-normalization config.
@@ -98,7 +98,7 @@ pub fn batch_norm3d<'a, T: Borrow<super::Path<'a>>>(
 }
 
 impl super::module::ModuleT for BatchNorm {
-    fn forward_t(&self, xs: &Tensor, train: bool) -> Tensor {
+    fn forward_t(&self, xs: &Tensor, train: bool) -> Result<Tensor, TchError> {
         let dim = xs.dim();
         if self.nd == 1 && dim != 2 && dim != 3 {
             panic!(

--- a/src/nn/conv.rs
+++ b/src/nn/conv.rs
@@ -26,16 +26,16 @@ impl PaddingMode {
         }
     }
 
-    pub fn f_pad(
+    pub fn pad(
         self,
         xs: &Tensor,
         reversed_padding_repeated_twice: &[i64],
     ) -> Result<Tensor, TchError> {
-        xs.f_pad(reversed_padding_repeated_twice, self.to_string(), None)
+        xs.pad(reversed_padding_repeated_twice, self.to_string(), None)
     }
 
-    pub fn pad(self, xs: &Tensor, reversed_padding_repeated_twice: &[i64]) -> Tensor {
-        xs.pad(reversed_padding_repeated_twice, self.to_string(), None)
+    pub fn f_pad(self, xs: &Tensor, reversed_padding_repeated_twice: &[i64]) -> Tensor {
+        xs.f_pad(reversed_padding_repeated_twice, self.to_string(), None)
     }
 }
 
@@ -191,10 +191,10 @@ pub fn conv3d<'a, T: Borrow<Path<'a>>>(vs: T, i: i64, o: i64, k: i64, c: ConvCon
 }
 
 impl super::module::Module for Conv1D {
-    fn forward(&self, xs: &Tensor) -> Tensor {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor, TchError> {
         let (xs, padding) = match self.config.padding_mode {
             PaddingMode::Zeros => (xs.shallow_clone(), self.config.padding),
-            p => (p.pad(xs, &self.reversed_padding_repeated_twice), [0]),
+            p => (p.pad(xs, &self.reversed_padding_repeated_twice)?, [0]),
         };
         xs.conv1d(
             &self.ws,
@@ -208,10 +208,10 @@ impl super::module::Module for Conv1D {
 }
 
 impl super::module::Module for Conv2D {
-    fn forward(&self, xs: &Tensor) -> Tensor {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor, TchError> {
         let (xs, padding) = match self.config.padding_mode {
             PaddingMode::Zeros => (xs.shallow_clone(), self.config.padding),
-            p => (p.pad(xs, &self.reversed_padding_repeated_twice), [0, 0]),
+            p => (p.pad(xs, &self.reversed_padding_repeated_twice)?, [0, 0]),
         };
         xs.conv2d(
             &self.ws,
@@ -225,10 +225,10 @@ impl super::module::Module for Conv2D {
 }
 
 impl super::module::Module for Conv3D {
-    fn forward(&self, xs: &Tensor) -> Tensor {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor, TchError> {
         let (xs, padding) = match self.config.padding_mode {
             PaddingMode::Zeros => (xs.shallow_clone(), self.config.padding),
-            p => (p.pad(xs, &self.reversed_padding_repeated_twice), [0, 0, 0]),
+            p => (p.pad(xs, &self.reversed_padding_repeated_twice)?, [0, 0, 0]),
         };
         xs.conv3d(
             &self.ws,

--- a/src/nn/conv_transpose.rs
+++ b/src/nn/conv_transpose.rs
@@ -1,6 +1,6 @@
 //! A two dimension transposed convolution layer.
 use super::Path;
-use crate::Tensor;
+use crate::{TchError, Tensor};
 use std::borrow::Borrow;
 
 /// A generic transposed convolution configuration.
@@ -144,7 +144,7 @@ pub fn conv_transpose3d<'a, T: Borrow<Path<'a>>>(
 }
 
 impl super::module::Module for ConvTranspose1D {
-    fn forward(&self, xs: &Tensor) -> Tensor {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor, TchError> {
         Tensor::conv_transpose1d(
             xs,
             &self.ws,
@@ -159,7 +159,7 @@ impl super::module::Module for ConvTranspose1D {
 }
 
 impl super::module::Module for ConvTranspose2D {
-    fn forward(&self, xs: &Tensor) -> Tensor {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor, TchError> {
         Tensor::conv_transpose2d(
             xs,
             &self.ws,
@@ -174,7 +174,7 @@ impl super::module::Module for ConvTranspose2D {
 }
 
 impl super::module::Module for ConvTranspose3D {
-    fn forward(&self, xs: &Tensor) -> Tensor {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor, TchError> {
         Tensor::conv_transpose3d(
             xs,
             &self.ws,

--- a/src/nn/func.rs
+++ b/src/nn/func.rs
@@ -1,9 +1,9 @@
 //! Layers defined by closures.
-use crate::Tensor;
+use crate::{TchError, Tensor};
 
 /// A layer defined by a simple closure.
 pub struct Func<'a> {
-    f: Box<dyn 'a + Fn(&Tensor) -> Tensor + Send>,
+    f: Box<dyn 'a + Fn(&Tensor) -> Result<Tensor, TchError> + Send>,
 }
 
 impl<'a> std::fmt::Debug for Func<'a> {
@@ -14,13 +14,13 @@ impl<'a> std::fmt::Debug for Func<'a> {
 
 pub fn func<'a, F>(f: F) -> Func<'a>
 where
-    F: 'a + Fn(&Tensor) -> Tensor + Send,
+    F: 'a + Fn(&Tensor) -> Result<Tensor, TchError> + Send,
 {
     Func { f: Box::new(f) }
 }
 
 impl<'a> super::module::Module for Func<'a> {
-    fn forward(&self, xs: &Tensor) -> Tensor {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor, TchError> {
         (*self.f)(xs)
     }
 }
@@ -39,13 +39,13 @@ impl<'a> std::fmt::Debug for FuncT<'a> {
 
 pub fn func_t<'a, F>(f: F) -> FuncT<'a>
 where
-    F: 'a + Fn(&Tensor, bool) -> Tensor + Send,
+    F: 'a + Fn(&Tensor, bool) -> Result<Tensor, TchError> + Send,
 {
     FuncT { f: Box::new(f) }
 }
 
 impl<'a> super::module::ModuleT for FuncT<'a> {
-    fn forward_t(&self, xs: &Tensor, train: bool) -> Tensor {
+    fn forward_t(&self, xs: &Tensor, train: bool) -> Result<Tensor, TchError> {
         (*self.f)(xs, train)
     }
 }

--- a/src/nn/func.rs
+++ b/src/nn/func.rs
@@ -28,7 +28,7 @@ impl<'a> super::module::Module for Func<'a> {
 /// A layer defined by a closure with an additional training parameter.
 #[allow(clippy::type_complexity)]
 pub struct FuncT<'a> {
-    f: Box<dyn 'a + Fn(&Tensor, bool) -> Tensor + Send>,
+    f: Box<dyn 'a + Fn(&Tensor, bool) -> Result<Tensor, TchError> + Send>,
 }
 
 impl<'a> std::fmt::Debug for FuncT<'a> {

--- a/src/nn/group_norm.rs
+++ b/src/nn/group_norm.rs
@@ -1,6 +1,6 @@
 //! A group-normalization layer.
 //! Group Normalization <https://arxiv.org/abs/1803.0849>
-use crate::Tensor;
+use crate::{TchError, Tensor};
 use std::borrow::Borrow;
 
 /// Group-normalization config.
@@ -53,7 +53,7 @@ pub fn group_norm<'a, T: Borrow<super::Path<'a>>>(
 }
 
 impl super::module::Module for GroupNorm {
-    fn forward(&self, xs: &Tensor) -> Tensor {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor, TchError> {
         Tensor::group_norm(
             xs,
             self.num_groups,

--- a/src/nn/layer_norm.rs
+++ b/src/nn/layer_norm.rs
@@ -37,18 +37,18 @@ pub fn layer_norm<'a, T: Borrow<super::Path<'a>>>(
     vs: T,
     normalized_shape: Vec<i64>,
     config: LayerNormConfig,
-) -> LayerNorm {
+) -> Result<LayerNorm, TchError> {
     let vs = vs.borrow();
 
     let (ws, bs) = if config.elementwise_affine {
-        let ws = vs.var("weight", normalized_shape.as_slice(), config.ws_init);
-        let bs = vs.var("bias", normalized_shape.as_slice(), config.bs_init);
+        let ws = vs.var("weight", normalized_shape.as_slice(), config.ws_init)?;
+        let bs = vs.var("bias", normalized_shape.as_slice(), config.bs_init)?;
         (Some(ws), Some(bs))
     } else {
         (None, None)
     };
 
-    LayerNorm { config, ws, bs, normalized_shape }
+    Ok(LayerNorm { config, ws, bs, normalized_shape })
 }
 
 impl super::module::Module for LayerNorm {

--- a/src/nn/layer_norm.rs
+++ b/src/nn/layer_norm.rs
@@ -1,5 +1,5 @@
 //! A layer-normalization layer.
-use crate::Tensor;
+use crate::{TchError, Tensor};
 use std::borrow::Borrow;
 
 /// Layer-normalization config.
@@ -52,7 +52,7 @@ pub fn layer_norm<'a, T: Borrow<super::Path<'a>>>(
 }
 
 impl super::module::Module for LayerNorm {
-    fn forward(&self, xs: &Tensor) -> Tensor {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor, TchError> {
         Tensor::layer_norm(
             xs,
             self.normalized_shape.as_slice(),

--- a/src/nn/linear.rs
+++ b/src/nn/linear.rs
@@ -45,7 +45,7 @@ pub fn linear<'a, T: Borrow<super::Path<'a>>>(
 }
 
 impl super::module::Module for Linear {
-    fn forward(&self, xs: &Tensor) -> Tensor {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor, crate::TchError> {
         xs.linear(&self.ws, self.bs.as_ref())
     }
 }

--- a/src/nn/mod.rs
+++ b/src/nn/mod.rs
@@ -50,20 +50,22 @@ pub use optimizer::{
 #[derive(Debug)]
 pub struct Id();
 
+use crate::{TchError, Tensor};
+
 impl ModuleT for Id {
-    fn forward_t(&self, xs: &crate::Tensor, _train: bool) -> crate::Tensor {
-        xs.shallow_clone()
+    fn forward_t(&self, xs: &Tensor, _train: bool) -> Result<Tensor, TchError> {
+        Ok(xs.shallow_clone())
     }
 }
 
 impl Module for crate::CModule {
-    fn forward(&self, xs: &crate::Tensor) -> crate::Tensor {
-        self.forward_ts(&[xs]).unwrap()
+    fn forward(&self, xs: &Tensor) -> Result<Tensor, TchError> {
+        self.forward_ts(&[xs])
     }
 }
 
 impl ModuleT for crate::TrainableCModule {
-    fn forward_t(&self, xs: &crate::Tensor, _train: bool) -> crate::Tensor {
-        self.inner.forward_ts(&[xs]).unwrap()
+    fn forward_t(&self, xs: &Tensor, _train: bool) -> Result<Tensor, TchError> {
+        self.inner.forward_ts(&[xs])
     }
 }

--- a/src/nn/module.rs
+++ b/src/nn/module.rs
@@ -1,9 +1,9 @@
 //! Basic module traits defining the forward pass.
-use crate::{data::Iter2, Device, Tensor};
+use crate::{data::Iter2, Device, TchError, Tensor};
 
 /// The simplest module trait, defining a forward function.
 pub trait Module: std::fmt::Debug + Send {
-    fn forward(&self, xs: &Tensor) -> Tensor;
+    fn forward(&self, xs: &Tensor) -> Result<Tensor, TchError>;
 }
 
 /// Module trait with an additional train parameter.
@@ -11,7 +11,7 @@ pub trait Module: std::fmt::Debug + Send {
 /// The train parameter is commonly used to have different behavior between training
 /// and evaluation, e.g. when using dropout or batch-normalization.
 pub trait ModuleT: std::fmt::Debug + Send {
-    fn forward_t(&self, xs: &Tensor, train: bool) -> Tensor;
+    fn forward_t(&self, xs: &Tensor, train: bool) -> Result<Tensor, TchError>;
 
     fn batch_accuracy_for_logits(
         &self,
@@ -24,9 +24,10 @@ pub trait ModuleT: std::fmt::Debug + Send {
         let mut sum_accuracy = 0f64;
         let mut sample_count = 0f64;
         for (xs, ys) in Iter2::new(xs, ys, batch_size).return_smaller_last_batch() {
-            let acc = self.forward_t(&xs.to_device(d), false).accuracy_for_logits(&ys.to_device(d));
+            let acc =
+                self.forward_t(&xs.to_device(d)?, false)?.accuracy_for_logits(&ys.to_device(d))?;
             let size = xs.size()[0] as f64;
-            sum_accuracy += f64::try_from(&acc).unwrap() * size;
+            sum_accuracy += f64::try_from(&acc)? * size;
             sample_count += size;
         }
         sum_accuracy / sample_count
@@ -37,31 +38,31 @@ impl<T> ModuleT for T
 where
     T: Module,
 {
-    fn forward_t(&self, xs: &Tensor, _train: bool) -> Tensor {
+    fn forward_t(&self, xs: &Tensor, _train: bool) -> Result<Tensor, TchError> {
         self.forward(xs)
     }
 }
 
 impl Tensor {
-    pub fn apply<M: Module>(&self, m: &M) -> Tensor {
+    pub fn apply<M: Module>(&self, m: &M) -> Result<Tensor, TchError> {
         m.forward(self)
     }
 
-    pub fn apply_t<M: ModuleT>(&self, m: &M, train: bool) -> Tensor {
+    pub fn apply_t<M: ModuleT>(&self, m: &M, train: bool) -> Result<Tensor, TchError> {
         m.forward_t(self, train)
     }
 
-    pub fn apply_opt<M: Module>(&self, m: &Option<M>) -> Tensor {
+    pub fn apply_opt<M: Module>(&self, m: &Option<M>) -> Result<Tensor, TchError> {
         match m {
             Some(m) => m.forward(self),
-            None => self.shallow_clone(),
+            None => Ok(self.shallow_clone()),
         }
     }
 
-    pub fn apply_opt_t<M: ModuleT>(&self, m: &Option<M>, train: bool) -> Tensor {
+    pub fn apply_opt_t<M: ModuleT>(&self, m: &Option<M>, train: bool) -> Result<Tensor, TchError> {
         match m {
             Some(m) => m.forward_t(self, train),
-            None => self.shallow_clone(),
+            None => Ok(self.shallow_clone()),
         }
     }
 }

--- a/src/nn/rnn.rs
+++ b/src/nn/rnn.rs
@@ -174,12 +174,12 @@ impl RNN for LSTM {
         let num_directions = if self.config.bidirectional { 2 } else { 1 };
         let layer_dim = self.config.num_layers * num_directions;
         let shape = [layer_dim, batch_dim, self.hidden_dim];
-        let zeros = Tensor::zeros(shape, (self.flat_weights[0].kind(), self.device));
+        let zeros = Tensor::f_zeros(shape, (self.flat_weights[0].f_kind(), self.device));
         LSTMState((zeros.shallow_clone(), zeros.shallow_clone()))
     }
 
     fn step(&self, input: &Tensor, in_state: &LSTMState) -> LSTMState {
-        let input = input.unsqueeze(1);
+        let input = input.f_unsqueeze(1);
         let (_output, state) = self.seq_init(&input, in_state);
         state
     }
@@ -187,7 +187,7 @@ impl RNN for LSTM {
     fn seq_init(&self, input: &Tensor, in_state: &LSTMState) -> (Tensor, LSTMState) {
         let LSTMState((h, c)) = in_state;
         let flat_weights = self.flat_weights.iter().collect::<Vec<_>>();
-        let (output, h, c) = input.lstm(
+        let (output, h, c) = input.f_lstm(
             &[h, c],
             &flat_weights,
             self.config.has_biases,

--- a/src/nn/sparse.rs
+++ b/src/nn/sparse.rs
@@ -1,5 +1,5 @@
 //! Sparse Layers
-use crate::Tensor;
+use crate::{TchError, Tensor};
 use std::borrow::Borrow;
 
 /// Configuration option for an embedding layer.
@@ -43,7 +43,7 @@ pub fn embedding<'a, T: Borrow<super::Path<'a>>>(
 }
 
 impl super::module::Module for Embedding {
-    fn forward(&self, xs: &Tensor) -> Tensor {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor, TchError> {
         Tensor::embedding(
             &self.ws,
             xs,

--- a/src/tensor/iter.rs
+++ b/src/tensor/iter.rs
@@ -25,7 +25,7 @@ impl std::iter::Iterator for Iter<i64> {
         if self.index >= self.len {
             return None;
         }
-        let v = self.content.int64_value(&[self.index]);
+        let v = self.content.f_int64_value(&[self.index]);
         self.index += 1;
         Some(v)
     }
@@ -37,7 +37,7 @@ impl std::iter::Iterator for Iter<f64> {
         if self.index >= self.len {
             return None;
         }
-        let v = self.content.double_value(&[self.index]);
+        let v = self.content.f_double_value(&[self.index]);
         self.index += 1;
         Some(v)
     }
@@ -47,7 +47,7 @@ impl std::iter::Sum for Tensor {
     fn sum<I: Iterator<Item = Tensor>>(mut iter: I) -> Tensor {
         match iter.next() {
             None => Tensor::from(0.),
-            Some(t) => iter.fold(t, |acc, x| x + acc),
+            Some(t) => iter.fold(t, |acc, x| (x + acc).unwrap()),
         }
     }
 }
@@ -56,7 +56,7 @@ impl<'a> std::iter::Sum<&'a Tensor> for Tensor {
     fn sum<I: Iterator<Item = &'a Tensor>>(mut iter: I) -> Tensor {
         match iter.next() {
             None => Tensor::from(0.),
-            Some(t) => iter.fold(t.shallow_clone(), |acc, x| x + acc),
+            Some(t) => iter.fold(t.shallow_clone(), |acc, x| (x + acc).unwrap()),
         }
     }
 }

--- a/src/tensor/npy.rs
+++ b/src/tensor/npy.rs
@@ -177,7 +177,7 @@ impl crate::Tensor {
         }
         let mut data: Vec<u8> = vec![];
         reader.read_to_end(&mut data)?;
-        Tensor::f_from_data_size(&data, &header.shape, header.descr)
+        Tensor::from_data_size(&data, &header.shape, header.descr)
     }
 
     /// Reads a npz file and returns some named tensors.
@@ -198,7 +198,7 @@ impl crate::Tensor {
             }
             let mut data: Vec<u8> = vec![];
             reader.read_to_end(&mut data)?;
-            let tensor = Tensor::f_from_data_size(&data, &header.shape, header.descr)?;
+            let tensor = Tensor::from_data_size(&data, &header.shape, header.descr)?;
             result.push((name, tensor))
         }
         Ok(result)
@@ -207,7 +207,7 @@ impl crate::Tensor {
     fn write<T: Write>(&self, f: &mut T) -> Result<(), TchError> {
         f.write_all(NPY_MAGIC_STRING)?;
         f.write_all(&[1u8, 0u8])?;
-        let kind = self.f_kind()?;
+        let kind = self.kind()?;
         let header = Header { descr: kind, fortran_order: false, shape: self.size() };
         let mut header = header.to_string()?;
         let pad = 16 - (NPY_MAGIC_STRING.len() + 5 + header.len()) % 16;
@@ -219,7 +219,7 @@ impl crate::Tensor {
         f.write_all(header.as_bytes())?;
         let numel = self.numel();
         let mut content = vec![0u8; numel * kind.elt_size_in_bytes()];
-        self.f_copy_data_u8(&mut content, numel)?;
+        self.copy_data_u8(&mut content, numel)?;
         f.write_all(&content)?;
         Ok(())
     }

--- a/src/tensor/ops.rs
+++ b/src/tensor/ops.rs
@@ -1,5 +1,5 @@
 //! Implement various ops traits for tensors
-use super::Tensor;
+use super::{TchError, Tensor};
 use crate::Scalar;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
@@ -7,18 +7,18 @@ fn id<T>(v: T) -> T {
     v
 }
 
-fn neg(t: Tensor) -> Tensor {
+fn neg(t: Tensor) -> Result<Tensor, TchError> {
     t.neg()
 }
 
-fn inv(t: Tensor) -> Tensor {
+fn inv(t: Tensor) -> Result<Tensor, TchError> {
     t.pow_tensor_scalar(-1)
 }
 
 macro_rules! impl_op {
     ($trait:ident, $func:ident, $op:ident) => {
         impl $trait<Tensor> for Tensor {
-            type Output = Tensor;
+            type Output = Result<Tensor, TchError>;
 
             fn $func(self, rhs: Tensor) -> Self::Output {
                 self.$op(&rhs)
@@ -26,7 +26,7 @@ macro_rules! impl_op {
         }
 
         impl $trait<&Tensor> for Tensor {
-            type Output = Tensor;
+            type Output = Result<Tensor, TchError>;
 
             fn $func(self, rhs: &Tensor) -> Self::Output {
                 self.$op(rhs)
@@ -34,7 +34,7 @@ macro_rules! impl_op {
         }
 
         impl<'a> $trait<&Tensor> for &'a Tensor {
-            type Output = Tensor;
+            type Output = Result<Tensor, TchError>;
 
             fn $func(self, rhs: &Tensor) -> Self::Output {
                 self.$op(rhs)
@@ -42,7 +42,7 @@ macro_rules! impl_op {
         }
 
         impl $trait<Tensor> for &Tensor {
-            type Output = Tensor;
+            type Output = Result<Tensor, TchError>;
 
             fn $func(self, rhs: Tensor) -> Self::Output {
                 self.$op(&rhs)
@@ -55,7 +55,7 @@ impl<S> Add<S> for &Tensor
 where
     S: Into<Scalar>,
 {
-    type Output = Tensor;
+    type Output = Result<Tensor, TchError>;
 
     fn add(self, rhs: S) -> Self::Output {
         self.g_add_scalar(rhs)
@@ -66,7 +66,7 @@ impl<S> Add<S> for Tensor
 where
     S: Into<Scalar>,
 {
-    type Output = Tensor;
+    type Output = Result<Tensor, TchError>;
 
     fn add(self, rhs: S) -> Self::Output {
         (&self).add(rhs)
@@ -77,7 +77,7 @@ impl<S> Sub<S> for &Tensor
 where
     S: Into<Scalar>,
 {
-    type Output = Tensor;
+    type Output = Result<Tensor, TchError>;
 
     fn sub(self, rhs: S) -> Self::Output {
         self.g_sub_scalar(rhs)
@@ -88,7 +88,7 @@ impl<S> Sub<S> for Tensor
 where
     S: Into<Scalar>,
 {
-    type Output = Tensor;
+    type Output = Result<Tensor, TchError>;
 
     fn sub(self, rhs: S) -> Self::Output {
         (&self).sub(rhs)
@@ -99,7 +99,7 @@ impl<S> Mul<S> for &Tensor
 where
     S: Into<Scalar>,
 {
-    type Output = Tensor;
+    type Output = Result<Tensor, TchError>;
 
     fn mul(self, rhs: S) -> Self::Output {
         self.g_mul_scalar(rhs)
@@ -110,7 +110,7 @@ impl<S> Mul<S> for Tensor
 where
     S: Into<Scalar>,
 {
-    type Output = Tensor;
+    type Output = Result<Tensor, TchError>;
 
     fn mul(self, rhs: S) -> Self::Output {
         (&self).mul(rhs)
@@ -121,7 +121,7 @@ impl<S> Div<S> for &Tensor
 where
     S: Into<Scalar>,
 {
-    type Output = Tensor;
+    type Output = Result<Tensor, TchError>;
 
     fn div(self, rhs: S) -> Self::Output {
         self.g_div_scalar(rhs)
@@ -132,7 +132,7 @@ impl<S> Div<S> for Tensor
 where
     S: Into<Scalar>,
 {
-    type Output = Tensor;
+    type Output = Result<Tensor, TchError>;
 
     fn div(self, rhs: S) -> Self::Output {
         (&self).div(rhs)
@@ -143,7 +143,7 @@ macro_rules! impl_op_basic {
     /* rev such that rev(op(b, a)) = op(a, b) */
     ($trait:ident, $func:ident, $op:ident, $rev:ident) => {
         impl $trait<Tensor> for i32 {
-            type Output = Tensor;
+            type Output = Result<Tensor, TchError>;
 
             fn $func(self, rhs: Tensor) -> Self::Output {
                 self.$func(&rhs)
@@ -151,7 +151,7 @@ macro_rules! impl_op_basic {
         }
 
         impl $trait<Tensor> for i64 {
-            type Output = Tensor;
+            type Output = Result<Tensor, TchError>;
 
             fn $func(self, rhs: Tensor) -> Self::Output {
                 self.$func(&rhs)
@@ -159,7 +159,7 @@ macro_rules! impl_op_basic {
         }
 
         impl $trait<Tensor> for f32 {
-            type Output = Tensor;
+            type Output = Result<Tensor, TchError>;
 
             fn $func(self, rhs: Tensor) -> Self::Output {
                 self.$func(&rhs)
@@ -167,7 +167,7 @@ macro_rules! impl_op_basic {
         }
 
         impl $trait<Tensor> for f64 {
-            type Output = Tensor;
+            type Output = Result<Tensor, TchError>;
 
             fn $func(self, rhs: Tensor) -> Self::Output {
                 self.$func(&rhs)
@@ -175,7 +175,7 @@ macro_rules! impl_op_basic {
         }
 
         impl $trait<&Tensor> for i32 {
-            type Output = Tensor;
+            type Output = Result<Tensor, TchError>;
 
             fn $func(self, rhs: &Tensor) -> Self::Output {
                 $rev(rhs.$op(self as i64))
@@ -183,7 +183,7 @@ macro_rules! impl_op_basic {
         }
 
         impl $trait<&Tensor> for i64 {
-            type Output = Tensor;
+            type Output = Result<Tensor, TchError>;
 
             fn $func(self, rhs: &Tensor) -> Self::Output {
                 $rev(rhs.$op(self))
@@ -191,7 +191,7 @@ macro_rules! impl_op_basic {
         }
 
         impl $trait<&Tensor> for f32 {
-            type Output = Tensor;
+            type Output = Result<Tensor, TchError>;
 
             fn $func(self, rhs: &Tensor) -> Self::Output {
                 $rev(rhs.$op(self as f64))
@@ -199,7 +199,7 @@ macro_rules! impl_op_basic {
         }
 
         impl $trait<&Tensor> for f64 {
-            type Output = Tensor;
+            type Output = Result<Tensor, TchError>;
 
             fn $func(self, rhs: &Tensor) -> Self::Output {
                 $rev(rhs.$op(self))
@@ -273,18 +273,18 @@ impl_op_assign!(SubAssign, sub_assign, g_sub_);
 impl_op_assign_basic!(SubAssign, sub_assign, g_sub_scalar_);
 
 impl Neg for Tensor {
-    type Output = Tensor;
+    type Output = Result<Tensor, TchError>;
 
-    fn neg(self) -> Tensor {
-        self.f_neg().unwrap()
+    fn neg(self) -> Result<Tensor, TchError> {
+        self.neg()
     }
 }
 
 impl Neg for &Tensor {
-    type Output = Tensor;
+    type Output = Result<Tensor, TchError>;
 
-    fn neg(self) -> Tensor {
-        self.f_neg().unwrap()
+    fn neg(self) -> Result<Tensor, TchError> {
+        self.neg()
     }
 }
 

--- a/src/vision/alexnet.rs
+++ b/src/vision/alexnet.rs
@@ -1,28 +1,28 @@
 //! AlexNet.
 //! <https://arxiv.org/abs/1404.5997>
-use crate::{nn, nn::Conv2D, nn::ModuleT, Tensor};
+use crate::{nn, nn::Conv2D, nn::ModuleT, TchError, Tensor};
 
 fn conv2d(p: nn::Path, c_in: i64, c_out: i64, ksize: i64, padding: i64, stride: i64) -> Conv2D {
     let conv2d_cfg = nn::ConvConfig { stride, padding, ..Default::default() };
     nn::conv2d(p, c_in, c_out, ksize, conv2d_cfg)
 }
 
-fn max_pool2d(xs: Tensor, ksize: i64, stride: i64) -> Tensor {
+fn max_pool2d(xs: Tensor, ksize: i64, stride: i64) -> Result<Tensor, TchError> {
     xs.max_pool2d([ksize, ksize], [stride, stride], [0, 0], [1, 1], false)
 }
 
 fn features(p: nn::Path) -> impl ModuleT {
     nn::seq_t()
         .add(conv2d(&p / "0", 3, 64, 11, 2, 4))
-        .add_fn(|xs| max_pool2d(xs.relu(), 3, 2))
+        .add_fn(|xs| max_pool2d(xs.relu()?, 3, 2))
         .add(conv2d(&p / "3", 64, 192, 5, 1, 2))
-        .add_fn(|xs| max_pool2d(xs.relu(), 3, 2))
+        .add_fn(|xs| max_pool2d(xs.relu()?, 3, 2))
         .add(conv2d(&p / "6", 192, 384, 3, 1, 1))
         .add_fn(|xs| xs.relu())
         .add(conv2d(&p / "8", 384, 256, 3, 1, 1))
         .add_fn(|xs| xs.relu())
         .add(conv2d(&p / "10", 256, 256, 3, 1, 1))
-        .add_fn(|xs| max_pool2d(xs.relu(), 3, 2))
+        .add_fn(|xs| max_pool2d(xs.relu()?, 3, 2))
 }
 
 fn classifier(p: nn::Path, nclasses: i64) -> impl ModuleT {
@@ -39,6 +39,6 @@ fn classifier(p: nn::Path, nclasses: i64) -> impl ModuleT {
 pub fn alexnet(p: &nn::Path, nclasses: i64) -> impl ModuleT {
     nn::seq_t()
         .add(features(p / "features"))
-        .add_fn(|xs| xs.adaptive_avg_pool2d([6, 6]).flat_view())
+        .add_fn(|xs| xs.adaptive_avg_pool2d([6, 6])?.flat_view())
         .add(classifier(p / "classifier", nclasses))
 }

--- a/src/vision/cifar.rs
+++ b/src/vision/cifar.rs
@@ -35,8 +35,7 @@ fn read_file_(filename: &std::path::Path) -> Result<(Tensor, Tensor), TchError> 
 }
 
 fn read_file(filename: &std::path::Path) -> Result<(Tensor, Tensor), TchError> {
-    read_file_(filename)
-        .map_err(|err| std::io::Error::new(err.kind(), format!("{filename:?} {err}")))
+    read_file_(filename).map_err(|e| e.io_path_context(filename))
 }
 
 pub fn load_dir<T: AsRef<std::path::Path>>(dir: T) -> Result<Dataset, TchError> {

--- a/src/vision/convmixer.rs
+++ b/src/vision/convmixer.rs
@@ -13,8 +13,8 @@ fn block(p: nn::Path, dim: i64, kernel_size: i64) -> impl nn::ModuleT {
     let conv2 = nn::conv2d(&p / "1", dim, dim, 1, Default::default());
     let bn2 = nn::batch_norm2d(&p / "3", dim, Default::default());
     nn::func_t(move |xs, train| {
-        let ys = xs.apply(&conv1).gelu("none").apply_t(&bn1, train);
-        (xs + ys).apply(&conv2).gelu("none").apply_t(&bn2, train)
+        let ys = xs.apply(&conv1)?.gelu("none")?.apply_t(&bn1, train)?;
+        (xs + ys)?.apply(&conv2)?.gelu("none")?.apply_t(&bn2, train)
     })
 }
 
@@ -32,11 +32,11 @@ fn convmixer(
     let blocks: Vec<_> = (0..depth).map(|index| block(p / (3 + index), dim, kernel_size)).collect();
     let fc = nn::linear(p / "25", dim, nclasses, Default::default());
     nn::func_t(move |xs, train| {
-        let mut xs = xs.apply(&conv1).gelu("none").apply_t(&bn1, train);
+        let mut xs = xs.apply(&conv1)?.gelu("none")?.apply_t(&bn1, train)?;
         for block in blocks.iter() {
-            xs = xs.apply_t(block, train)
+            xs = xs.apply_t(block, train)?
         }
-        xs.adaptive_avg_pool2d([1, 1]).flat_view().apply(&fc)
+        xs.adaptive_avg_pool2d([1, 1])?.flat_view()?.apply(&fc)
     })
 }
 

--- a/src/vision/dataset.rs
+++ b/src/vision/dataset.rs
@@ -81,15 +81,15 @@ pub fn random_cutout(t: &Tensor, sz: i64) -> Result<Tensor, TchError> {
 }
 
 pub fn augmentation(t: &Tensor, flip: bool, crop: i64, cutout: i64) -> Result<Tensor, TchError> {
-    let mut t = Ok(t.shallow_clone());
+    let mut t = t.shallow_clone();
     if flip {
-        t = random_flip(&t?)?;
+        t = random_flip(&t)?;
     }
     if crop > 0 {
-        t = random_crop(&t?, crop);
+        t = random_crop(&t, crop)?;
     }
     if cutout > 0 {
-        t = random_cutout(&t?, cutout);
+        t = random_cutout(&t, cutout)?;
     }
-    t
+    Ok(t)
 }

--- a/src/vision/dataset.rs
+++ b/src/vision/dataset.rs
@@ -1,6 +1,6 @@
 //! A simple dataset structure shared by various computer vision datasets.
 use crate::data::Iter2;
-use crate::{IndexOp, Tensor};
+use crate::{IndexOp, TchError, Tensor};
 use rand::Rng;
 
 #[derive(Debug)]
@@ -25,51 +25,51 @@ impl Dataset {
 /// Randomly applies horizontal flips
 /// This expects a 4 dimension NCHW tensor and returns a tensor with
 /// an identical shape.
-pub fn random_flip(t: &Tensor) -> Tensor {
+pub fn random_flip(t: &Tensor) -> Result<Tensor, TchError> {
     let size = t.size();
     if size.len() != 4 {
         panic!("unexpected shape for tensor {t:?}")
     }
-    let output = t.zeros_like();
+    let output = t.zeros_like()?;
     for batch_index in 0..size[0] {
         let mut output_view = output.i(batch_index);
         let t_view = t.i(batch_index);
-        let src = if rand::random() { t_view } else { t_view.flip([2]) };
-        output_view.copy_(&src)
+        let src = if rand::random() { t_view } else { t_view.flip([2])? };
+        output_view.copy_(&src)?
     }
-    output
+    Ok(output)
 }
 
 /// Pad the image using reflections and take some random crops.
 /// This expects a 4 dimension NCHW tensor and returns a tensor with
 /// an identical shape.
-pub fn random_crop(t: &Tensor, pad: i64) -> Tensor {
+pub fn random_crop(t: &Tensor, pad: i64) -> Result<Tensor, TchError> {
     let size = t.size();
     if size.len() != 4 {
         panic!("unexpected shape for tensor {t:?}")
     }
     let sz_h = size[2];
     let sz_w = size[3];
-    let padded = t.reflection_pad2d([pad, pad, pad, pad]);
-    let output = t.zeros_like();
+    let padded = t.reflection_pad2d([pad, pad, pad, pad])?;
+    let output = t.zeros_like()?;
     for bindex in 0..size[0] {
         let mut output_view = output.i(bindex);
         let start_w = rand::thread_rng().gen_range(0..2 * pad);
         let start_h = rand::thread_rng().gen_range(0..2 * pad);
         let src = padded.i((bindex, .., start_h..start_h + sz_h, start_w..start_w + sz_w));
-        output_view.copy_(&src)
+        output_view.copy_(&src)?
     }
-    output
+    Ok(output)
 }
 
 /// Applies cutout: randomly remove some square areas in the original images.
 /// <https://arxiv.org/abs/1708.04552>
-pub fn random_cutout(t: &Tensor, sz: i64) -> Tensor {
+pub fn random_cutout(t: &Tensor, sz: i64) -> Result<Tensor, TchError> {
     let size = t.size();
     if size.len() != 4 || sz > size[2] || sz > size[3] {
         panic!("unexpected shape for tensor {t:?} {sz}")
     }
-    let mut output = t.zeros_like();
+    let mut output = t.zeros_like()?;
     output.copy_(t);
     for bindex in 0..size[0] {
         let start_h = rand::thread_rng().gen_range(0..size[2] - sz + 1);
@@ -77,19 +77,19 @@ pub fn random_cutout(t: &Tensor, sz: i64) -> Tensor {
         let _output =
             output.i((bindex, .., start_h..start_h + sz, start_w..start_w + sz)).fill_(0.0);
     }
-    output
+    Ok(output)
 }
 
-pub fn augmentation(t: &Tensor, flip: bool, crop: i64, cutout: i64) -> Tensor {
-    let mut t = t.shallow_clone();
+pub fn augmentation(t: &Tensor, flip: bool, crop: i64, cutout: i64) -> Result<Tensor, TchError> {
+    let mut t = Ok(t.shallow_clone());
     if flip {
-        t = random_flip(&t);
+        t = random_flip(&t?)?;
     }
     if crop > 0 {
-        t = random_crop(&t, crop);
+        t = random_crop(&t?, crop);
     }
     if cutout > 0 {
-        t = random_cutout(&t, cutout);
+        t = random_cutout(&t?, cutout);
     }
     t
 }

--- a/src/vision/imagenet.rs
+++ b/src/vision/imagenet.rs
@@ -15,13 +15,15 @@ lazy_static! {
 pub fn normalize(tensor: &Tensor) -> Result<Tensor, TchError> {
     let mean = IMAGENET_MEAN.lock().unwrap();
     let std = IMAGENET_STD.lock().unwrap();
-    ((tensor.to_kind(Kind::Float)? / 255.0)? - &mean)? / &std
+    ((tensor.to_kind(Kind::Float)? / 255.0)? - mean.as_ref())? / std.as_ref()
 }
 
 pub fn unnormalize(tensor: &Tensor) -> Result<Tensor, TchError> {
     let mean = IMAGENET_MEAN.lock().unwrap();
     let std = IMAGENET_STD.lock().unwrap();
-    let tensor = (((tensor * &std)? + &mean)? * 255.0)?.clamp(0., 255.0)?.to_kind(Kind::Uint8)?;
+    let tensor = (((tensor * std.as_ref())? + mean.as_ref())? * 255.0)?
+        .clamp(0., 255.0)?
+        .to_kind(Kind::Uint8)?;
     Ok(tensor)
 }
 

--- a/src/vision/inception.rs
+++ b/src/vision/inception.rs
@@ -1,5 +1,5 @@
 //! InceptionV3.
-use crate::{nn, nn::ModuleT, Tensor};
+use crate::{nn, nn::ModuleT, TchError, Tensor};
 
 fn conv_bn(p: nn::Path, c_in: i64, c_out: i64, ksize: i64, pad: i64, stride: i64) -> impl ModuleT {
     let conv2d_cfg = nn::ConvConfig { stride, padding: pad, bias: false, ..Default::default() };
@@ -20,7 +20,7 @@ fn conv_bn2(p: nn::Path, c_in: i64, c_out: i64, ksize: [i64; 2], pad: [i64; 2]) 
         .add_fn(|xs| xs.relu())
 }
 
-fn max_pool2d(xs: &Tensor, ksize: i64, stride: i64) -> Tensor {
+fn max_pool2d(xs: &Tensor, ksize: i64, stride: i64) -> Result<Tensor, TchError> {
     xs.max_pool2d([ksize, ksize], [stride, stride], [0, 0], [1, 1], false)
 }
 
@@ -33,10 +33,10 @@ fn inception_a(p: nn::Path, c_in: i64, c_pool: i64) -> impl ModuleT {
     let b3_3 = conv_bn(&p / "branch3x3dbl_3", 96, 96, 3, 1, 1);
     let bpool = conv_bn(&p / "branch_pool", c_in, c_pool, 1, 0, 1);
     nn::func_t(move |xs, tr| {
-        let b1 = xs.apply_t(&b1, tr);
-        let b2 = xs.apply_t(&b2_1, tr).apply_t(&b2_2, tr);
-        let b3 = xs.apply_t(&b3_1, tr).apply_t(&b3_2, tr).apply_t(&b3_3, tr);
-        let bpool = xs.avg_pool2d([3, 3], [1, 1], [1, 1], false, true, 9).apply_t(&bpool, tr);
+        let b1 = xs.apply_t(&b1, tr)?;
+        let b2 = xs.apply_t(&b2_1, tr)?.apply_t(&b2_2, tr)?;
+        let b3 = xs.apply_t(&b3_1, tr)?.apply_t(&b3_2, tr)?.apply_t(&b3_3, tr)?;
+        let bpool = xs.avg_pool2d([3, 3], [1, 1], [1, 1], false, true, 9)?.apply_t(&bpool, tr)?;
         Tensor::cat(&[b1, b2, b3, bpool], 1)
     })
 }
@@ -47,9 +47,9 @@ fn inception_b(p: nn::Path, c_in: i64) -> impl ModuleT {
     let b2_2 = conv_bn(&p / "branch3x3dbl_2", 64, 96, 3, 1, 1);
     let b2_3 = conv_bn(&p / "branch3x3dbl_3", 96, 96, 3, 0, 2);
     nn::func_t(move |xs, tr| {
-        let b1 = xs.apply_t(&b1, tr);
-        let b2 = xs.apply_t(&b2_1, tr).apply_t(&b2_2, tr).apply_t(&b2_3, tr);
-        let bpool = max_pool2d(xs, 3, 2);
+        let b1 = xs.apply_t(&b1, tr)?;
+        let b2 = xs.apply_t(&b2_1, tr)?.apply_t(&b2_2, tr)?.apply_t(&b2_3, tr)?;
+        let bpool = max_pool2d(xs, 3, 2)?;
         Tensor::cat(&[b1, b2, bpool], 1)
     })
 }
@@ -70,15 +70,15 @@ fn inception_c(p: nn::Path, c_in: i64, c7: i64) -> impl ModuleT {
     let bpool = conv_bn(&p / "branch_pool", c_in, 192, 1, 0, 1);
 
     nn::func_t(move |xs, tr| {
-        let b1 = xs.apply_t(&b1, tr);
-        let b2 = xs.apply_t(&b2_1, tr).apply_t(&b2_2, tr).apply_t(&b2_3, tr);
+        let b1 = xs.apply_t(&b1, tr)?;
+        let b2 = xs.apply_t(&b2_1, tr)?.apply_t(&b2_2, tr)?.apply_t(&b2_3, tr)?;
         let b3 = xs
-            .apply_t(&b3_1, tr)
-            .apply_t(&b3_2, tr)
-            .apply_t(&b3_3, tr)
-            .apply_t(&b3_4, tr)
-            .apply_t(&b3_5, tr);
-        let bpool = xs.avg_pool2d([3, 3], [1, 1], [1, 1], false, true, 9).apply_t(&bpool, tr);
+            .apply_t(&b3_1, tr)?
+            .apply_t(&b3_2, tr)?
+            .apply_t(&b3_3, tr)?
+            .apply_t(&b3_4, tr)?
+            .apply_t(&b3_5, tr)?;
+        let bpool = xs.avg_pool2d([3, 3], [1, 1], [1, 1], false, true, 9)?.apply_t(&bpool, tr)?;
         Tensor::cat(&[b1, b2, b3, bpool], 1)
     })
 }
@@ -93,9 +93,10 @@ fn inception_d(p: nn::Path, c_in: i64) -> impl ModuleT {
     let b2_4 = conv_bn(&p / "branch7x7x3_4", 192, 192, 3, 0, 2);
 
     nn::func_t(move |xs, tr| {
-        let b1 = xs.apply_t(&b1_1, tr).apply_t(&b1_2, tr);
-        let b2 = xs.apply_t(&b2_1, tr).apply_t(&b2_2, tr).apply_t(&b2_3, tr).apply_t(&b2_4, tr);
-        let bpool = max_pool2d(xs, 3, 2);
+        let b1 = xs.apply_t(&b1_1, tr)?.apply_t(&b1_2, tr)?;
+        let b2 =
+            xs.apply_t(&b2_1, tr)?.apply_t(&b2_2, tr)?.apply_t(&b2_3, tr)?.apply_t(&b2_4, tr)?;
+        let bpool = max_pool2d(xs, 3, 2)?;
         Tensor::cat(&[b1, b2, bpool], 1)
     })
 }
@@ -115,15 +116,15 @@ fn inception_e(p: nn::Path, c_in: i64) -> impl ModuleT {
     let bpool = conv_bn(&p / "branch_pool", c_in, 192, 1, 0, 1);
 
     nn::func_t(move |xs, tr| {
-        let b1 = xs.apply_t(&b1, tr);
+        let b1 = xs.apply_t(&b1, tr)?;
 
-        let b2 = xs.apply_t(&b2_1, tr);
-        let b2 = Tensor::cat(&[b2.apply_t(&b2_2a, tr), b2.apply_t(&b2_2b, tr)], 1);
+        let b2 = xs.apply_t(&b2_1, tr)?;
+        let b2 = Tensor::cat(&[b2.apply_t(&b2_2a, tr)?, b2.apply_t(&b2_2b, tr)?], 1)?;
 
-        let b3 = xs.apply_t(&b3_1, tr).apply_t(&b3_2, tr);
-        let b3 = Tensor::cat(&[b3.apply_t(&b3_3a, tr), b3.apply_t(&b3_3b, tr)], 1);
+        let b3 = xs.apply_t(&b3_1, tr)?.apply_t(&b3_2, tr)?;
+        let b3 = Tensor::cat(&[b3.apply_t(&b3_3a, tr)?, b3.apply_t(&b3_3b, tr)?], 1)?;
 
-        let bpool = xs.avg_pool2d([3, 3], [1, 1], [1, 1], false, true, 9).apply_t(&bpool, tr);
+        let bpool = xs.avg_pool2d([3, 3], [1, 1], [1, 1], false, true, 9)?.apply_t(&bpool, tr)?;
 
         Tensor::cat(&[b1, b2, b3, bpool], 1)
     })
@@ -134,10 +135,10 @@ pub fn v3(p: &nn::Path, nclasses: i64) -> impl ModuleT {
         .add(conv_bn(p / "Conv2d_1a_3x3", 3, 32, 3, 0, 2))
         .add(conv_bn(p / "Conv2d_2a_3x3", 32, 32, 3, 0, 1))
         .add(conv_bn(p / "Conv2d_2b_3x3", 32, 64, 3, 1, 1))
-        .add_fn(|xs| max_pool2d(&xs.relu(), 3, 2))
+        .add_fn(|xs| max_pool2d(&xs.relu()?, 3, 2))
         .add(conv_bn(p / "Conv2d_3b_1x1", 64, 80, 1, 0, 1))
         .add(conv_bn(p / "Conv2d_4a_3x3", 80, 192, 3, 0, 1))
-        .add_fn(|xs| max_pool2d(&xs.relu(), 3, 2))
+        .add_fn(|xs| max_pool2d(&xs.relu()?, 3, 2))
         .add(inception_a(p / "Mixed_5b", 192, 32))
         .add(inception_a(p / "Mixed_5c", 256, 64))
         .add(inception_a(p / "Mixed_5d", 288, 64))
@@ -149,6 +150,6 @@ pub fn v3(p: &nn::Path, nclasses: i64) -> impl ModuleT {
         .add(inception_d(p / "Mixed_7a", 768))
         .add(inception_e(p / "Mixed_7b", 1280))
         .add(inception_e(p / "Mixed_7c", 2048))
-        .add_fn_t(|xs, train| xs.adaptive_avg_pool2d([1, 1]).dropout(0.5, train).flat_view())
+        .add_fn_t(|xs, train| xs.adaptive_avg_pool2d([1, 1])?.dropout(0.5, train)?.flat_view())
         .add(nn::linear(p / "fc", 2048, nclasses, Default::default()))
 }

--- a/src/vision/mnist.rs
+++ b/src/vision/mnist.rs
@@ -51,13 +51,11 @@ fn read_images_(filename: &std::path::Path) -> Result<Tensor, TchError> {
 }
 
 fn read_labels(filename: &std::path::Path) -> Result<Tensor, TchError> {
-    read_labels_(filename)
-        .map_err(|err| std::io::Error::new(err.kind(), format!("{filename:?} {err}")))
+    read_labels_(filename).map_err(|e| e.io_path_context(filename))
 }
 
 fn read_images(filename: &std::path::Path) -> Result<Tensor, TchError> {
-    read_images_(filename)
-        .map_err(|err| std::io::Error::new(err.kind(), format!("{filename:?} {err}")))
+    read_images_(filename).map_err(|e| e.io_path_context(filename))
 }
 
 pub fn load_dir<T: AsRef<std::path::Path>>(dir: T) -> Result<Dataset, TchError> {

--- a/src/vision/mnist.rs
+++ b/src/vision/mnist.rs
@@ -3,11 +3,11 @@
 //! The files can be obtained from the following link:
 //! <http://yann.lecun.com/exdb/mnist/>
 use super::dataset::Dataset;
-use crate::{Kind, Tensor};
+use crate::{Kind, TchError, Tensor};
 use std::fs::File;
-use std::io::{self, BufReader, Read, Result};
+use std::io::{self, BufReader, Read};
 
-fn read_u32<T: Read>(reader: &mut T) -> Result<u32> {
+fn read_u32<T: Read>(reader: &mut T) -> std::io::Result<u32> {
     let mut b = vec![0u8; 4];
     reader.read_exact(&mut b)?;
     let (result, _) =
@@ -15,7 +15,7 @@ fn read_u32<T: Read>(reader: &mut T) -> Result<u32> {
     Ok(result as u32)
 }
 
-fn check_magic_number<T: Read>(reader: &mut T, expected: u32) -> Result<()> {
+fn check_magic_number<T: Read>(reader: &mut T, expected: u32) -> std::io::Result<()> {
     let magic_number = read_u32(reader)?;
     if magic_number != expected {
         return Err(io::Error::new(
@@ -26,16 +26,16 @@ fn check_magic_number<T: Read>(reader: &mut T, expected: u32) -> Result<()> {
     Ok(())
 }
 
-fn read_labels_(filename: &std::path::Path) -> Result<Tensor> {
+fn read_labels_(filename: &std::path::Path) -> Result<Tensor, TchError> {
     let mut buf_reader = BufReader::new(File::open(filename)?);
     check_magic_number(&mut buf_reader, 2049)?;
     let samples = read_u32(&mut buf_reader)?;
     let mut data = vec![0u8; samples as usize];
     buf_reader.read_exact(&mut data)?;
-    Ok(Tensor::from_slice(&data).to_kind(Kind::Int64))
+    Ok(Tensor::from_slice(&data)?.to_kind(Kind::Int64)?)
 }
 
-fn read_images_(filename: &std::path::Path) -> Result<Tensor> {
+fn read_images_(filename: &std::path::Path) -> Result<Tensor, TchError> {
     let mut buf_reader = BufReader::new(File::open(filename)?);
     check_magic_number(&mut buf_reader, 2051)?;
     let samples = read_u32(&mut buf_reader)?;
@@ -44,23 +44,23 @@ fn read_images_(filename: &std::path::Path) -> Result<Tensor> {
     let data_len = samples * rows * cols;
     let mut data = vec![0u8; data_len as usize];
     buf_reader.read_exact(&mut data)?;
-    let tensor = Tensor::from_slice(&data)
-        .view((i64::from(samples), i64::from(rows * cols)))
-        .to_kind(Kind::Float);
-    Ok(tensor / 255.)
+    let tensor = Tensor::from_slice(&data)?
+        .view((i64::from(samples), i64::from(rows * cols)))?
+        .to_kind(Kind::Float)?;
+    tensor / 255.
 }
 
-fn read_labels(filename: &std::path::Path) -> Result<Tensor> {
+fn read_labels(filename: &std::path::Path) -> Result<Tensor, TchError> {
     read_labels_(filename)
         .map_err(|err| std::io::Error::new(err.kind(), format!("{filename:?} {err}")))
 }
 
-fn read_images(filename: &std::path::Path) -> Result<Tensor> {
+fn read_images(filename: &std::path::Path) -> Result<Tensor, TchError> {
     read_images_(filename)
         .map_err(|err| std::io::Error::new(err.kind(), format!("{filename:?} {err}")))
 }
 
-pub fn load_dir<T: AsRef<std::path::Path>>(dir: T) -> Result<Dataset> {
+pub fn load_dir<T: AsRef<std::path::Path>>(dir: T) -> Result<Dataset, TchError> {
     let dir = dir.as_ref();
     let train_images = read_images(&dir.join("train-images-idx3-ubyte"))?;
     let train_labels = read_labels(&dir.join("train-labels-idx1-ubyte"))?;

--- a/src/vision/resnet.rs
+++ b/src/vision/resnet.rs
@@ -28,8 +28,9 @@ fn basic_block(p: nn::Path, c_in: i64, c_out: i64, stride: i64) -> impl ModuleT 
     let bn2 = nn::batch_norm2d(&p / "bn2", c_out, Default::default());
     let downsample = downsample(&p / "downsample", c_in, c_out, stride);
     nn::func_t(move |xs, train| {
-        let ys = xs.apply(&conv1).apply_t(&bn1, train).relu().apply(&conv2).apply_t(&bn2, train);
-        (xs.apply_t(&downsample, train) + ys).relu()
+        let ys =
+            xs.apply(&conv1)?.apply_t(&bn1, train)?.relu()?.apply(&conv2)?.apply_t(&bn2, train)?;
+        (xs.apply_t(&downsample, train)? + ys)?.relu()
     })
 }
 
@@ -57,16 +58,16 @@ fn resnet(
     let layer4 = basic_layer(p / "layer4", 256, 512, 2, c4);
     let fc = nclasses.map(|n| nn::linear(p / "fc", 512, n, Default::default()));
     nn::func_t(move |xs, train| {
-        xs.apply(&conv1)
-            .apply_t(&bn1, train)
-            .relu()
-            .max_pool2d([3, 3], [2, 2], [1, 1], [1, 1], false)
-            .apply_t(&layer1, train)
-            .apply_t(&layer2, train)
-            .apply_t(&layer3, train)
-            .apply_t(&layer4, train)
-            .adaptive_avg_pool2d([1, 1])
-            .flat_view()
+        xs.apply(&conv1)?
+            .apply_t(&bn1, train)?
+            .relu()?
+            .max_pool2d([3, 3], [2, 2], [1, 1], [1, 1], false)?
+            .apply_t(&layer1, train)?
+            .apply_t(&layer2, train)?
+            .apply_t(&layer3, train)?
+            .apply_t(&layer4, train)?
+            .adaptive_avg_pool2d([1, 1])?
+            .flat_view()?
             .apply_opt(&fc)
     })
 }
@@ -108,15 +109,15 @@ fn bottleneck_block(p: nn::Path, c_in: i64, c_out: i64, stride: i64, e: i64) -> 
     let downsample = downsample(&p / "downsample", c_in, e_dim, stride);
     nn::func_t(move |xs, train| {
         let ys = xs
-            .apply(&conv1)
-            .apply_t(&bn1, train)
-            .relu()
-            .apply(&conv2)
-            .apply_t(&bn2, train)
-            .relu()
-            .apply(&conv3)
-            .apply_t(&bn3, train);
-        (xs.apply_t(&downsample, train) + ys).relu()
+            .apply(&conv1)?
+            .apply_t(&bn1, train)?
+            .relu()?
+            .apply(&conv2)?
+            .apply_t(&bn2, train)?
+            .relu()?
+            .apply(&conv3)?
+            .apply_t(&bn3, train)?;
+        (xs.apply_t(&downsample, train)? + ys)?.relu()
     })
 }
 
@@ -144,16 +145,16 @@ fn bottleneck_resnet(
     let layer4 = bottleneck_layer(p / "layer4", 4 * 256, 512, 2, c4);
     let fc = nclasses.map(|n| nn::linear(p / "fc", 4 * 512, n, Default::default()));
     nn::func_t(move |xs, train| {
-        xs.apply(&conv1)
-            .apply_t(&bn1, train)
-            .relu()
-            .max_pool2d([3, 3], [2, 2], [1, 1], [1, 1], false)
-            .apply_t(&layer1, train)
-            .apply_t(&layer2, train)
-            .apply_t(&layer3, train)
-            .apply_t(&layer4, train)
-            .adaptive_avg_pool2d([1, 1])
-            .flat_view()
+        xs.apply(&conv1)?
+            .apply_t(&bn1, train)?
+            .relu()?
+            .max_pool2d([3, 3], [2, 2], [1, 1], [1, 1], false)?
+            .apply_t(&layer1, train)?
+            .apply_t(&layer2, train)?
+            .apply_t(&layer3, train)?
+            .apply_t(&layer4, train)?
+            .adaptive_avg_pool2d([1, 1])?
+            .flat_view()?
             .apply_opt(&fc)
     })
 }

--- a/src/vision/squeezenet.rs
+++ b/src/vision/squeezenet.rs
@@ -1,8 +1,8 @@
 //! SqueezeNet implementation.
 
-use crate::{nn, nn::Module, nn::ModuleT, Tensor};
+use crate::{nn, nn::Module, nn::ModuleT, TchError, Tensor};
 
-fn max_pool2d(xs: &Tensor) -> Tensor {
+fn max_pool2d(xs: &Tensor) -> Result<Tensor, TchError> {
     xs.max_pool2d([3, 3], [2, 2], [0, 0], [1, 1], true)
 }
 
@@ -12,8 +12,8 @@ fn fire(p: nn::Path, c_in: i64, c_squeeze: i64, c_exp1: i64, c_exp3: i64) -> imp
     let exp1 = nn::conv2d(&p / "expand1x1", c_squeeze, c_exp1, 1, Default::default());
     let exp3 = nn::conv2d(&p / "expand3x3", c_squeeze, c_exp3, 3, cfg3);
     nn::func(move |xs| {
-        let xs = xs.apply(&squeeze).relu();
-        Tensor::cat(&[xs.apply(&exp1).relu(), xs.apply(&exp3).relu()], 1)
+        let xs = xs.apply(&squeeze)?.relu()?;
+        Tensor::cat(&[xs.apply(&exp1)?.relu()?, xs.apply(&exp3)?.relu()?], 1)
     })
 }
 
@@ -56,7 +56,7 @@ fn squeezenet(p: &nn::Path, v1_0: bool, nclasses: i64) -> impl ModuleT {
     features
         .add_fn_t(|xs, train| xs.dropout(0.5, train))
         .add(nn::conv2d(&c_p / "1", 512, nclasses, 1, final_conv_cfg))
-        .add_fn(|xs| xs.relu().adaptive_avg_pool2d([1, 1]).flat_view())
+        .add_fn(|xs| xs.relu()?.adaptive_avg_pool2d([1, 1])?.flat_view())
 }
 
 pub fn v1_0(p: &nn::Path, nclasses: i64) -> impl ModuleT {

--- a/src/wrappers/tensor_fallible_generated.rs
+++ b/src/wrappers/tensor_fallible_generated.rs
@@ -15,7 +15,7 @@ fn ptr_list<T: Borrow<Tensor>>(l: &[T]) -> Vec<*mut C_tensor> {
 }
 
 impl Tensor {
-    pub fn f_internal_and_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn internal_and_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg___and__(
             c_tensors.as_mut_ptr(),
@@ -25,7 +25,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_and_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn internal_and_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg___and__tensor_(
             c_tensors.as_mut_ptr(),
@@ -35,7 +35,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_iand_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn internal_iand_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg___iand__(
             c_tensors.as_mut_ptr(),
@@ -45,7 +45,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_iand_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn internal_iand_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg___iand__tensor_(
             c_tensors.as_mut_ptr(),
@@ -55,7 +55,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_ilshift_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn internal_ilshift_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg___ilshift__(
             c_tensors.as_mut_ptr(),
@@ -65,7 +65,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_ilshift_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn internal_ilshift_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg___ilshift__tensor_(
             c_tensors.as_mut_ptr(),
@@ -75,7 +75,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_ior_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn internal_ior_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg___ior__(
             c_tensors.as_mut_ptr(),
@@ -85,7 +85,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_ior_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn internal_ior_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg___ior__tensor_(
             c_tensors.as_mut_ptr(),
@@ -95,7 +95,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_irshift_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn internal_irshift_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg___irshift__(
             c_tensors.as_mut_ptr(),
@@ -105,7 +105,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_irshift_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn internal_irshift_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg___irshift__tensor_(
             c_tensors.as_mut_ptr(),
@@ -115,7 +115,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_ixor_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn internal_ixor_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg___ixor__(
             c_tensors.as_mut_ptr(),
@@ -125,7 +125,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_ixor_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn internal_ixor_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg___ixor__tensor_(
             c_tensors.as_mut_ptr(),
@@ -135,7 +135,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_lshift_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn internal_lshift_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg___lshift__(
             c_tensors.as_mut_ptr(),
@@ -145,7 +145,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_lshift_scalar_out_<S: Into<Scalar>>(
+    pub fn internal_lshift_scalar_out_<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
@@ -160,7 +160,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_lshift_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn internal_lshift_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg___lshift__tensor_(
             c_tensors.as_mut_ptr(),
@@ -170,7 +170,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_lshift_tensor_out_(
+    pub fn internal_lshift_tensor_out_(
         &self,
         out: &Tensor,
         other: &Tensor,
@@ -185,19 +185,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_or_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn internal_or_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg___or__(c_tensors.as_mut_ptr(), self.c_tensor, other.into().c_scalar));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_or_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn internal_or_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg___or__tensor_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_rshift_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn internal_rshift_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg___rshift__(
             c_tensors.as_mut_ptr(),
@@ -207,7 +207,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_rshift_scalar_out_<S: Into<Scalar>>(
+    pub fn internal_rshift_scalar_out_<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
@@ -222,7 +222,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_rshift_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn internal_rshift_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg___rshift__tensor_(
             c_tensors.as_mut_ptr(),
@@ -232,7 +232,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_rshift_tensor_out_(
+    pub fn internal_rshift_tensor_out_(
         &self,
         out: &Tensor,
         other: &Tensor,
@@ -247,7 +247,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_xor_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn internal_xor_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg___xor__(
             c_tensors.as_mut_ptr(),
@@ -257,7 +257,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_xor_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn internal_xor_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg___xor__tensor_(
             c_tensors.as_mut_ptr(),
@@ -267,7 +267,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_adaptive_avg_pool2d(
+    pub fn internal_adaptive_avg_pool2d(
         &self,
         output_size: impl IntList,
     ) -> Result<Tensor, TchError> {
@@ -281,7 +281,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_adaptive_avg_pool2d_backward(
+    pub fn internal_adaptive_avg_pool2d_backward(
         &self,
         grad_output: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -294,7 +294,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_adaptive_avg_pool2d_backward_out(
+    pub fn internal_adaptive_avg_pool2d_backward_out(
         &self,
         out: &Tensor,
         grad_output: &Tensor,
@@ -309,7 +309,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_adaptive_avg_pool2d_out(
+    pub fn internal_adaptive_avg_pool2d_out(
         &self,
         out: &Tensor,
         output_size: impl IntList,
@@ -325,7 +325,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_adaptive_avg_pool3d(
+    pub fn internal_adaptive_avg_pool3d(
         &self,
         output_size: impl IntList,
     ) -> Result<Tensor, TchError> {
@@ -339,7 +339,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_adaptive_avg_pool3d_backward(
+    pub fn internal_adaptive_avg_pool3d_backward(
         &self,
         grad_output: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -352,7 +352,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_adaptive_avg_pool3d_backward_out(
+    pub fn internal_adaptive_avg_pool3d_backward_out(
         &self,
         out: &Tensor,
         grad_output: &Tensor,
@@ -367,7 +367,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_adaptive_avg_pool3d_out(
+    pub fn internal_adaptive_avg_pool3d_out(
         &self,
         out: &Tensor,
         output_size: impl IntList,
@@ -383,7 +383,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_add_batch_dim(&self, batch_dim: i64, level: i64) -> Result<Tensor, TchError> {
+    pub fn internal_add_batch_dim(&self, batch_dim: i64, level: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__add_batch_dim(
             c_tensors.as_mut_ptr(),
@@ -394,23 +394,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_add_relu(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn internal_add_relu(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__add_relu(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_add_relu_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn internal_add_relu_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__add_relu_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_add_relu_out(
-        &self,
-        out: &Tensor,
-        other: &Tensor,
-    ) -> Result<Tensor, TchError> {
+    pub fn internal_add_relu_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__add_relu_out(
             c_tensors.as_mut_ptr(),
@@ -421,10 +417,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_add_relu_scalar<S: Into<Scalar>>(
-        &self,
-        other: S,
-    ) -> Result<Tensor, TchError> {
+    pub fn internal_add_relu_scalar<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__add_relu_scalar(
             c_tensors.as_mut_ptr(),
@@ -434,7 +427,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_add_relu_scalar_<S: Into<Scalar>>(
+    pub fn internal_add_relu_scalar_<S: Into<Scalar>>(
         &mut self,
         other: S,
     ) -> Result<Tensor, TchError> {
@@ -447,7 +440,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_add_relu_scalar_out<S: Into<Scalar>>(
+    pub fn internal_add_relu_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
@@ -462,7 +455,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_addmm_activation(
+    pub fn internal_addmm_activation(
         &self,
         mat1: &Tensor,
         mat2: &Tensor,
@@ -479,7 +472,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_addmm_activation_out(
+    pub fn internal_addmm_activation_out(
         &self,
         out: &Tensor,
         mat1: &Tensor,
@@ -498,13 +491,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_aminmax(&self) -> Result<(Tensor, Tensor), TchError> {
+    pub fn internal_aminmax(&self) -> Result<(Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 2];
         unsafe_torch_err!(atg__aminmax(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_aminmax_dim(
+    pub fn internal_aminmax_dim(
         &self,
         dim: i64,
         keepdim: bool,
@@ -519,7 +512,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_aminmax_dim_out(
+    pub fn internal_aminmax_dim_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -538,7 +531,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_aminmax_out(
+    pub fn internal_aminmax_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -553,7 +546,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_amp_update_scale(
+    pub fn internal_amp_update_scale(
         &self,
         growth_tracker: &Tensor,
         found_inf: &Tensor,
@@ -574,7 +567,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_amp_update_scale_(
+    pub fn internal_amp_update_scale_(
         &mut self,
         growth_tracker: &Tensor,
         found_inf: &Tensor,
@@ -595,7 +588,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_amp_update_scale_out(
+    pub fn internal_amp_update_scale_out(
         &self,
         out: &Tensor,
         growth_tracker: &Tensor,
@@ -618,7 +611,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_assert_tensor_metadata(
+    pub fn internal_assert_tensor_metadata(
         a: &Tensor,
         size: impl IntListOption,
         stride: impl IntListOption,
@@ -635,7 +628,7 @@ impl Tensor {
         Ok(())
     }
 
-    pub fn f_internal_autocast_to_full_precision(
+    pub fn internal_autocast_to_full_precision(
         &self,
         cuda_enabled: bool,
         cpu_enabled: bool,
@@ -650,7 +643,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_autocast_to_reduced_precision(
+    pub fn internal_autocast_to_reduced_precision(
         &self,
         cuda_enabled: bool,
         cpu_enabled: bool,
@@ -669,7 +662,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_cast_byte(&self, non_blocking: bool) -> Result<Tensor, TchError> {
+    pub fn internal_cast_byte(&self, non_blocking: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__cast_byte(
             c_tensors.as_mut_ptr(),
@@ -679,7 +672,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_cast_char(&self, non_blocking: bool) -> Result<Tensor, TchError> {
+    pub fn internal_cast_char(&self, non_blocking: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__cast_char(
             c_tensors.as_mut_ptr(),
@@ -689,7 +682,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_cast_double(&self, non_blocking: bool) -> Result<Tensor, TchError> {
+    pub fn internal_cast_double(&self, non_blocking: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__cast_double(
             c_tensors.as_mut_ptr(),
@@ -699,7 +692,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_cast_float(&self, non_blocking: bool) -> Result<Tensor, TchError> {
+    pub fn internal_cast_float(&self, non_blocking: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__cast_float(
             c_tensors.as_mut_ptr(),
@@ -709,7 +702,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_cast_half(&self, non_blocking: bool) -> Result<Tensor, TchError> {
+    pub fn internal_cast_half(&self, non_blocking: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__cast_half(
             c_tensors.as_mut_ptr(),
@@ -719,7 +712,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_cast_int(&self, non_blocking: bool) -> Result<Tensor, TchError> {
+    pub fn internal_cast_int(&self, non_blocking: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__cast_int(
             c_tensors.as_mut_ptr(),
@@ -729,7 +722,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_cast_long(&self, non_blocking: bool) -> Result<Tensor, TchError> {
+    pub fn internal_cast_long(&self, non_blocking: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__cast_long(
             c_tensors.as_mut_ptr(),
@@ -739,7 +732,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_cast_short(&self, non_blocking: bool) -> Result<Tensor, TchError> {
+    pub fn internal_cast_short(&self, non_blocking: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__cast_short(
             c_tensors.as_mut_ptr(),
@@ -749,7 +742,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_cdist_backward(
+    pub fn internal_cdist_backward(
         grad: &Tensor,
         x1: &Tensor,
         x2: &Tensor,
@@ -768,7 +761,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_cdist_backward_out(
+    pub fn internal_cdist_backward_out(
         out: &Tensor,
         grad: &Tensor,
         x1: &Tensor,
@@ -789,7 +782,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_cholesky_solve_helper(
+    pub fn internal_cholesky_solve_helper(
         &self,
         a: &Tensor,
         upper: bool,
@@ -804,7 +797,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_cholesky_solve_helper_out(
+    pub fn internal_cholesky_solve_helper_out(
         &self,
         out: &Tensor,
         a: &Tensor,
@@ -821,7 +814,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_chunk_grad_outputs_efficient_attention(
+    pub fn internal_chunk_grad_outputs_efficient_attention(
         query: &Tensor,
         key: &Tensor,
         value: &Tensor,
@@ -839,19 +832,19 @@ impl Tensor {
         Ok(return_ != 0)
     }
 
-    pub fn f_internal_coalesce(&self) -> Result<Tensor, TchError> {
+    pub fn internal_coalesce(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__coalesce(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_coalesce_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn internal_coalesce_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__coalesce_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_coalesced(&self, coalesced: bool) -> Result<Tensor, TchError> {
+    pub fn internal_coalesced(&self, coalesced: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__coalesced(
             c_tensors.as_mut_ptr(),
@@ -861,7 +854,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_coalesced_(&mut self, coalesced: bool) -> Result<Tensor, TchError> {
+    pub fn internal_coalesced_(&mut self, coalesced: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__coalesced_(
             c_tensors.as_mut_ptr(),
@@ -871,7 +864,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_coalesced_out(
+    pub fn internal_coalesced_out(
         &self,
         out: &Tensor,
         coalesced: bool,
@@ -886,7 +879,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_compute_linear_combination(
+    pub fn internal_compute_linear_combination(
         &self,
         coefficients: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -899,7 +892,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_compute_linear_combination_out(
+    pub fn internal_compute_linear_combination_out(
         &self,
         out: &Tensor,
         coefficients: &Tensor,
@@ -914,31 +907,31 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_conj(&self) -> Result<Tensor, TchError> {
+    pub fn internal_conj(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__conj(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_conj_copy(&self) -> Result<Tensor, TchError> {
+    pub fn internal_conj_copy(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__conj_copy(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_conj_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn internal_conj_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__conj_copy_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_conj_physical(&self) -> Result<Tensor, TchError> {
+    pub fn internal_conj_physical(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__conj_physical(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_conj_physical_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn internal_conj_physical_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__conj_physical_out(
             c_tensors.as_mut_ptr(),
@@ -948,7 +941,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_conv_depthwise2d<T: Borrow<Tensor>>(
+    pub fn internal_conv_depthwise2d<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         kernel_size: impl IntList,
@@ -975,7 +968,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_conv_depthwise2d_out<T: Borrow<Tensor>>(
+    pub fn internal_conv_depthwise2d_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -1004,7 +997,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_convert_indices_from_coo_to_csr(
+    pub fn internal_convert_indices_from_coo_to_csr(
         &self,
         size: i64,
         out_int32: bool,
@@ -1019,7 +1012,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_convert_indices_from_coo_to_csr_out(
+    pub fn internal_convert_indices_from_coo_to_csr_out(
         &self,
         out: &Tensor,
         size: i64,
@@ -1036,7 +1029,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_convert_indices_from_csr_to_coo(
+    pub fn internal_convert_indices_from_csr_to_coo(
         crow_indices: &Tensor,
         col_indices: &Tensor,
         out_int32: bool,
@@ -1053,7 +1046,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_convert_indices_from_csr_to_coo_out(
+    pub fn internal_convert_indices_from_csr_to_coo_out(
         out: &Tensor,
         crow_indices: &Tensor,
         col_indices: &Tensor,
@@ -1072,7 +1065,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_convolution<T: Borrow<Tensor>>(
+    pub fn internal_convolution<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -1111,7 +1104,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_convolution_deprecated<T: Borrow<Tensor>>(
+    pub fn internal_convolution_deprecated<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -1148,7 +1141,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_convolution_mode<T: Borrow<Tensor>>(
+    pub fn internal_convolution_mode<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -1174,7 +1167,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_convolution_out<T: Borrow<Tensor>>(
+    pub fn internal_convolution_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -1215,11 +1208,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_copy_from(
-        &self,
-        dst: &Tensor,
-        non_blocking: bool,
-    ) -> Result<Tensor, TchError> {
+    pub fn internal_copy_from(&self, dst: &Tensor, non_blocking: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__copy_from(
             c_tensors.as_mut_ptr(),
@@ -1230,7 +1219,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_copy_from_and_resize(&self, dst: &Tensor) -> Result<Tensor, TchError> {
+    pub fn internal_copy_from_and_resize(&self, dst: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__copy_from_and_resize(
             c_tensors.as_mut_ptr(),
@@ -1240,7 +1229,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_copy_from_and_resize_out(
+    pub fn internal_copy_from_and_resize_out(
         &self,
         out: &Tensor,
         dst: &Tensor,
@@ -1255,7 +1244,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_copy_from_out(
+    pub fn internal_copy_from_out(
         &self,
         out: &Tensor,
         dst: &Tensor,
@@ -1272,7 +1261,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_ctc_loss(
+    pub fn internal_ctc_loss(
         log_probs: &Tensor,
         targets: &Tensor,
         input_lengths: impl IntList,
@@ -1295,7 +1284,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_ctc_loss_backward(
+    pub fn internal_ctc_loss_backward(
         grad: &Tensor,
         log_probs: &Tensor,
         targets: &Tensor,
@@ -1324,7 +1313,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_ctc_loss_backward_out(
+    pub fn internal_ctc_loss_backward_out(
         out: &Tensor,
         grad: &Tensor,
         log_probs: &Tensor,
@@ -1355,7 +1344,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_ctc_loss_backward_tensor(
+    pub fn internal_ctc_loss_backward_tensor(
         grad: &Tensor,
         log_probs: &Tensor,
         targets: &Tensor,
@@ -1382,7 +1371,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_ctc_loss_out(
+    pub fn internal_ctc_loss_out(
         out0: &Tensor,
         out1: &Tensor,
         log_probs: &Tensor,
@@ -1409,7 +1398,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_ctc_loss_tensor(
+    pub fn internal_ctc_loss_tensor(
         log_probs: &Tensor,
         targets: &Tensor,
         input_lengths: &Tensor,
@@ -1430,7 +1419,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_ctc_loss_tensor_out(
+    pub fn internal_ctc_loss_tensor_out(
         out0: &Tensor,
         out1: &Tensor,
         log_probs: &Tensor,
@@ -1455,7 +1444,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_cudnn_ctc_loss(
+    pub fn internal_cudnn_ctc_loss(
         log_probs: &Tensor,
         targets: &Tensor,
         input_lengths: impl IntList,
@@ -1480,7 +1469,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_cudnn_ctc_loss_out(
+    pub fn internal_cudnn_ctc_loss_out(
         out0: &Tensor,
         out1: &Tensor,
         log_probs: &Tensor,
@@ -1509,7 +1498,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_cudnn_ctc_loss_tensor(
+    pub fn internal_cudnn_ctc_loss_tensor(
         log_probs: &Tensor,
         targets: &Tensor,
         input_lengths: &Tensor,
@@ -1532,7 +1521,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_cudnn_init_dropout_state(
+    pub fn internal_cudnn_init_dropout_state(
         dropout: f64,
         train: bool,
         dropout_seed: i64,
@@ -1550,7 +1539,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_cudnn_init_dropout_state_out(
+    pub fn internal_cudnn_init_dropout_state_out(
         out: &Tensor,
         dropout: f64,
         train: bool,
@@ -1567,7 +1556,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_cudnn_rnn<T: Borrow<Tensor>>(
+    pub fn internal_cudnn_rnn<T: Borrow<Tensor>>(
         &self,
         weight: &[T],
         weight_stride0: i64,
@@ -1616,7 +1605,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_cudnn_rnn_flatten_weight<T: Borrow<Tensor>>(
+    pub fn internal_cudnn_rnn_flatten_weight<T: Borrow<Tensor>>(
         weight_arr: &[T],
         weight_stride0: i64,
         input_size: i64,
@@ -1644,7 +1633,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_cudnn_rnn_flatten_weight_out<T: Borrow<Tensor>>(
+    pub fn internal_cudnn_rnn_flatten_weight_out<T: Borrow<Tensor>>(
         out: &Tensor,
         weight_arr: &[T],
         weight_stride0: i64,
@@ -1674,7 +1663,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_cudnn_rnn_out<T: Borrow<Tensor>>(
+    pub fn internal_cudnn_rnn_out<T: Borrow<Tensor>>(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -1733,43 +1722,43 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_cufft_get_plan_cache_max_size(device_index: i64) -> Result<i64, TchError> {
+    pub fn internal_cufft_get_plan_cache_max_size(device_index: i64) -> Result<i64, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg__cufft_get_plan_cache_max_size(device_index));
         Ok(return_)
     }
 
-    pub fn f_internal_cufft_get_plan_cache_size(device_index: i64) -> Result<i64, TchError> {
+    pub fn internal_cufft_get_plan_cache_size(device_index: i64) -> Result<i64, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg__cufft_get_plan_cache_size(device_index));
         Ok(return_)
     }
 
-    pub fn f_internal_debug_has_internal_overlap(&self) -> Result<i64, TchError> {
+    pub fn internal_debug_has_internal_overlap(&self) -> Result<i64, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg__debug_has_internal_overlap(self.c_tensor));
         Ok(return_)
     }
 
-    pub fn f_internal_dim_arange(like: &Tensor, dim: i64) -> Result<Tensor, TchError> {
+    pub fn internal_dim_arange(like: &Tensor, dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__dim_arange(c_tensors.as_mut_ptr(), like.c_tensor, dim));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_dimi(&self) -> Result<i64, TchError> {
+    pub fn internal_dimi(&self) -> Result<i64, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg__dimi(self.c_tensor));
         Ok(return_)
     }
 
-    pub fn f_internal_dimv(&self) -> Result<i64, TchError> {
+    pub fn internal_dimv(&self) -> Result<i64, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg__dimv(self.c_tensor));
         Ok(return_)
     }
 
-    pub fn f_internal_dirichlet_grad(
+    pub fn internal_dirichlet_grad(
         x: &Tensor,
         alpha: &Tensor,
         total: &Tensor,
@@ -1784,7 +1773,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_dirichlet_grad_out(
+    pub fn internal_dirichlet_grad_out(
         out: &Tensor,
         x: &Tensor,
         alpha: &Tensor,
@@ -1801,7 +1790,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_efficient_attention_backward(
+    pub fn internal_efficient_attention_backward(
         grad_out_: &Tensor,
         query: &Tensor,
         key: &Tensor,
@@ -1830,7 +1819,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_efficientzerotensor(
+    pub fn internal_efficientzerotensor(
         size: impl IntList,
         options: (Kind, Device),
     ) -> Result<Tensor, TchError> {
@@ -1845,7 +1834,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_efficientzerotensor_out(
+    pub fn internal_efficientzerotensor_out(
         out: &Tensor,
         size: impl IntList,
     ) -> Result<Tensor, TchError> {
@@ -1859,7 +1848,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_embedding_bag<T: Borrow<Tensor>>(
+    pub fn internal_embedding_bag<T: Borrow<Tensor>>(
         weight: &Tensor,
         indices: &Tensor,
         offsets: &Tensor,
@@ -1891,7 +1880,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_embedding_bag_backward<T: Borrow<Tensor>>(
+    pub fn internal_embedding_bag_backward<T: Borrow<Tensor>>(
         grad: &Tensor,
         indices: &Tensor,
         offsets: &Tensor,
@@ -1924,7 +1913,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_embedding_bag_dense_backward<T: Borrow<Tensor>>(
+    pub fn internal_embedding_bag_dense_backward<T: Borrow<Tensor>>(
         grad: &Tensor,
         indices: &Tensor,
         offset2bag: &Tensor,
@@ -1953,7 +1942,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_embedding_bag_dense_backward_out<T: Borrow<Tensor>>(
+    pub fn internal_embedding_bag_dense_backward_out<T: Borrow<Tensor>>(
         out: &Tensor,
         grad: &Tensor,
         indices: &Tensor,
@@ -1984,7 +1973,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_embedding_bag_forward_only<T: Borrow<Tensor>>(
+    pub fn internal_embedding_bag_forward_only<T: Borrow<Tensor>>(
         weight: &Tensor,
         indices: &Tensor,
         offsets: &Tensor,
@@ -2016,7 +2005,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_embedding_bag_forward_only_out<T: Borrow<Tensor>>(
+    pub fn internal_embedding_bag_forward_only_out<T: Borrow<Tensor>>(
         out0: &Tensor,
         out1: &Tensor,
         out2: &Tensor,
@@ -2056,7 +2045,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_embedding_bag_out<T: Borrow<Tensor>>(
+    pub fn internal_embedding_bag_out<T: Borrow<Tensor>>(
         out0: &Tensor,
         out1: &Tensor,
         out2: &Tensor,
@@ -2096,7 +2085,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_embedding_bag_per_sample_weights_backward(
+    pub fn internal_embedding_bag_per_sample_weights_backward(
         grad: &Tensor,
         weight: &Tensor,
         indices: &Tensor,
@@ -2119,7 +2108,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_embedding_bag_per_sample_weights_backward_out(
+    pub fn internal_embedding_bag_per_sample_weights_backward_out(
         out: &Tensor,
         grad: &Tensor,
         weight: &Tensor,
@@ -2144,7 +2133,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_embedding_bag_sparse_backward<T: Borrow<Tensor>>(
+    pub fn internal_embedding_bag_sparse_backward<T: Borrow<Tensor>>(
         grad: &Tensor,
         indices: &Tensor,
         offsets: &Tensor,
@@ -2173,7 +2162,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_empty_affine_quantized(
+    pub fn internal_empty_affine_quantized(
         size: impl IntList,
         options: (Kind, Device),
         scale: f64,
@@ -2192,7 +2181,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_empty_affine_quantized_out(
+    pub fn internal_empty_affine_quantized_out(
         out: &Tensor,
         size: impl IntList,
         scale: f64,
@@ -2210,7 +2199,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_empty_per_channel_affine_quantized(
+    pub fn internal_empty_per_channel_affine_quantized(
         size: impl IntList,
         scales: &Tensor,
         zero_points: &Tensor,
@@ -2231,7 +2220,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_empty_per_channel_affine_quantized_out(
+    pub fn internal_empty_per_channel_affine_quantized_out(
         out: &Tensor,
         size: impl IntList,
         scales: &Tensor,
@@ -2251,13 +2240,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_euclidean_dist(x1: &Tensor, x2: &Tensor) -> Result<Tensor, TchError> {
+    pub fn internal_euclidean_dist(x1: &Tensor, x2: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__euclidean_dist(c_tensors.as_mut_ptr(), x1.c_tensor, x2.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_euclidean_dist_out(
+    pub fn internal_euclidean_dist_out(
         out: &Tensor,
         x1: &Tensor,
         x2: &Tensor,
@@ -2272,7 +2261,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_fake_quantize_learnable_per_channel_affine(
+    pub fn internal_fake_quantize_learnable_per_channel_affine(
         &self,
         scale: &Tensor,
         zero_point: &Tensor,
@@ -2295,7 +2284,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_fake_quantize_learnable_per_channel_affine_backward(
+    pub fn internal_fake_quantize_learnable_per_channel_affine_backward(
         &self,
         grad: &Tensor,
         scale: &Tensor,
@@ -2324,7 +2313,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_fake_quantize_learnable_per_channel_affine_out(
+    pub fn internal_fake_quantize_learnable_per_channel_affine_out(
         &self,
         out: &Tensor,
         scale: &Tensor,
@@ -2349,7 +2338,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_fake_quantize_learnable_per_tensor_affine(
+    pub fn internal_fake_quantize_learnable_per_tensor_affine(
         &self,
         scale: &Tensor,
         zero_point: &Tensor,
@@ -2370,7 +2359,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_fake_quantize_learnable_per_tensor_affine_backward(
+    pub fn internal_fake_quantize_learnable_per_tensor_affine_backward(
         &self,
         grad: &Tensor,
         scale: &Tensor,
@@ -2397,7 +2386,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_fake_quantize_learnable_per_tensor_affine_out(
+    pub fn internal_fake_quantize_learnable_per_tensor_affine_out(
         &self,
         out: &Tensor,
         scale: &Tensor,
@@ -2420,7 +2409,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_fake_quantize_per_tensor_affine_cachemask_tensor_qparams(
+    pub fn internal_fake_quantize_per_tensor_affine_cachemask_tensor_qparams(
         &self,
         scale: &Tensor,
         zero_point: &Tensor,
@@ -2441,7 +2430,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_fake_quantize_per_tensor_affine_cachemask_tensor_qparams_out(
+    pub fn internal_fake_quantize_per_tensor_affine_cachemask_tensor_qparams_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -2466,7 +2455,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_fft_c2c(
+    pub fn internal_fft_c2c(
         &self,
         dim: impl IntList,
         normalization: i64,
@@ -2484,7 +2473,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_fft_c2c_out(
+    pub fn internal_fft_c2c_out(
         &self,
         out: &Tensor,
         dim: impl IntList,
@@ -2504,7 +2493,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_fft_c2r(
+    pub fn internal_fft_c2r(
         &self,
         dim: impl IntList,
         normalization: i64,
@@ -2522,7 +2511,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_fft_c2r_out(
+    pub fn internal_fft_c2r_out(
         &self,
         out: &Tensor,
         dim: impl IntList,
@@ -2542,7 +2531,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_fft_r2c(
+    pub fn internal_fft_r2c(
         &self,
         dim: impl IntList,
         normalization: i64,
@@ -2560,7 +2549,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_fft_r2c_out(
+    pub fn internal_fft_r2c_out(
         &self,
         out: &Tensor,
         dim: impl IntList,
@@ -2580,7 +2569,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_flash_attention_backward(
+    pub fn internal_flash_attention_backward(
         grad_out: &Tensor,
         query: &Tensor,
         key: &Tensor,
@@ -2621,12 +2610,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_foobar(
-        &self,
-        arg1: bool,
-        arg2: bool,
-        arg3: bool,
-    ) -> Result<Tensor, TchError> {
+    pub fn internal_foobar(&self, arg1: bool, arg2: bool, arg3: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__foobar(
             c_tensors.as_mut_ptr(),
@@ -2638,7 +2622,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_foobar_out(
+    pub fn internal_foobar_out(
         &self,
         out: &Tensor,
         arg1: bool,
@@ -2657,13 +2641,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_fused_dropout(&self, p: f64) -> Result<(Tensor, Tensor), TchError> {
+    pub fn internal_fused_dropout(&self, p: f64) -> Result<(Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 2];
         unsafe_torch_err!(atg__fused_dropout(c_tensors.as_mut_ptr(), self.c_tensor, p));
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_fused_dropout_out(
+    pub fn internal_fused_dropout_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -2680,7 +2664,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_fused_moving_avg_obs_fq_helper(
+    pub fn internal_fused_moving_avg_obs_fq_helper(
         &self,
         observer_on: &Tensor,
         fake_quant_on: &Tensor,
@@ -2715,7 +2699,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_fused_moving_avg_obs_fq_helper_functional(
+    pub fn internal_fused_moving_avg_obs_fq_helper_functional(
         &self,
         observer_on: &Tensor,
         fake_quant_on: &Tensor,
@@ -2757,7 +2741,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_fused_moving_avg_obs_fq_helper_out(
+    pub fn internal_fused_moving_avg_obs_fq_helper_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -2796,7 +2780,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_fused_sdp_choice<T: Borrow<Tensor>>(
+    pub fn internal_fused_sdp_choice<T: Borrow<Tensor>>(
         query: &Tensor,
         key: &Tensor,
         value: &Tensor,
@@ -2818,19 +2802,19 @@ impl Tensor {
         Ok(return_)
     }
 
-    pub fn f_internal_fw_primal(&self, level: i64) -> Result<Tensor, TchError> {
+    pub fn internal_fw_primal(&self, level: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__fw_primal(c_tensors.as_mut_ptr(), self.c_tensor, level));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_fw_primal_copy(&self, level: i64) -> Result<Tensor, TchError> {
+    pub fn internal_fw_primal_copy(&self, level: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__fw_primal_copy(c_tensors.as_mut_ptr(), self.c_tensor, level));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_fw_primal_copy_out(
+    pub fn internal_fw_primal_copy_out(
         &self,
         out: &Tensor,
         level: i64,
@@ -2845,7 +2829,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_gather_sparse_backward(
+    pub fn internal_gather_sparse_backward(
         &self,
         dim: i64,
         index: &Tensor,
@@ -2862,7 +2846,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_grid_sampler_2d_cpu_fallback(
+    pub fn internal_grid_sampler_2d_cpu_fallback(
         &self,
         grid: &Tensor,
         interpolation_mode: i64,
@@ -2881,7 +2865,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_grid_sampler_2d_cpu_fallback_backward(
+    pub fn internal_grid_sampler_2d_cpu_fallback_backward(
         &self,
         grad_output: &Tensor,
         grid: &Tensor,
@@ -2902,7 +2886,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_grid_sampler_2d_cpu_fallback_out(
+    pub fn internal_grid_sampler_2d_cpu_fallback_out(
         &self,
         out: &Tensor,
         grid: &Tensor,
@@ -2923,7 +2907,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_has_compatible_shallow_copy_type(
+    pub fn internal_has_compatible_shallow_copy_type(
         &self,
         from: &Tensor,
     ) -> Result<bool, TchError> {
@@ -2934,13 +2918,13 @@ impl Tensor {
         Ok(return_ != 0)
     }
 
-    pub fn f_internal_has_same_storage_numel(&self, other: &Tensor) -> Result<bool, TchError> {
+    pub fn internal_has_same_storage_numel(&self, other: &Tensor) -> Result<bool, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg__has_same_storage_numel(self.c_tensor, other.c_tensor));
         Ok(return_ != 0)
     }
 
-    pub fn f_internal_histogramdd_bin_edges<T: Borrow<Tensor>>(
+    pub fn internal_histogramdd_bin_edges<T: Borrow<Tensor>>(
         &self,
         bins: impl IntList,
         range: impl DoubleList,
@@ -2970,7 +2954,7 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_internal_histogramdd_bin_edges_out<T: Borrow<Tensor>>(
+    pub fn internal_histogramdd_bin_edges_out<T: Borrow<Tensor>>(
         &self,
         out: &[T],
         bins: impl IntList,
@@ -2992,7 +2976,7 @@ impl Tensor {
         Ok(())
     }
 
-    pub fn f_internal_histogramdd_from_bin_cts<T: Borrow<Tensor>>(
+    pub fn internal_histogramdd_from_bin_cts<T: Borrow<Tensor>>(
         &self,
         bins: impl IntList,
         range: impl DoubleList,
@@ -3013,7 +2997,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_histogramdd_from_bin_cts_out<T: Borrow<Tensor>>(
+    pub fn internal_histogramdd_from_bin_cts_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         bins: impl IntList,
@@ -3036,7 +3020,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_histogramdd_from_bin_tensors<T: Borrow<Tensor>>(
+    pub fn internal_histogramdd_from_bin_tensors<T: Borrow<Tensor>>(
         &self,
         bins: &[T],
         weight: Option<T>,
@@ -3054,7 +3038,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_histogramdd_from_bin_tensors_out<T: Borrow<Tensor>>(
+    pub fn internal_histogramdd_from_bin_tensors_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         bins: &[T],
@@ -3074,7 +3058,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_index_put_impl<T: Borrow<Tensor>>(
+    pub fn internal_index_put_impl<T: Borrow<Tensor>>(
         &self,
         indices: &[Option<T>],
         values: &Tensor,
@@ -3094,7 +3078,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_index_put_impl_<T: Borrow<Tensor>>(
+    pub fn internal_index_put_impl_<T: Borrow<Tensor>>(
         &mut self,
         indices: &[Option<T>],
         values: &Tensor,
@@ -3114,7 +3098,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_index_put_impl_out<T: Borrow<Tensor>>(
+    pub fn internal_index_put_impl_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         indices: &[Option<T>],
@@ -3136,19 +3120,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_indices(&self) -> Result<Tensor, TchError> {
+    pub fn internal_indices(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__indices(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_indices_copy(&self) -> Result<Tensor, TchError> {
+    pub fn internal_indices_copy(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__indices_copy(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_indices_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn internal_indices_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__indices_copy_out(
             c_tensors.as_mut_ptr(),
@@ -3158,25 +3142,25 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_is_all_true(&self) -> Result<Tensor, TchError> {
+    pub fn internal_is_all_true(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__is_all_true(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_is_any_true(&self) -> Result<Tensor, TchError> {
+    pub fn internal_is_any_true(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__is_any_true(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_is_zerotensor(&self) -> Result<bool, TchError> {
+    pub fn internal_is_zerotensor(&self) -> Result<bool, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg__is_zerotensor(self.c_tensor));
         Ok(return_ != 0)
     }
 
-    pub fn f_internal_linalg_check_errors(
+    pub fn internal_linalg_check_errors(
         info: &Tensor,
         api_name: &str,
         is_matrix: bool,
@@ -3190,7 +3174,7 @@ impl Tensor {
         Ok(())
     }
 
-    pub fn f_internal_linalg_det(a: &Tensor) -> Result<(Tensor, Tensor, Tensor), TchError> {
+    pub fn internal_linalg_det(a: &Tensor) -> Result<(Tensor, Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 3];
         unsafe_torch_err!(atg__linalg_det(c_tensors.as_mut_ptr(), a.c_tensor));
         Ok((
@@ -3200,7 +3184,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_linalg_det_result(
+    pub fn internal_linalg_det_result(
         result: &Tensor,
         lu: &Tensor,
         pivots: &Tensor,
@@ -3221,7 +3205,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_linalg_eigh(
+    pub fn internal_linalg_eigh(
         a: &Tensor,
         uplo: &str,
         compute_v: bool,
@@ -3237,7 +3221,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_linalg_eigh_eigenvalues(
+    pub fn internal_linalg_eigh_eigenvalues(
         eigenvalues: &Tensor,
         eigenvectors: &Tensor,
         a: &Tensor,
@@ -3257,7 +3241,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_linalg_slogdet(
+    pub fn internal_linalg_slogdet(
         a: &Tensor,
     ) -> Result<(Tensor, Tensor, Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 4];
@@ -3270,7 +3254,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_linalg_slogdet_sign(
+    pub fn internal_linalg_slogdet_sign(
         sign: &Tensor,
         logabsdet: &Tensor,
         lu: &Tensor,
@@ -3294,7 +3278,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_linalg_solve_ex(
+    pub fn internal_linalg_solve_ex(
         a: &Tensor,
         b: &Tensor,
         left: bool,
@@ -3316,7 +3300,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_linalg_solve_ex_result(
+    pub fn internal_linalg_solve_ex_result(
         result: &Tensor,
         lu: &Tensor,
         pivots: &Tensor,
@@ -3346,7 +3330,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_linalg_svd(
+    pub fn internal_linalg_svd(
         a: &Tensor,
         full_matrices: bool,
         compute_uv: bool,
@@ -3368,7 +3352,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_linalg_svd_u(
+    pub fn internal_linalg_svd_u(
         u: &Tensor,
         s: &Tensor,
         vh: &Tensor,
@@ -3396,11 +3380,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_log_softmax(
-        &self,
-        dim: i64,
-        half_to_float: bool,
-    ) -> Result<Tensor, TchError> {
+    pub fn internal_log_softmax(&self, dim: i64, half_to_float: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__log_softmax(
             c_tensors.as_mut_ptr(),
@@ -3411,7 +3391,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_log_softmax_backward_data(
+    pub fn internal_log_softmax_backward_data(
         grad_output: &Tensor,
         output: &Tensor,
         dim: i64,
@@ -3428,7 +3408,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_log_softmax_backward_data_out(
+    pub fn internal_log_softmax_backward_data_out(
         out: &Tensor,
         grad_output: &Tensor,
         output: &Tensor,
@@ -3447,7 +3427,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_log_softmax_out(
+    pub fn internal_log_softmax_out(
         &self,
         out: &Tensor,
         dim: i64,
@@ -3464,13 +3444,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_logcumsumexp(&self, dim: i64) -> Result<Tensor, TchError> {
+    pub fn internal_logcumsumexp(&self, dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__logcumsumexp(c_tensors.as_mut_ptr(), self.c_tensor, dim));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_logcumsumexp_out(&self, out: &Tensor, dim: i64) -> Result<Tensor, TchError> {
+    pub fn internal_logcumsumexp_out(&self, out: &Tensor, dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__logcumsumexp_out(
             c_tensors.as_mut_ptr(),
@@ -3481,7 +3461,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_lstm_mps<T: Borrow<Tensor>>(
+    pub fn internal_lstm_mps<T: Borrow<Tensor>>(
         &self,
         hx: &[T],
         params: &[T],
@@ -3517,7 +3497,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_lstm_mps_out<T: Borrow<Tensor>>(
+    pub fn internal_lstm_mps_out<T: Borrow<Tensor>>(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -3565,7 +3545,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_lu_with_info(
+    pub fn internal_lu_with_info(
         &self,
         pivot: bool,
         check_errors: bool,
@@ -3584,7 +3564,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_make_dual(
+    pub fn internal_make_dual(
         primal: &Tensor,
         tangent: &Tensor,
         level: i64,
@@ -3599,7 +3579,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_make_dual_copy(
+    pub fn internal_make_dual_copy(
         primal: &Tensor,
         tangent: &Tensor,
         level: i64,
@@ -3614,7 +3594,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_make_dual_copy_out(
+    pub fn internal_make_dual_copy_out(
         out: &Tensor,
         primal: &Tensor,
         tangent: &Tensor,
@@ -3631,7 +3611,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_make_per_channel_quantized_tensor(
+    pub fn internal_make_per_channel_quantized_tensor(
         &self,
         scale: &Tensor,
         zero_point: &Tensor,
@@ -3648,7 +3628,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_make_per_channel_quantized_tensor_out(
+    pub fn internal_make_per_channel_quantized_tensor_out(
         &self,
         out: &Tensor,
         scale: &Tensor,
@@ -3667,7 +3647,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_make_per_tensor_quantized_tensor(
+    pub fn internal_make_per_tensor_quantized_tensor(
         &self,
         scale: f64,
         zero_point: i64,
@@ -3682,7 +3662,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_make_per_tensor_quantized_tensor_out(
+    pub fn internal_make_per_tensor_quantized_tensor_out(
         &self,
         out: &Tensor,
         scale: f64,
@@ -3699,7 +3679,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_masked_scale(&self, mask: &Tensor, scale: f64) -> Result<Tensor, TchError> {
+    pub fn internal_masked_scale(&self, mask: &Tensor, scale: f64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__masked_scale(
             c_tensors.as_mut_ptr(),
@@ -3710,7 +3690,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_masked_scale_out(
+    pub fn internal_masked_scale_out(
         &self,
         out: &Tensor,
         mask: &Tensor,
@@ -3727,7 +3707,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_masked_softmax(
+    pub fn internal_masked_softmax(
         &self,
         mask: &Tensor,
         dim: impl Into<Option<i64>>,
@@ -3748,7 +3728,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_masked_softmax_backward(
+    pub fn internal_masked_softmax_backward(
         grad_output: &Tensor,
         output: &Tensor,
         mask: &Tensor,
@@ -3767,7 +3747,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_masked_softmax_backward_out(
+    pub fn internal_masked_softmax_backward_out(
         out: &Tensor,
         grad_output: &Tensor,
         output: &Tensor,
@@ -3788,7 +3768,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_masked_softmax_out(
+    pub fn internal_masked_softmax_out(
         &self,
         out: &Tensor,
         mask: &Tensor,
@@ -3811,7 +3791,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_mkldnn_reshape(&self, shape: impl IntList) -> Result<Tensor, TchError> {
+    pub fn internal_mkldnn_reshape(&self, shape: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__mkldnn_reshape(
             c_tensors.as_mut_ptr(),
@@ -3822,7 +3802,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_mkldnn_reshape_out(
+    pub fn internal_mkldnn_reshape_out(
         &self,
         out: &Tensor,
         shape: impl IntList,
@@ -3838,17 +3818,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_mkldnn_transpose(&self, dim0: i64, dim1: i64) -> Result<Tensor, TchError> {
+    pub fn internal_mkldnn_transpose(&self, dim0: i64, dim1: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__mkldnn_transpose(c_tensors.as_mut_ptr(), self.c_tensor, dim0, dim1));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_mkldnn_transpose_(
-        &mut self,
-        dim0: i64,
-        dim1: i64,
-    ) -> Result<Tensor, TchError> {
+    pub fn internal_mkldnn_transpose_(&mut self, dim0: i64, dim1: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__mkldnn_transpose_(
             c_tensors.as_mut_ptr(),
@@ -3859,7 +3835,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_mkldnn_transpose_out(
+    pub fn internal_mkldnn_transpose_out(
         &self,
         out: &Tensor,
         dim0: i64,
@@ -3876,7 +3852,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_mps_convolution<T: Borrow<Tensor>>(
+    pub fn internal_mps_convolution<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -3902,7 +3878,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_mps_convolution_out<T: Borrow<Tensor>>(
+    pub fn internal_mps_convolution_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -3930,7 +3906,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_mps_convolution_transpose(
+    pub fn internal_mps_convolution_transpose(
         &self,
         weight: &Tensor,
         padding: impl IntList,
@@ -3957,7 +3933,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_mps_convolution_transpose_out(
+    pub fn internal_mps_convolution_transpose_out(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -3986,7 +3962,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_native_batch_norm_legit<T: Borrow<Tensor>>(
+    pub fn internal_native_batch_norm_legit<T: Borrow<Tensor>>(
         &self,
         weight: Option<T>,
         bias: Option<T>,
@@ -4015,7 +3991,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_native_batch_norm_legit_functional<T: Borrow<Tensor>>(
+    pub fn internal_native_batch_norm_legit_functional<T: Borrow<Tensor>>(
         &self,
         weight: Option<T>,
         bias: Option<T>,
@@ -4046,7 +4022,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_native_batch_norm_legit_no_stats<T: Borrow<Tensor>>(
+    pub fn internal_native_batch_norm_legit_no_stats<T: Borrow<Tensor>>(
         &self,
         weight: Option<T>,
         bias: Option<T>,
@@ -4071,7 +4047,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_native_batch_norm_legit_no_stats_out<T: Borrow<Tensor>>(
+    pub fn internal_native_batch_norm_legit_no_stats_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         save_mean: &Tensor,
@@ -4102,7 +4078,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_native_batch_norm_legit_out<T: Borrow<Tensor>>(
+    pub fn internal_native_batch_norm_legit_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         save_mean: &Tensor,
@@ -4137,7 +4113,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_native_decoder_only_multi_head_attention<T: Borrow<Tensor>>(
+    pub fn internal_native_decoder_only_multi_head_attention<T: Borrow<Tensor>>(
         query: &Tensor,
         key: &Tensor,
         value: &Tensor,
@@ -4179,7 +4155,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_native_decoder_only_multi_head_attention_out<T: Borrow<Tensor>>(
+    pub fn internal_native_decoder_only_multi_head_attention_out<T: Borrow<Tensor>>(
         out0: &Tensor,
         out1: &Tensor,
         out2: &Tensor,
@@ -4229,7 +4205,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_native_multi_head_attention<T: Borrow<Tensor>>(
+    pub fn internal_native_multi_head_attention<T: Borrow<Tensor>>(
         query: &Tensor,
         key: &Tensor,
         value: &Tensor,
@@ -4266,7 +4242,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_native_multi_head_attention_out<T: Borrow<Tensor>>(
+    pub fn internal_native_multi_head_attention_out<T: Borrow<Tensor>>(
         out0: &Tensor,
         out1: &Tensor,
         query: &Tensor,
@@ -4307,19 +4283,19 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_neg_view(&self) -> Result<Tensor, TchError> {
+    pub fn internal_neg_view(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__neg_view(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_neg_view_copy(&self) -> Result<Tensor, TchError> {
+    pub fn internal_neg_view_copy(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__neg_view_copy(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_neg_view_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn internal_neg_view_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__neg_view_copy_out(
             c_tensors.as_mut_ptr(),
@@ -4329,7 +4305,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_nested_from_padded(
+    pub fn internal_nested_from_padded(
         padded: &Tensor,
         cpu_nested_shape_example: &Tensor,
         fuse_transform_0213: bool,
@@ -4344,7 +4320,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_nested_from_padded_and_nested_example(
+    pub fn internal_nested_from_padded_and_nested_example(
         padded: &Tensor,
         nt_example: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -4357,7 +4333,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_nested_from_padded_and_nested_example_out(
+    pub fn internal_nested_from_padded_and_nested_example_out(
         out: &Tensor,
         padded: &Tensor,
         nt_example: &Tensor,
@@ -4372,7 +4348,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_nested_from_padded_out(
+    pub fn internal_nested_from_padded_out(
         out: &Tensor,
         padded: &Tensor,
         cpu_nested_shape_example: &Tensor,
@@ -4389,7 +4365,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_nested_select_backward(
+    pub fn internal_nested_select_backward(
         &self,
         grad_output: &Tensor,
         dim: i64,
@@ -4406,7 +4382,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_nested_sum_backward(
+    pub fn internal_nested_sum_backward(
         &self,
         grad: &Tensor,
         dim: impl IntListOption,
@@ -4424,7 +4400,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_nested_view_from_buffer(
+    pub fn internal_nested_view_from_buffer(
         &self,
         nested_size: &Tensor,
         nested_strides: &Tensor,
@@ -4442,7 +4418,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_nested_view_from_buffer_copy(
+    pub fn internal_nested_view_from_buffer_copy(
         &self,
         nested_size: &Tensor,
         nested_strides: &Tensor,
@@ -4460,7 +4436,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_nested_view_from_buffer_copy_out(
+    pub fn internal_nested_view_from_buffer_copy_out(
         &self,
         out: &Tensor,
         nested_size: &Tensor,
@@ -4480,7 +4456,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_new_zeros_with_same_feature_meta(
+    pub fn internal_new_zeros_with_same_feature_meta(
         &self,
         other: &Tensor,
         self_num_batch_dims: i64,
@@ -4495,7 +4471,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_new_zeros_with_same_feature_meta_out(
+    pub fn internal_new_zeros_with_same_feature_meta_out(
         &self,
         out: &Tensor,
         other: &Tensor,
@@ -4512,13 +4488,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_nnpack_available() -> Result<bool, TchError> {
+    pub fn internal_nnpack_available() -> Result<bool, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg__nnpack_available());
         Ok(return_ != 0)
     }
 
-    pub fn f_internal_nnpack_spatial_convolution<T: Borrow<Tensor>>(
+    pub fn internal_nnpack_spatial_convolution<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -4539,7 +4515,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_nnpack_spatial_convolution_out<T: Borrow<Tensor>>(
+    pub fn internal_nnpack_spatial_convolution_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -4562,13 +4538,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_nnz(&self) -> Result<i64, TchError> {
+    pub fn internal_nnz(&self) -> Result<i64, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg__nnz(self.c_tensor));
         Ok(return_)
     }
 
-    pub fn f_internal_pack_padded_sequence(
+    pub fn internal_pack_padded_sequence(
         &self,
         lengths: &Tensor,
         batch_first: bool,
@@ -4583,7 +4559,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_pack_padded_sequence_backward(
+    pub fn internal_pack_padded_sequence_backward(
         grad: &Tensor,
         input_size: impl IntList,
         batch_sizes: &Tensor,
@@ -4601,7 +4577,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_pack_padded_sequence_out(
+    pub fn internal_pack_padded_sequence_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -4620,7 +4596,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_pad_circular(&self, pad: impl IntList) -> Result<Tensor, TchError> {
+    pub fn internal_pad_circular(&self, pad: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__pad_circular(
             c_tensors.as_mut_ptr(),
@@ -4631,7 +4607,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_pad_enum(
+    pub fn internal_pad_enum(
         &self,
         pad: impl IntList,
         mode: i64,
@@ -4651,7 +4627,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_pad_packed_sequence<S: Into<Scalar>>(
+    pub fn internal_pad_packed_sequence<S: Into<Scalar>>(
         data: &Tensor,
         batch_sizes: &Tensor,
         batch_first: bool,
@@ -4670,7 +4646,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_pdist_backward(
+    pub fn internal_pdist_backward(
         &self,
         grad: &Tensor,
         p: f64,
@@ -4687,7 +4663,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_pdist_backward_out(
+    pub fn internal_pdist_backward_out(
         &self,
         out: &Tensor,
         grad: &Tensor,
@@ -4706,13 +4682,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_pin_memory(&self, device: Device) -> Result<Tensor, TchError> {
+    pub fn internal_pin_memory(&self, device: Device) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__pin_memory(c_tensors.as_mut_ptr(), self.c_tensor, device.c_int()));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_pin_memory_out(
+    pub fn internal_pin_memory_out(
         &self,
         out: &Tensor,
         device: Device,
@@ -4727,7 +4703,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_prelu_kernel(&self, weight: &Tensor) -> Result<Tensor, TchError> {
+    pub fn internal_prelu_kernel(&self, weight: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__prelu_kernel(
             c_tensors.as_mut_ptr(),
@@ -4737,7 +4713,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_prelu_kernel_backward(
+    pub fn internal_prelu_kernel_backward(
         &self,
         grad_output: &Tensor,
         weight: &Tensor,
@@ -4752,7 +4728,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_remove_batch_dim(
+    pub fn internal_remove_batch_dim(
         &self,
         level: i64,
         batch_size: i64,
@@ -4769,7 +4745,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_reshape_alias(
+    pub fn internal_reshape_alias(
         &self,
         size: impl IntList,
         stride: impl IntList,
@@ -4786,7 +4762,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_reshape_alias_copy(
+    pub fn internal_reshape_alias_copy(
         &self,
         size: impl IntList,
         stride: impl IntList,
@@ -4803,7 +4779,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_reshape_alias_copy_out(
+    pub fn internal_reshape_alias_copy_out(
         &self,
         out: &Tensor,
         size: impl IntList,
@@ -4822,7 +4798,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_reshape_copy(&self, size: impl IntList) -> Result<Tensor, TchError> {
+    pub fn internal_reshape_copy(&self, size: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__reshape_copy(
             c_tensors.as_mut_ptr(),
@@ -4833,7 +4809,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_reshape_from_tensor(&self, shape: &Tensor) -> Result<Tensor, TchError> {
+    pub fn internal_reshape_from_tensor(&self, shape: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__reshape_from_tensor(
             c_tensors.as_mut_ptr(),
@@ -4843,7 +4819,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_resize_output(
+    pub fn internal_resize_output(
         &self,
         size: impl IntList,
         device: Device,
@@ -4859,7 +4835,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_resize_output_(
+    pub fn internal_resize_output_(
         &mut self,
         size: impl IntList,
         device: Device,
@@ -4875,7 +4851,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_resize_output_out(
+    pub fn internal_resize_output_out(
         &self,
         out: &Tensor,
         size: impl IntList,
@@ -4893,7 +4869,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_rowwise_prune(
+    pub fn internal_rowwise_prune(
         weight: &Tensor,
         mask: &Tensor,
         compressed_indices_dtype: Kind,
@@ -4908,13 +4884,13 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_sample_dirichlet(&self) -> Result<Tensor, TchError> {
+    pub fn internal_sample_dirichlet(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__sample_dirichlet(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sample_dirichlet_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn internal_sample_dirichlet_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__sample_dirichlet_out(
             c_tensors.as_mut_ptr(),
@@ -4924,13 +4900,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_saturate_weight_to_fp16(weight: &Tensor) -> Result<Tensor, TchError> {
+    pub fn internal_saturate_weight_to_fp16(weight: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__saturate_weight_to_fp16(c_tensors.as_mut_ptr(), weight.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_scaled_dot_product_attention<T: Borrow<Tensor>>(
+    pub fn internal_scaled_dot_product_attention<T: Borrow<Tensor>>(
         query: &Tensor,
         key: &Tensor,
         value: &Tensor,
@@ -4953,7 +4929,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_scaled_dot_product_attention_math<T: Borrow<Tensor>>(
+    pub fn internal_scaled_dot_product_attention_math<T: Borrow<Tensor>>(
         query: &Tensor,
         key: &Tensor,
         value: &Tensor,
@@ -4976,7 +4952,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_scaled_dot_product_efficient_attention(
+    pub fn internal_scaled_dot_product_efficient_attention(
         query: &Tensor,
         key: &Tensor,
         value: &Tensor,
@@ -4995,7 +4971,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_scaled_dot_product_efficient_attention_backward(
+    pub fn internal_scaled_dot_product_efficient_attention_backward(
         grad_out_: &Tensor,
         query: &Tensor,
         key: &Tensor,
@@ -5024,7 +5000,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_scaled_dot_product_flash_attention_backward(
+    pub fn internal_scaled_dot_product_flash_attention_backward(
         grad_out: &Tensor,
         query: &Tensor,
         key: &Tensor,
@@ -5065,7 +5041,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_scatter_reduce(
+    pub fn internal_scatter_reduce(
         &self,
         dim: i64,
         index: &Tensor,
@@ -5087,7 +5063,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_scatter_reduce_(
+    pub fn internal_scatter_reduce_(
         &mut self,
         dim: i64,
         index: &Tensor,
@@ -5109,7 +5085,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_scatter_reduce_two_out(
+    pub fn internal_scatter_reduce_two_out(
         &self,
         out: &Tensor,
         dim: i64,
@@ -5133,7 +5109,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_segment_reduce_backward<T: Borrow<Tensor>, S: Into<Scalar>>(
+    pub fn internal_segment_reduce_backward<T: Borrow<Tensor>, S: Into<Scalar>>(
         grad: &Tensor,
         output: &Tensor,
         data: &Tensor,
@@ -5159,7 +5135,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_segment_reduce_backward_out<T: Borrow<Tensor>, S: Into<Scalar>>(
+    pub fn internal_segment_reduce_backward_out<T: Borrow<Tensor>, S: Into<Scalar>>(
         out: &Tensor,
         grad: &Tensor,
         output: &Tensor,
@@ -5187,13 +5163,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_shape_as_tensor(&self) -> Result<Tensor, TchError> {
+    pub fn internal_shape_as_tensor(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__shape_as_tensor(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_slow_conv2d_backward(
+    pub fn internal_slow_conv2d_backward(
         &self,
         grad_input: &Tensor,
         grad_weight: &Tensor,
@@ -5227,7 +5203,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_sobol_engine_draw(
+    pub fn internal_sobol_engine_draw(
         quasi: &Tensor,
         n: i64,
         sobolstate: &Tensor,
@@ -5248,7 +5224,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_sobol_engine_ff_(
+    pub fn internal_sobol_engine_ff_(
         &mut self,
         n: i64,
         sobolstate: &Tensor,
@@ -5267,7 +5243,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sobol_engine_initialize_state_(
+    pub fn internal_sobol_engine_initialize_state_(
         &mut self,
         dimension: i64,
     ) -> Result<Tensor, TchError> {
@@ -5280,7 +5256,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sobol_engine_scramble_(
+    pub fn internal_sobol_engine_scramble_(
         &mut self,
         ltm: &Tensor,
         dimension: i64,
@@ -5295,7 +5271,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_softmax(&self, dim: i64, half_to_float: bool) -> Result<Tensor, TchError> {
+    pub fn internal_softmax(&self, dim: i64, half_to_float: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__softmax(
             c_tensors.as_mut_ptr(),
@@ -5306,7 +5282,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_softmax_backward_data(
+    pub fn internal_softmax_backward_data(
         grad_output: &Tensor,
         output: &Tensor,
         dim: i64,
@@ -5323,7 +5299,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_softmax_backward_data_out(
+    pub fn internal_softmax_backward_data_out(
         grad_input: &Tensor,
         grad_output: &Tensor,
         output: &Tensor,
@@ -5342,7 +5318,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_softmax_out(
+    pub fn internal_softmax_out(
         &self,
         out: &Tensor,
         dim: i64,
@@ -5359,11 +5335,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_addmm(
-        &self,
-        mat1: &Tensor,
-        mat2: &Tensor,
-    ) -> Result<Tensor, TchError> {
+    pub fn internal_sparse_addmm(&self, mat1: &Tensor, mat2: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__sparse_addmm(
             c_tensors.as_mut_ptr(),
@@ -5374,7 +5346,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_addmm_out(
+    pub fn internal_sparse_addmm_out(
         &self,
         out: &Tensor,
         mat1: &Tensor,
@@ -5391,7 +5363,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_broadcast_to(&self, size: impl IntList) -> Result<Tensor, TchError> {
+    pub fn internal_sparse_broadcast_to(&self, size: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__sparse_broadcast_to(
             c_tensors.as_mut_ptr(),
@@ -5402,7 +5374,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_broadcast_to_copy(
+    pub fn internal_sparse_broadcast_to_copy(
         &self,
         size: impl IntList,
     ) -> Result<Tensor, TchError> {
@@ -5416,7 +5388,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_broadcast_to_copy_out(
+    pub fn internal_sparse_broadcast_to_copy_out(
         &self,
         out: &Tensor,
         size: impl IntList,
@@ -5432,7 +5404,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_bsc_tensor_unsafe(
+    pub fn internal_sparse_bsc_tensor_unsafe(
         ccol_indices: &Tensor,
         row_indices: &Tensor,
         values: &Tensor,
@@ -5453,7 +5425,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_bsr_tensor_unsafe(
+    pub fn internal_sparse_bsr_tensor_unsafe(
         crow_indices: &Tensor,
         col_indices: &Tensor,
         values: &Tensor,
@@ -5474,7 +5446,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_compressed_tensor_unsafe(
+    pub fn internal_sparse_compressed_tensor_unsafe(
         compressed_indices: &Tensor,
         plain_indices: &Tensor,
         values: &Tensor,
@@ -5495,7 +5467,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_coo_tensor_unsafe(
+    pub fn internal_sparse_coo_tensor_unsafe(
         indices: &Tensor,
         values: &Tensor,
         size: impl IntList,
@@ -5514,7 +5486,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_coo_tensor_with_dims(
+    pub fn internal_sparse_coo_tensor_with_dims(
         sparse_dim: i64,
         dense_dim: i64,
         size: impl IntList,
@@ -5533,7 +5505,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_coo_tensor_with_dims_and_tensors(
+    pub fn internal_sparse_coo_tensor_with_dims_and_tensors(
         sparse_dim: i64,
         dense_dim: i64,
         size: impl IntList,
@@ -5556,7 +5528,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_coo_tensor_with_dims_and_tensors_out(
+    pub fn internal_sparse_coo_tensor_with_dims_and_tensors_out(
         out: &Tensor,
         sparse_dim: i64,
         dense_dim: i64,
@@ -5578,7 +5550,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_coo_tensor_with_dims_out(
+    pub fn internal_sparse_coo_tensor_with_dims_out(
         out: &Tensor,
         sparse_dim: i64,
         dense_dim: i64,
@@ -5596,7 +5568,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_csc_tensor_unsafe(
+    pub fn internal_sparse_csc_tensor_unsafe(
         ccol_indices: &Tensor,
         row_indices: &Tensor,
         values: &Tensor,
@@ -5617,7 +5589,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_csr_prod(
+    pub fn internal_sparse_csr_prod(
         &self,
         dim: impl IntList,
         keepdim: bool,
@@ -5635,7 +5607,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_csr_prod_dim_dtype_out(
+    pub fn internal_sparse_csr_prod_dim_dtype_out(
         &self,
         out: &Tensor,
         dim: impl IntList,
@@ -5655,7 +5627,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_csr_sum(
+    pub fn internal_sparse_csr_sum(
         &self,
         dim: impl IntList,
         keepdim: bool,
@@ -5673,7 +5645,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_csr_sum_dim_dtype_out(
+    pub fn internal_sparse_csr_sum_dim_dtype_out(
         &self,
         out: &Tensor,
         dim: impl IntList,
@@ -5693,7 +5665,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_csr_tensor_unsafe(
+    pub fn internal_sparse_csr_tensor_unsafe(
         crow_indices: &Tensor,
         col_indices: &Tensor,
         values: &Tensor,
@@ -5714,7 +5686,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_log_softmax(
+    pub fn internal_sparse_log_softmax(
         &self,
         dim: i64,
         half_to_float: bool,
@@ -5729,7 +5701,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_log_softmax_backward_data(
+    pub fn internal_sparse_log_softmax_backward_data(
         &self,
         grad_output: &Tensor,
         output: &Tensor,
@@ -5746,7 +5718,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_log_softmax_backward_data_out(
+    pub fn internal_sparse_log_softmax_backward_data_out(
         &self,
         out: &Tensor,
         grad_output: &Tensor,
@@ -5765,7 +5737,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_log_softmax_int(
+    pub fn internal_sparse_log_softmax_int(
         &self,
         dim: i64,
         dtype: impl Into<Option<Kind>>,
@@ -5780,7 +5752,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_log_softmax_out(
+    pub fn internal_sparse_log_softmax_out(
         &self,
         out: &Tensor,
         dim: i64,
@@ -5797,13 +5769,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_mm(sparse: &Tensor, dense: &Tensor) -> Result<Tensor, TchError> {
+    pub fn internal_sparse_mm(sparse: &Tensor, dense: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__sparse_mm(c_tensors.as_mut_ptr(), sparse.c_tensor, dense.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_mm_reduce(
+    pub fn internal_sparse_mm_reduce(
         sparse: &Tensor,
         dense: &Tensor,
         reduce: &str,
@@ -5819,7 +5791,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_mm_reduce_impl(
+    pub fn internal_sparse_mm_reduce_impl(
         &self,
         other: &Tensor,
         reduce: &str,
@@ -5835,7 +5807,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_sparse_softmax(
+    pub fn internal_sparse_softmax(
         &self,
         dim: i64,
         half_to_float: bool,
@@ -5850,7 +5822,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_softmax_backward_data(
+    pub fn internal_sparse_softmax_backward_data(
         &self,
         grad_output: &Tensor,
         output: &Tensor,
@@ -5867,7 +5839,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_softmax_backward_data_out(
+    pub fn internal_sparse_softmax_backward_data_out(
         &self,
         out: &Tensor,
         grad_output: &Tensor,
@@ -5886,7 +5858,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_softmax_int(
+    pub fn internal_sparse_softmax_int(
         &self,
         dim: i64,
         dtype: impl Into<Option<Kind>>,
@@ -5901,7 +5873,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_softmax_out(
+    pub fn internal_sparse_softmax_out(
         &self,
         out: &Tensor,
         dim: i64,
@@ -5918,7 +5890,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_sparse_matmul(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn internal_sparse_sparse_matmul(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__sparse_sparse_matmul(
             c_tensors.as_mut_ptr(),
@@ -5928,7 +5900,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_sparse_matmul_out(
+    pub fn internal_sparse_sparse_matmul_out(
         &self,
         out: &Tensor,
         other: &Tensor,
@@ -5943,13 +5915,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_sum(&self) -> Result<Tensor, TchError> {
+    pub fn internal_sparse_sum(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__sparse_sum(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_sum_backward(
+    pub fn internal_sparse_sum_backward(
         &self,
         grad: &Tensor,
         dim: impl IntList,
@@ -5965,7 +5937,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_sum_backward_out(
+    pub fn internal_sparse_sum_backward_out(
         &self,
         out: &Tensor,
         grad: &Tensor,
@@ -5983,7 +5955,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_sum_dim(&self, dim: impl IntList) -> Result<Tensor, TchError> {
+    pub fn internal_sparse_sum_dim(&self, dim: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__sparse_sum_dim(
             c_tensors.as_mut_ptr(),
@@ -5994,7 +5966,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_sum_dim_dtype(
+    pub fn internal_sparse_sum_dim_dtype(
         &self,
         dim: impl IntList,
         dtype: Kind,
@@ -6010,7 +5982,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_sum_dim_out(
+    pub fn internal_sparse_sum_dim_out(
         &self,
         out: &Tensor,
         dim: impl IntList,
@@ -6026,7 +5998,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_sparse_sum_dtype(&self, dtype: Kind) -> Result<Tensor, TchError> {
+    pub fn internal_sparse_sum_dtype(&self, dtype: Kind) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__sparse_sum_dtype(
             c_tensors.as_mut_ptr(),
@@ -6036,7 +6008,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_spdiags(
+    pub fn internal_spdiags(
         diagonals: &Tensor,
         offsets: &Tensor,
         shape: impl IntList,
@@ -6054,7 +6026,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_spdiags_out(
+    pub fn internal_spdiags_out(
         out: &Tensor,
         diagonals: &Tensor,
         offsets: &Tensor,
@@ -6074,10 +6046,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_stack<T: Borrow<Tensor>>(
-        tensors: &[T],
-        dim: i64,
-    ) -> Result<Tensor, TchError> {
+    pub fn internal_stack<T: Borrow<Tensor>>(tensors: &[T], dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__stack(
             c_tensors.as_mut_ptr(),
@@ -6088,7 +6057,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_stack_out<T: Borrow<Tensor>>(
+    pub fn internal_stack_out<T: Borrow<Tensor>>(
         out: &Tensor,
         tensors: &[T],
         dim: i64,
@@ -6104,13 +6073,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_standard_gamma(&self) -> Result<Tensor, TchError> {
+    pub fn internal_standard_gamma(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__standard_gamma(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_standard_gamma_grad(&self, output: &Tensor) -> Result<Tensor, TchError> {
+    pub fn internal_standard_gamma_grad(&self, output: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__standard_gamma_grad(
             c_tensors.as_mut_ptr(),
@@ -6120,7 +6089,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_standard_gamma_grad_out(
+    pub fn internal_standard_gamma_grad_out(
         &self,
         out: &Tensor,
         output: &Tensor,
@@ -6135,7 +6104,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_standard_gamma_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn internal_standard_gamma_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__standard_gamma_out(
             c_tensors.as_mut_ptr(),
@@ -6145,7 +6114,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_test_ambiguous_defaults(
+    pub fn internal_test_ambiguous_defaults(
         dummy: &Tensor,
         a: i64,
         b: i64,
@@ -6160,7 +6129,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_test_ambiguous_defaults_b(
+    pub fn internal_test_ambiguous_defaults_b(
         dummy: &Tensor,
         a: i64,
         b: &str,
@@ -6176,7 +6145,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_test_autograd_multiple_dispatch(&self) -> Result<Tensor, TchError> {
+    pub fn internal_test_autograd_multiple_dispatch(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__test_autograd_multiple_dispatch(
             c_tensors.as_mut_ptr(),
@@ -6185,7 +6154,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_test_autograd_multiple_dispatch_fullcoverage_out(
+    pub fn internal_test_autograd_multiple_dispatch_fullcoverage_out(
         &self,
         out: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -6198,7 +6167,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_test_autograd_multiple_dispatch_ntonly(
+    pub fn internal_test_autograd_multiple_dispatch_ntonly(
         &self,
         b: bool,
     ) -> Result<Tensor, TchError> {
@@ -6211,7 +6180,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_test_autograd_multiple_dispatch_view(&self) -> Result<Tensor, TchError> {
+    pub fn internal_test_autograd_multiple_dispatch_view(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__test_autograd_multiple_dispatch_view(
             c_tensors.as_mut_ptr(),
@@ -6220,7 +6189,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_test_autograd_multiple_dispatch_view_copy(&self) -> Result<Tensor, TchError> {
+    pub fn internal_test_autograd_multiple_dispatch_view_copy(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__test_autograd_multiple_dispatch_view_copy(
             c_tensors.as_mut_ptr(),
@@ -6229,7 +6198,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_test_autograd_multiple_dispatch_view_copy_out(
+    pub fn internal_test_autograd_multiple_dispatch_view_copy_out(
         &self,
         out: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -6242,13 +6211,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_test_check_tensor(&self) -> Result<Tensor, TchError> {
+    pub fn internal_test_check_tensor(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__test_check_tensor(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_test_optional_filled_intlist(
+    pub fn internal_test_optional_filled_intlist(
         values: &Tensor,
         addends: impl IntListOption,
     ) -> Result<Tensor, TchError> {
@@ -6262,7 +6231,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_test_optional_filled_intlist_out(
+    pub fn internal_test_optional_filled_intlist_out(
         out: &Tensor,
         values: &Tensor,
         addends: impl IntListOption,
@@ -6278,7 +6247,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_test_optional_floatlist(
+    pub fn internal_test_optional_floatlist(
         values: &Tensor,
         addends: impl DoubleList,
     ) -> Result<Tensor, TchError> {
@@ -6292,7 +6261,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_test_optional_floatlist_out(
+    pub fn internal_test_optional_floatlist_out(
         out: &Tensor,
         values: &Tensor,
         addends: impl DoubleList,
@@ -6308,7 +6277,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_test_optional_intlist(
+    pub fn internal_test_optional_intlist(
         values: &Tensor,
         addends: impl IntListOption,
     ) -> Result<Tensor, TchError> {
@@ -6322,7 +6291,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_test_optional_intlist_out(
+    pub fn internal_test_optional_intlist_out(
         out: &Tensor,
         values: &Tensor,
         addends: impl IntListOption,
@@ -6338,10 +6307,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_test_serialization_subcmul(
-        &self,
-        other: &Tensor,
-    ) -> Result<Tensor, TchError> {
+    pub fn internal_test_serialization_subcmul(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__test_serialization_subcmul(
             c_tensors.as_mut_ptr(),
@@ -6351,7 +6317,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_test_string_default(
+    pub fn internal_test_string_default(
         dummy: &Tensor,
         a: &str,
         b: &str,
@@ -6368,13 +6334,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_test_warn_in_autograd(&self) -> Result<Tensor, TchError> {
+    pub fn internal_test_warn_in_autograd(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__test_warn_in_autograd(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_test_warn_in_autograd_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn internal_test_warn_in_autograd_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__test_warn_in_autograd_out(
             c_tensors.as_mut_ptr(),
@@ -6384,7 +6350,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_to_copy(
+    pub fn internal_to_copy(
         &self,
         options: (Kind, Device),
         non_blocking: bool,
@@ -6400,7 +6366,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_to_copy_out(
+    pub fn internal_to_copy_out(
         &self,
         out: &Tensor,
         non_blocking: bool,
@@ -6415,7 +6381,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_to_cpu<T: Borrow<Tensor>>(tensors: &[T]) -> Result<Vec<Tensor>, TchError> {
+    pub fn internal_to_cpu<T: Borrow<Tensor>>(tensors: &[T]) -> Result<Vec<Tensor>, TchError> {
         let c_tensors =
             unsafe_torch_err!(atg__to_cpu(ptr_list(tensors).as_ptr(), tensors.len() as i32));
         let mut r__ = vec![];
@@ -6432,7 +6398,7 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_internal_to_dense(&self, dtype: impl Into<Option<Kind>>) -> Result<Tensor, TchError> {
+    pub fn internal_to_dense(&self, dtype: impl Into<Option<Kind>>) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__to_dense(
             c_tensors.as_mut_ptr(),
@@ -6442,7 +6408,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_to_dense_out(
+    pub fn internal_to_dense_out(
         &self,
         out: &Tensor,
         dtype: impl Into<Option<Kind>>,
@@ -6457,7 +6423,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_transform_bias_rescale_qkv(
+    pub fn internal_transform_bias_rescale_qkv(
         qkv: &Tensor,
         qkv_bias: &Tensor,
         num_heads: i64,
@@ -6476,7 +6442,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_transform_bias_rescale_qkv_out(
+    pub fn internal_transform_bias_rescale_qkv_out(
         out0: &Tensor,
         out1: &Tensor,
         out2: &Tensor,
@@ -6501,7 +6467,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_transformer_decoder_only_layer_fwd<T: Borrow<Tensor>>(
+    pub fn internal_transformer_decoder_only_layer_fwd<T: Borrow<Tensor>>(
         src: &Tensor,
         embed_dim: i64,
         num_heads: i64,
@@ -6556,7 +6522,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_transformer_decoder_only_layer_fwd_out<T: Borrow<Tensor>>(
+    pub fn internal_transformer_decoder_only_layer_fwd_out<T: Borrow<Tensor>>(
         out0: &Tensor,
         out1: &Tensor,
         out2: &Tensor,
@@ -6617,7 +6583,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_transformer_encoder_layer_fwd<T: Borrow<Tensor>>(
+    pub fn internal_transformer_encoder_layer_fwd<T: Borrow<Tensor>>(
         src: &Tensor,
         embed_dim: i64,
         num_heads: i64,
@@ -6668,7 +6634,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_transformer_encoder_layer_fwd_out<T: Borrow<Tensor>>(
+    pub fn internal_transformer_encoder_layer_fwd_out<T: Borrow<Tensor>>(
         out: &Tensor,
         src: &Tensor,
         embed_dim: i64,
@@ -6721,7 +6687,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_trilinear(
+    pub fn internal_trilinear(
         i1: &Tensor,
         i2: &Tensor,
         i3: &Tensor,
@@ -6750,7 +6716,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_trilinear_out(
+    pub fn internal_trilinear_out(
         out: &Tensor,
         i1: &Tensor,
         i2: &Tensor,
@@ -6781,7 +6747,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_triton_multi_head_attention<T: Borrow<Tensor>>(
+    pub fn internal_triton_multi_head_attention<T: Borrow<Tensor>>(
         query: &Tensor,
         key: &Tensor,
         value: &Tensor,
@@ -6810,7 +6776,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_triton_multi_head_attention_out<T: Borrow<Tensor>>(
+    pub fn internal_triton_multi_head_attention_out<T: Borrow<Tensor>>(
         out: &Tensor,
         query: &Tensor,
         key: &Tensor,
@@ -6841,7 +6807,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_triton_scaled_dot_attention(
+    pub fn internal_triton_scaled_dot_attention(
         q: &Tensor,
         k: &Tensor,
         v: &Tensor,
@@ -6858,7 +6824,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_triton_scaled_dot_attention_out(
+    pub fn internal_triton_scaled_dot_attention_out(
         out: &Tensor,
         q: &Tensor,
         k: &Tensor,
@@ -6877,7 +6843,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_unique(
+    pub fn internal_unique(
         &self,
         sorted: bool,
         return_inverse: bool,
@@ -6892,7 +6858,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_unique2(
+    pub fn internal_unique2(
         &self,
         sorted: bool,
         return_inverse: bool,
@@ -6913,7 +6879,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_unique2_out(
+    pub fn internal_unique2_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -6940,7 +6906,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_internal_unique_out(
+    pub fn internal_unique_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -6959,13 +6925,13 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_unpack_dual(dual: &Tensor, level: i64) -> Result<(Tensor, Tensor), TchError> {
+    pub fn internal_unpack_dual(dual: &Tensor, level: i64) -> Result<(Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 2];
         unsafe_torch_err!(atg__unpack_dual(c_tensors.as_mut_ptr(), dual.c_tensor, level));
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_unsafe_view(&self, size: impl IntList) -> Result<Tensor, TchError> {
+    pub fn internal_unsafe_view(&self, size: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__unsafe_view(
             c_tensors.as_mut_ptr(),
@@ -6976,7 +6942,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_unsafe_view_out(
+    pub fn internal_unsafe_view_out(
         &self,
         out: &Tensor,
         size: impl IntList,
@@ -6992,7 +6958,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_upsample_bicubic2d_aa(
+    pub fn internal_upsample_bicubic2d_aa(
         &self,
         output_size: impl IntList,
         align_corners: bool,
@@ -7016,7 +6982,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_upsample_bicubic2d_aa_backward(
+    pub fn internal_upsample_bicubic2d_aa_backward(
         grad_output: &Tensor,
         output_size: impl IntList,
         input_size: impl IntList,
@@ -7043,7 +7009,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_upsample_bicubic2d_aa_backward_grad_input(
+    pub fn internal_upsample_bicubic2d_aa_backward_grad_input(
         grad_input: &Tensor,
         grad_output: &Tensor,
         output_size: impl IntList,
@@ -7072,7 +7038,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_upsample_bicubic2d_aa_out(
+    pub fn internal_upsample_bicubic2d_aa_out(
         &self,
         out: &Tensor,
         output_size: impl IntList,
@@ -7098,7 +7064,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_upsample_bicubic2d_aa_vec(
+    pub fn internal_upsample_bicubic2d_aa_vec(
         &self,
         output_size: impl IntListOption,
         align_corners: bool,
@@ -7117,7 +7083,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_upsample_bilinear2d_aa(
+    pub fn internal_upsample_bilinear2d_aa(
         &self,
         output_size: impl IntList,
         align_corners: bool,
@@ -7141,7 +7107,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_upsample_bilinear2d_aa_backward(
+    pub fn internal_upsample_bilinear2d_aa_backward(
         grad_output: &Tensor,
         output_size: impl IntList,
         input_size: impl IntList,
@@ -7168,7 +7134,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_upsample_bilinear2d_aa_backward_grad_input(
+    pub fn internal_upsample_bilinear2d_aa_backward_grad_input(
         grad_input: &Tensor,
         grad_output: &Tensor,
         output_size: impl IntList,
@@ -7197,7 +7163,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_upsample_bilinear2d_aa_out(
+    pub fn internal_upsample_bilinear2d_aa_out(
         &self,
         out: &Tensor,
         output_size: impl IntList,
@@ -7223,7 +7189,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_upsample_bilinear2d_aa_vec(
+    pub fn internal_upsample_bilinear2d_aa_vec(
         &self,
         output_size: impl IntListOption,
         align_corners: bool,
@@ -7242,7 +7208,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_upsample_nearest_exact1d(
+    pub fn internal_upsample_nearest_exact1d(
         &self,
         output_size: impl IntList,
         scales: impl Into<Option<f64>>,
@@ -7260,7 +7226,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_upsample_nearest_exact1d_backward(
+    pub fn internal_upsample_nearest_exact1d_backward(
         grad_output: &Tensor,
         output_size: impl IntList,
         input_size: impl IntList,
@@ -7281,7 +7247,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_upsample_nearest_exact1d_backward_grad_input(
+    pub fn internal_upsample_nearest_exact1d_backward_grad_input(
         grad_input: &Tensor,
         grad_output: &Tensor,
         output_size: impl IntList,
@@ -7304,7 +7270,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_upsample_nearest_exact1d_out(
+    pub fn internal_upsample_nearest_exact1d_out(
         &self,
         out: &Tensor,
         output_size: impl IntList,
@@ -7324,7 +7290,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_upsample_nearest_exact1d_vec(
+    pub fn internal_upsample_nearest_exact1d_vec(
         &self,
         output_size: impl IntListOption,
         scale_factors: impl DoubleList,
@@ -7341,7 +7307,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_upsample_nearest_exact2d(
+    pub fn internal_upsample_nearest_exact2d(
         &self,
         output_size: impl IntList,
         scales_h: impl Into<Option<f64>>,
@@ -7363,7 +7329,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_upsample_nearest_exact2d_backward(
+    pub fn internal_upsample_nearest_exact2d_backward(
         grad_output: &Tensor,
         output_size: impl IntList,
         input_size: impl IntList,
@@ -7388,7 +7354,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_upsample_nearest_exact2d_backward_grad_input(
+    pub fn internal_upsample_nearest_exact2d_backward_grad_input(
         grad_input: &Tensor,
         grad_output: &Tensor,
         output_size: impl IntList,
@@ -7415,7 +7381,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_upsample_nearest_exact2d_out(
+    pub fn internal_upsample_nearest_exact2d_out(
         &self,
         out: &Tensor,
         output_size: impl IntList,
@@ -7439,7 +7405,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_upsample_nearest_exact2d_vec(
+    pub fn internal_upsample_nearest_exact2d_vec(
         &self,
         output_size: impl IntListOption,
         scale_factors: impl DoubleList,
@@ -7456,7 +7422,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_upsample_nearest_exact3d(
+    pub fn internal_upsample_nearest_exact3d(
         &self,
         output_size: impl IntList,
         scales_d: impl Into<Option<f64>>,
@@ -7482,7 +7448,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_upsample_nearest_exact3d_backward(
+    pub fn internal_upsample_nearest_exact3d_backward(
         grad_output: &Tensor,
         output_size: impl IntList,
         input_size: impl IntList,
@@ -7511,7 +7477,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_upsample_nearest_exact3d_backward_grad_input(
+    pub fn internal_upsample_nearest_exact3d_backward_grad_input(
         grad_input: &Tensor,
         grad_output: &Tensor,
         output_size: impl IntList,
@@ -7542,7 +7508,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_upsample_nearest_exact3d_out(
+    pub fn internal_upsample_nearest_exact3d_out(
         &self,
         out: &Tensor,
         output_size: impl IntList,
@@ -7570,7 +7536,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_upsample_nearest_exact3d_vec(
+    pub fn internal_upsample_nearest_exact3d_vec(
         &self,
         output_size: impl IntListOption,
         scale_factors: impl DoubleList,
@@ -7587,7 +7553,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_use_cudnn_ctc_loss(
+    pub fn internal_use_cudnn_ctc_loss(
         log_probs: &Tensor,
         targets: &Tensor,
         input_lengths: impl IntList,
@@ -7609,7 +7575,7 @@ impl Tensor {
         Ok(return_ != 0)
     }
 
-    pub fn f_internal_use_cudnn_ctc_loss_tensor(
+    pub fn internal_use_cudnn_ctc_loss_tensor(
         log_probs: &Tensor,
         targets: &Tensor,
         input_lengths: &Tensor,
@@ -7629,13 +7595,13 @@ impl Tensor {
         Ok(return_ != 0)
     }
 
-    pub fn f_internal_use_cudnn_rnn_flatten_weight() -> Result<bool, TchError> {
+    pub fn internal_use_cudnn_rnn_flatten_weight() -> Result<bool, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg__use_cudnn_rnn_flatten_weight());
         Ok(return_ != 0)
     }
 
-    pub fn f_internal_validate_compressed_sparse_indices(
+    pub fn internal_validate_compressed_sparse_indices(
         is_crow: bool,
         compressed_idx: &Tensor,
         plain_idx: &Tensor,
@@ -7654,7 +7620,7 @@ impl Tensor {
         Ok(())
     }
 
-    pub fn f_internal_validate_sparse_bsc_tensor_args(
+    pub fn internal_validate_sparse_bsc_tensor_args(
         ccol_indices: &Tensor,
         row_indices: &Tensor,
         values: &Tensor,
@@ -7670,7 +7636,7 @@ impl Tensor {
         Ok(())
     }
 
-    pub fn f_internal_validate_sparse_bsr_tensor_args(
+    pub fn internal_validate_sparse_bsr_tensor_args(
         crow_indices: &Tensor,
         col_indices: &Tensor,
         values: &Tensor,
@@ -7686,7 +7652,7 @@ impl Tensor {
         Ok(())
     }
 
-    pub fn f_internal_validate_sparse_compressed_tensor_args(
+    pub fn internal_validate_sparse_compressed_tensor_args(
         compressed_indices: &Tensor,
         plain_indices: &Tensor,
         values: &Tensor,
@@ -7704,7 +7670,7 @@ impl Tensor {
         Ok(())
     }
 
-    pub fn f_internal_validate_sparse_csc_tensor_args(
+    pub fn internal_validate_sparse_csc_tensor_args(
         ccol_indices: &Tensor,
         row_indices: &Tensor,
         values: &Tensor,
@@ -7720,7 +7686,7 @@ impl Tensor {
         Ok(())
     }
 
-    pub fn f_internal_validate_sparse_csr_tensor_args(
+    pub fn internal_validate_sparse_csr_tensor_args(
         crow_indices: &Tensor,
         col_indices: &Tensor,
         values: &Tensor,
@@ -7736,19 +7702,19 @@ impl Tensor {
         Ok(())
     }
 
-    pub fn f_internal_values(&self) -> Result<Tensor, TchError> {
+    pub fn internal_values(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__values(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_values_copy(&self) -> Result<Tensor, TchError> {
+    pub fn internal_values_copy(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__values_copy(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_values_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn internal_values_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__values_copy_out(
             c_tensors.as_mut_ptr(),
@@ -7758,19 +7724,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_version(&self) -> Result<i64, TchError> {
+    pub fn internal_version(&self) -> Result<i64, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg__version(self.c_tensor));
         Ok(return_)
     }
 
-    pub fn f_internal_weight_norm(v: &Tensor, g: &Tensor, dim: i64) -> Result<Tensor, TchError> {
+    pub fn internal_weight_norm(v: &Tensor, g: &Tensor, dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg__weight_norm(c_tensors.as_mut_ptr(), v.c_tensor, g.c_tensor, dim));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_internal_weight_norm_differentiable_backward(
+    pub fn internal_weight_norm_differentiable_backward(
         grad_w: &Tensor,
         saved_v: &Tensor,
         saved_g: &Tensor,
@@ -7789,7 +7755,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_weight_norm_interface(
+    pub fn internal_weight_norm_interface(
         v: &Tensor,
         g: &Tensor,
         dim: i64,
@@ -7804,7 +7770,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_weight_norm_interface_backward(
+    pub fn internal_weight_norm_interface_backward(
         grad_w: &Tensor,
         saved_v: &Tensor,
         saved_g: &Tensor,
@@ -7823,7 +7789,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_weight_norm_interface_backward_out(
+    pub fn internal_weight_norm_interface_backward_out(
         out0: &Tensor,
         out1: &Tensor,
         grad_w: &Tensor,
@@ -7846,7 +7812,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_internal_weight_norm_interface_out(
+    pub fn internal_weight_norm_interface_out(
         out0: &Tensor,
         out1: &Tensor,
         v: &Tensor,
@@ -7865,79 +7831,79 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_abs(&self) -> Result<Tensor, TchError> {
+    pub fn abs(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_abs(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_abs_(&mut self) -> Result<Tensor, TchError> {
+    pub fn abs_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_abs_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_abs_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn abs_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_abs_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_absolute(&self) -> Result<Tensor, TchError> {
+    pub fn absolute(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_absolute(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_absolute_(&mut self) -> Result<Tensor, TchError> {
+    pub fn absolute_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_absolute_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_absolute_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn absolute_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_absolute_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_acos(&self) -> Result<Tensor, TchError> {
+    pub fn acos(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_acos(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_acos_(&mut self) -> Result<Tensor, TchError> {
+    pub fn acos_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_acos_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_acos_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn acos_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_acos_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_acosh(&self) -> Result<Tensor, TchError> {
+    pub fn acosh(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_acosh(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_acosh_(&mut self) -> Result<Tensor, TchError> {
+    pub fn acosh_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_acosh_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_acosh_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn acosh_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_acosh_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_adaptive_avg_pool1d(&self, output_size: impl IntList) -> Result<Tensor, TchError> {
+    pub fn adaptive_avg_pool1d(&self, output_size: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_adaptive_avg_pool1d(
             c_tensors.as_mut_ptr(),
@@ -7948,7 +7914,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_adaptive_avg_pool2d(&self, output_size: impl IntList) -> Result<Tensor, TchError> {
+    pub fn adaptive_avg_pool2d(&self, output_size: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_adaptive_avg_pool2d(
             c_tensors.as_mut_ptr(),
@@ -7959,7 +7925,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_adaptive_avg_pool2d_out(
+    pub fn adaptive_avg_pool2d_out(
         &self,
         out: &Tensor,
         output_size: impl IntList,
@@ -7975,7 +7941,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_adaptive_avg_pool3d(&self, output_size: impl IntList) -> Result<Tensor, TchError> {
+    pub fn adaptive_avg_pool3d(&self, output_size: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_adaptive_avg_pool3d(
             c_tensors.as_mut_ptr(),
@@ -7986,7 +7952,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_adaptive_avg_pool3d_backward(
+    pub fn adaptive_avg_pool3d_backward(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -8001,7 +7967,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_adaptive_avg_pool3d_out(
+    pub fn adaptive_avg_pool3d_out(
         &self,
         out: &Tensor,
         output_size: impl IntList,
@@ -8017,7 +7983,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_adaptive_max_pool1d(
+    pub fn adaptive_max_pool1d(
         &self,
         output_size: impl IntList,
     ) -> Result<(Tensor, Tensor), TchError> {
@@ -8031,7 +7997,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_adaptive_max_pool2d(
+    pub fn adaptive_max_pool2d(
         &self,
         output_size: impl IntList,
     ) -> Result<(Tensor, Tensor), TchError> {
@@ -8045,7 +8011,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_adaptive_max_pool2d_backward(
+    pub fn adaptive_max_pool2d_backward(
         &self,
         grad_output: &Tensor,
         indices: &Tensor,
@@ -8060,7 +8026,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_adaptive_max_pool2d_backward_grad_input(
+    pub fn adaptive_max_pool2d_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -8077,7 +8043,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_adaptive_max_pool2d_out(
+    pub fn adaptive_max_pool2d_out(
         &self,
         out: &Tensor,
         indices: &Tensor,
@@ -8095,7 +8061,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_adaptive_max_pool3d(
+    pub fn adaptive_max_pool3d(
         &self,
         output_size: impl IntList,
     ) -> Result<(Tensor, Tensor), TchError> {
@@ -8109,7 +8075,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_adaptive_max_pool3d_backward(
+    pub fn adaptive_max_pool3d_backward(
         &self,
         grad_output: &Tensor,
         indices: &Tensor,
@@ -8124,7 +8090,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_adaptive_max_pool3d_backward_grad_input(
+    pub fn adaptive_max_pool3d_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -8141,7 +8107,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_adaptive_max_pool3d_out(
+    pub fn adaptive_max_pool3d_out(
         &self,
         out: &Tensor,
         indices: &Tensor,
@@ -8159,19 +8125,19 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_add(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn g_add(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_add(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_add_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn g_add_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_add_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_add_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn add_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_add_out(
             c_tensors.as_mut_ptr(),
@@ -8182,7 +8148,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_add_scalar<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
+    pub fn g_add_scalar<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_add_scalar(
             c_tensors.as_mut_ptr(),
@@ -8192,7 +8158,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_add_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn g_add_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_add_scalar_(
             c_tensors.as_mut_ptr(),
@@ -8202,7 +8168,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_add_scalar_out<S: Into<Scalar>>(
+    pub fn add_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
@@ -8217,7 +8183,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_addbmm(&self, batch1: &Tensor, batch2: &Tensor) -> Result<Tensor, TchError> {
+    pub fn addbmm(&self, batch1: &Tensor, batch2: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_addbmm(
             c_tensors.as_mut_ptr(),
@@ -8228,7 +8194,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_addbmm_(&mut self, batch1: &Tensor, batch2: &Tensor) -> Result<Tensor, TchError> {
+    pub fn addbmm_(&mut self, batch1: &Tensor, batch2: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_addbmm_(
             c_tensors.as_mut_ptr(),
@@ -8239,7 +8205,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_addbmm_out(
+    pub fn addbmm_out(
         &self,
         out: &Tensor,
         batch1: &Tensor,
@@ -8256,7 +8222,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_addcdiv(&self, tensor1: &Tensor, tensor2: &Tensor) -> Result<Tensor, TchError> {
+    pub fn addcdiv(&self, tensor1: &Tensor, tensor2: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_addcdiv(
             c_tensors.as_mut_ptr(),
@@ -8267,7 +8233,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_addcdiv_(&mut self, tensor1: &Tensor, tensor2: &Tensor) -> Result<Tensor, TchError> {
+    pub fn addcdiv_(&mut self, tensor1: &Tensor, tensor2: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_addcdiv_(
             c_tensors.as_mut_ptr(),
@@ -8278,7 +8244,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_addcdiv_out(
+    pub fn addcdiv_out(
         &self,
         out: &Tensor,
         tensor1: &Tensor,
@@ -8295,7 +8261,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_addcmul(&self, tensor1: &Tensor, tensor2: &Tensor) -> Result<Tensor, TchError> {
+    pub fn addcmul(&self, tensor1: &Tensor, tensor2: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_addcmul(
             c_tensors.as_mut_ptr(),
@@ -8306,7 +8272,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_addcmul_(&mut self, tensor1: &Tensor, tensor2: &Tensor) -> Result<Tensor, TchError> {
+    pub fn addcmul_(&mut self, tensor1: &Tensor, tensor2: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_addcmul_(
             c_tensors.as_mut_ptr(),
@@ -8317,7 +8283,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_addcmul_out(
+    pub fn addcmul_out(
         &self,
         out: &Tensor,
         tensor1: &Tensor,
@@ -8334,7 +8300,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_addmm(&self, mat1: &Tensor, mat2: &Tensor) -> Result<Tensor, TchError> {
+    pub fn addmm(&self, mat1: &Tensor, mat2: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_addmm(
             c_tensors.as_mut_ptr(),
@@ -8345,7 +8311,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_addmm_(&mut self, mat1: &Tensor, mat2: &Tensor) -> Result<Tensor, TchError> {
+    pub fn addmm_(&mut self, mat1: &Tensor, mat2: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_addmm_(
             c_tensors.as_mut_ptr(),
@@ -8356,7 +8322,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_addmm_out(
+    pub fn addmm_out(
         &self,
         out: &Tensor,
         mat1: &Tensor,
@@ -8373,7 +8339,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_addmv(&self, mat: &Tensor, vec: &Tensor) -> Result<Tensor, TchError> {
+    pub fn addmv(&self, mat: &Tensor, vec: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_addmv(
             c_tensors.as_mut_ptr(),
@@ -8384,7 +8350,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_addmv_(&mut self, mat: &Tensor, vec: &Tensor) -> Result<Tensor, TchError> {
+    pub fn addmv_(&mut self, mat: &Tensor, vec: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_addmv_(
             c_tensors.as_mut_ptr(),
@@ -8395,12 +8361,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_addmv_out(
-        &self,
-        out: &Tensor,
-        mat: &Tensor,
-        vec: &Tensor,
-    ) -> Result<Tensor, TchError> {
+    pub fn addmv_out(&self, out: &Tensor, mat: &Tensor, vec: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_addmv_out(
             c_tensors.as_mut_ptr(),
@@ -8412,7 +8373,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_addr(&self, vec1: &Tensor, vec2: &Tensor) -> Result<Tensor, TchError> {
+    pub fn addr(&self, vec1: &Tensor, vec2: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_addr(
             c_tensors.as_mut_ptr(),
@@ -8423,7 +8384,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_addr_(&mut self, vec1: &Tensor, vec2: &Tensor) -> Result<Tensor, TchError> {
+    pub fn addr_(&mut self, vec1: &Tensor, vec2: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_addr_(
             c_tensors.as_mut_ptr(),
@@ -8434,12 +8395,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_addr_out(
-        &self,
-        out: &Tensor,
-        vec1: &Tensor,
-        vec2: &Tensor,
-    ) -> Result<Tensor, TchError> {
+    pub fn addr_out(&self, out: &Tensor, vec1: &Tensor, vec2: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_addr_out(
             c_tensors.as_mut_ptr(),
@@ -8451,13 +8407,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_adjoint(&self) -> Result<Tensor, TchError> {
+    pub fn adjoint(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_adjoint(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_affine_grid_generator(
+    pub fn affine_grid_generator(
         theta: &Tensor,
         size: impl IntList,
         align_corners: bool,
@@ -8473,7 +8429,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_affine_grid_generator_backward(
+    pub fn affine_grid_generator_backward(
         grad: &Tensor,
         size: impl IntList,
         align_corners: bool,
@@ -8489,7 +8445,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_affine_grid_generator_out(
+    pub fn affine_grid_generator_out(
         out: &Tensor,
         theta: &Tensor,
         size: impl IntList,
@@ -8507,31 +8463,31 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_alias(&self) -> Result<Tensor, TchError> {
+    pub fn alias(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_alias(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_alias_copy(&self) -> Result<Tensor, TchError> {
+    pub fn alias_copy(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_alias_copy(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_alias_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn alias_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_alias_copy_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_align_as(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn align_as(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_align_as(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_align_tensors<T: Borrow<Tensor>>(tensors: &[T]) -> Result<Vec<Tensor>, TchError> {
+    pub fn align_tensors<T: Borrow<Tensor>>(tensors: &[T]) -> Result<Vec<Tensor>, TchError> {
         let c_tensors =
             unsafe_torch_err!(atg_align_tensors(ptr_list(tensors).as_ptr(), tensors.len() as i32));
         let mut r__ = vec![];
@@ -8548,19 +8504,19 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_all(&self) -> Result<Tensor, TchError> {
+    pub fn all(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_all(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_all_all_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn all_all_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_all_all_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_all_dim(&self, dim: i64, keepdim: bool) -> Result<Tensor, TchError> {
+    pub fn all_dim(&self, dim: i64, keepdim: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_all_dim(
             c_tensors.as_mut_ptr(),
@@ -8571,7 +8527,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_all_out(&self, out: &Tensor, dim: i64, keepdim: bool) -> Result<Tensor, TchError> {
+    pub fn all_out(&self, out: &Tensor, dim: i64, keepdim: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_all_out(
             c_tensors.as_mut_ptr(),
@@ -8583,7 +8539,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_allclose(
+    pub fn allclose(
         &self,
         other: &Tensor,
         rtol: f64,
@@ -8603,7 +8559,7 @@ impl Tensor {
         Ok(return_ != 0)
     }
 
-    pub fn f_alpha_dropout(&self, p: f64, train: bool) -> Result<Tensor, TchError> {
+    pub fn alpha_dropout(&self, p: f64, train: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_alpha_dropout(
             c_tensors.as_mut_ptr(),
@@ -8614,7 +8570,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_alpha_dropout_(&mut self, p: f64, train: bool) -> Result<Tensor, TchError> {
+    pub fn alpha_dropout_(&mut self, p: f64, train: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_alpha_dropout_(
             c_tensors.as_mut_ptr(),
@@ -8625,7 +8581,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_amax(&self, dim: impl IntList, keepdim: bool) -> Result<Tensor, TchError> {
+    pub fn amax(&self, dim: impl IntList, keepdim: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_amax(
             c_tensors.as_mut_ptr(),
@@ -8637,7 +8593,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_amax_out(
+    pub fn amax_out(
         &self,
         out: &Tensor,
         dim: impl IntList,
@@ -8655,7 +8611,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_amin(&self, dim: impl IntList, keepdim: bool) -> Result<Tensor, TchError> {
+    pub fn amin(&self, dim: impl IntList, keepdim: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_amin(
             c_tensors.as_mut_ptr(),
@@ -8667,7 +8623,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_amin_out(
+    pub fn amin_out(
         &self,
         out: &Tensor,
         dim: impl IntList,
@@ -8685,7 +8641,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_aminmax(
+    pub fn aminmax(
         &self,
         dim: impl Into<Option<i64>>,
         keepdim: bool,
@@ -8702,7 +8658,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_aminmax_out(
+    pub fn aminmax_out(
         &self,
         min: &Tensor,
         max: &Tensor,
@@ -8723,31 +8679,31 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_angle(&self) -> Result<Tensor, TchError> {
+    pub fn angle(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_angle(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_angle_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn angle_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_angle_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_any(&self) -> Result<Tensor, TchError> {
+    pub fn any(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_any(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_any_all_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn any_all_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_any_all_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_any_dim(&self, dim: i64, keepdim: bool) -> Result<Tensor, TchError> {
+    pub fn any_dim(&self, dim: i64, keepdim: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_any_dim(
             c_tensors.as_mut_ptr(),
@@ -8758,7 +8714,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_any_out(&self, out: &Tensor, dim: i64, keepdim: bool) -> Result<Tensor, TchError> {
+    pub fn any_out(&self, out: &Tensor, dim: i64, keepdim: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_any_out(
             c_tensors.as_mut_ptr(),
@@ -8770,7 +8726,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_arange<S: Into<Scalar>>(end: S, options: (Kind, Device)) -> Result<Tensor, TchError> {
+    pub fn arange<S: Into<Scalar>>(end: S, options: (Kind, Device)) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_arange(
             c_tensors.as_mut_ptr(),
@@ -8781,7 +8737,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_arange_start<S: Into<Scalar>>(
+    pub fn arange_start<S: Into<Scalar>>(
         start: S,
         end: S,
         options: (Kind, Device),
@@ -8797,7 +8753,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_arange_start_step<S: Into<Scalar>>(
+    pub fn arange_start_step<S: Into<Scalar>>(
         start: S,
         end: S,
         step: S,
@@ -8815,97 +8771,97 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_arccos(&self) -> Result<Tensor, TchError> {
+    pub fn arccos(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_arccos(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_arccos_(&mut self) -> Result<Tensor, TchError> {
+    pub fn arccos_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_arccos_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_arccos_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn arccos_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_arccos_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_arccosh(&self) -> Result<Tensor, TchError> {
+    pub fn arccosh(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_arccosh(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_arccosh_(&mut self) -> Result<Tensor, TchError> {
+    pub fn arccosh_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_arccosh_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_arccosh_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn arccosh_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_arccosh_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_arcsin(&self) -> Result<Tensor, TchError> {
+    pub fn arcsin(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_arcsin(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_arcsin_(&mut self) -> Result<Tensor, TchError> {
+    pub fn arcsin_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_arcsin_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_arcsin_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn arcsin_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_arcsin_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_arcsinh(&self) -> Result<Tensor, TchError> {
+    pub fn arcsinh(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_arcsinh(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_arcsinh_(&mut self) -> Result<Tensor, TchError> {
+    pub fn arcsinh_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_arcsinh_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_arcsinh_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn arcsinh_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_arcsinh_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_arctan(&self) -> Result<Tensor, TchError> {
+    pub fn arctan(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_arctan(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_arctan2(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn arctan2(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_arctan2(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_arctan2_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn arctan2_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_arctan2_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_arctan2_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn arctan2_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_arctan2_out(
             c_tensors.as_mut_ptr(),
@@ -8916,37 +8872,37 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_arctan_(&mut self) -> Result<Tensor, TchError> {
+    pub fn arctan_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_arctan_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_arctan_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn arctan_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_arctan_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_arctanh(&self) -> Result<Tensor, TchError> {
+    pub fn arctanh(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_arctanh(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_arctanh_(&mut self) -> Result<Tensor, TchError> {
+    pub fn arctanh_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_arctanh_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_arctanh_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn arctanh_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_arctanh_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_argmax(&self, dim: impl Into<Option<i64>>, keepdim: bool) -> Result<Tensor, TchError> {
+    pub fn argmax(&self, dim: impl Into<Option<i64>>, keepdim: bool) -> Result<Tensor, TchError> {
         let dim = dim.into();
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_argmax(
@@ -8959,7 +8915,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_argmax_out(
+    pub fn argmax_out(
         &self,
         out: &Tensor,
         dim: impl Into<Option<i64>>,
@@ -8978,7 +8934,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_argmin(&self, dim: impl Into<Option<i64>>, keepdim: bool) -> Result<Tensor, TchError> {
+    pub fn argmin(&self, dim: impl Into<Option<i64>>, keepdim: bool) -> Result<Tensor, TchError> {
         let dim = dim.into();
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_argmin(
@@ -8991,7 +8947,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_argmin_out(
+    pub fn argmin_out(
         &self,
         out: &Tensor,
         dim: impl Into<Option<i64>>,
@@ -9010,7 +8966,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_argsort(&self, dim: i64, descending: bool) -> Result<Tensor, TchError> {
+    pub fn argsort(&self, dim: i64, descending: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_argsort(
             c_tensors.as_mut_ptr(),
@@ -9021,7 +8977,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_argsort_stable(
+    pub fn argsort_stable(
         &self,
         stable: bool,
         dim: i64,
@@ -9038,7 +8994,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_argsort_stable_out(
+    pub fn argsort_stable_out(
         &self,
         out: &Tensor,
         stable: bool,
@@ -9057,13 +9013,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_argwhere(&self) -> Result<Tensor, TchError> {
+    pub fn argwhere(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_argwhere(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_as_strided(
+    pub fn as_strided(
         &self,
         size: impl IntList,
         stride: impl IntList,
@@ -9084,7 +9040,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_as_strided_(
+    pub fn as_strided_(
         &mut self,
         size: impl IntList,
         stride: impl IntList,
@@ -9105,7 +9061,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_as_strided_copy(
+    pub fn as_strided_copy(
         &self,
         size: impl IntList,
         stride: impl IntList,
@@ -9126,7 +9082,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_as_strided_copy_out(
+    pub fn as_strided_copy_out(
         &self,
         out: &Tensor,
         size: impl IntList,
@@ -9149,7 +9105,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_as_strided_scatter(
+    pub fn as_strided_scatter(
         &self,
         src: &Tensor,
         size: impl IntList,
@@ -9172,7 +9128,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_as_strided_scatter_out(
+    pub fn as_strided_scatter_out(
         &self,
         out: &Tensor,
         src: &Tensor,
@@ -9197,61 +9153,61 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_asin(&self) -> Result<Tensor, TchError> {
+    pub fn asin(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_asin(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_asin_(&mut self) -> Result<Tensor, TchError> {
+    pub fn asin_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_asin_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_asin_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn asin_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_asin_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_asinh(&self) -> Result<Tensor, TchError> {
+    pub fn asinh(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_asinh(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_asinh_(&mut self) -> Result<Tensor, TchError> {
+    pub fn asinh_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_asinh_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_asinh_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn asinh_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_asinh_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_atan(&self) -> Result<Tensor, TchError> {
+    pub fn atan(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_atan(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_atan2(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn atan2(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_atan2(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_atan2_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn atan2_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_atan2_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_atan2_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn atan2_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_atan2_out(
             c_tensors.as_mut_ptr(),
@@ -9262,45 +9218,43 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_atan_(&mut self) -> Result<Tensor, TchError> {
+    pub fn atan_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_atan_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_atan_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn atan_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_atan_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_atanh(&self) -> Result<Tensor, TchError> {
+    pub fn atanh(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_atanh(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_atanh_(&mut self) -> Result<Tensor, TchError> {
+    pub fn atanh_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_atanh_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_atanh_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn atanh_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_atanh_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_atleast_1d(&self) -> Result<Tensor, TchError> {
+    pub fn atleast_1d(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_atleast_1d(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_atleast_1d_sequence<T: Borrow<Tensor>>(
-        tensors: &[T],
-    ) -> Result<Vec<Tensor>, TchError> {
+    pub fn atleast_1d_sequence<T: Borrow<Tensor>>(tensors: &[T]) -> Result<Vec<Tensor>, TchError> {
         let c_tensors = unsafe_torch_err!(atg_atleast_1d_sequence(
             ptr_list(tensors).as_ptr(),
             tensors.len() as i32
@@ -9319,15 +9273,13 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_atleast_2d(&self) -> Result<Tensor, TchError> {
+    pub fn atleast_2d(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_atleast_2d(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_atleast_2d_sequence<T: Borrow<Tensor>>(
-        tensors: &[T],
-    ) -> Result<Vec<Tensor>, TchError> {
+    pub fn atleast_2d_sequence<T: Borrow<Tensor>>(tensors: &[T]) -> Result<Vec<Tensor>, TchError> {
         let c_tensors = unsafe_torch_err!(atg_atleast_2d_sequence(
             ptr_list(tensors).as_ptr(),
             tensors.len() as i32
@@ -9346,15 +9298,13 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_atleast_3d(&self) -> Result<Tensor, TchError> {
+    pub fn atleast_3d(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_atleast_3d(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_atleast_3d_sequence<T: Borrow<Tensor>>(
-        tensors: &[T],
-    ) -> Result<Vec<Tensor>, TchError> {
+    pub fn atleast_3d_sequence<T: Borrow<Tensor>>(tensors: &[T]) -> Result<Vec<Tensor>, TchError> {
         let c_tensors = unsafe_torch_err!(atg_atleast_3d_sequence(
             ptr_list(tensors).as_ptr(),
             tensors.len() as i32
@@ -9373,7 +9323,7 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_avg_pool1d(
+    pub fn avg_pool1d(
         &self,
         kernel_size: impl IntList,
         stride: impl IntList,
@@ -9397,7 +9347,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_avg_pool2d(
+    pub fn avg_pool2d(
         &self,
         kernel_size: impl IntList,
         stride: impl IntList,
@@ -9425,7 +9375,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_avg_pool2d_backward(
+    pub fn avg_pool2d_backward(
         &self,
         grad_output: &Tensor,
         kernel_size: impl IntList,
@@ -9455,7 +9405,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_avg_pool2d_backward_grad_input(
+    pub fn avg_pool2d_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -9487,7 +9437,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_avg_pool2d_out(
+    pub fn avg_pool2d_out(
         &self,
         out: &Tensor,
         kernel_size: impl IntList,
@@ -9517,7 +9467,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_avg_pool3d(
+    pub fn avg_pool3d(
         &self,
         kernel_size: impl IntList,
         stride: impl IntList,
@@ -9545,7 +9495,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_avg_pool3d_backward(
+    pub fn avg_pool3d_backward(
         &self,
         grad_output: &Tensor,
         kernel_size: impl IntList,
@@ -9575,7 +9525,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_avg_pool3d_backward_grad_input(
+    pub fn avg_pool3d_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -9607,7 +9557,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_avg_pool3d_out(
+    pub fn avg_pool3d_out(
         &self,
         out: &Tensor,
         kernel_size: impl IntList,
@@ -9637,7 +9587,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_baddbmm<S: Into<Scalar>>(
+    pub fn baddbmm<S: Into<Scalar>>(
         &self,
         batch1: &Tensor,
         batch2: &Tensor,
@@ -9656,7 +9606,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_baddbmm_(&mut self, batch1: &Tensor, batch2: &Tensor) -> Result<Tensor, TchError> {
+    pub fn baddbmm_(&mut self, batch1: &Tensor, batch2: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_baddbmm_(
             c_tensors.as_mut_ptr(),
@@ -9667,7 +9617,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_baddbmm_out(
+    pub fn baddbmm_out(
         &self,
         out: &Tensor,
         batch1: &Tensor,
@@ -9684,7 +9634,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bartlett_window(
+    pub fn bartlett_window(
         window_length: i64,
         options: (Kind, Device),
     ) -> Result<Tensor, TchError> {
@@ -9698,7 +9648,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bartlett_window_out(out: &Tensor, window_length: i64) -> Result<Tensor, TchError> {
+    pub fn bartlett_window_out(out: &Tensor, window_length: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_bartlett_window_out(
             c_tensors.as_mut_ptr(),
@@ -9708,7 +9658,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bartlett_window_periodic(
+    pub fn bartlett_window_periodic(
         window_length: i64,
         periodic: bool,
         options: (Kind, Device),
@@ -9724,7 +9674,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bartlett_window_periodic_out(
+    pub fn bartlett_window_periodic_out(
         out: &Tensor,
         window_length: i64,
         periodic: bool,
@@ -9739,7 +9689,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_batch_norm<T: Borrow<Tensor>>(
+    pub fn batch_norm<T: Borrow<Tensor>>(
         &self,
         weight: Option<T>,
         bias: Option<T>,
@@ -9766,7 +9716,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_batch_norm_backward_elemt<T: Borrow<Tensor>>(
+    pub fn batch_norm_backward_elemt<T: Borrow<Tensor>>(
         &self,
         grad_out: &Tensor,
         mean: &Tensor,
@@ -9791,7 +9741,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_batch_norm_backward_elemt_out<T: Borrow<Tensor>>(
+    pub fn batch_norm_backward_elemt_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         grad_out: &Tensor,
@@ -9818,7 +9768,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_batch_norm_backward_reduce<T: Borrow<Tensor>>(
+    pub fn batch_norm_backward_reduce<T: Borrow<Tensor>>(
         &self,
         grad_out: &Tensor,
         mean: &Tensor,
@@ -9848,7 +9798,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_batch_norm_backward_reduce_out<T: Borrow<Tensor>>(
+    pub fn batch_norm_backward_reduce_out<T: Borrow<Tensor>>(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -9886,7 +9836,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_batch_norm_elemt<T: Borrow<Tensor>>(
+    pub fn batch_norm_elemt<T: Borrow<Tensor>>(
         &self,
         weight: Option<T>,
         bias: Option<T>,
@@ -9907,7 +9857,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_batch_norm_elemt_out<T: Borrow<Tensor>>(
+    pub fn batch_norm_elemt_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: Option<T>,
@@ -9930,7 +9880,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_batch_norm_gather_stats<T: Borrow<Tensor>>(
+    pub fn batch_norm_gather_stats<T: Borrow<Tensor>>(
         &self,
         mean: &Tensor,
         invstd: &Tensor,
@@ -9955,7 +9905,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_batch_norm_gather_stats_out<T: Borrow<Tensor>>(
+    pub fn batch_norm_gather_stats_out<T: Borrow<Tensor>>(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -9984,7 +9934,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_batch_norm_gather_stats_with_counts<T: Borrow<Tensor>>(
+    pub fn batch_norm_gather_stats_with_counts<T: Borrow<Tensor>>(
         &self,
         mean: &Tensor,
         invstd: &Tensor,
@@ -10009,7 +9959,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_batch_norm_gather_stats_with_counts_out<T: Borrow<Tensor>>(
+    pub fn batch_norm_gather_stats_with_counts_out<T: Borrow<Tensor>>(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -10038,13 +9988,13 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_batch_norm_stats(&self, eps: f64) -> Result<(Tensor, Tensor), TchError> {
+    pub fn batch_norm_stats(&self, eps: f64) -> Result<(Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 2];
         unsafe_torch_err!(atg_batch_norm_stats(c_tensors.as_mut_ptr(), self.c_tensor, eps));
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_batch_norm_stats_out(
+    pub fn batch_norm_stats_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -10061,7 +10011,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_batch_norm_update_stats<T: Borrow<Tensor>>(
+    pub fn batch_norm_update_stats<T: Borrow<Tensor>>(
         &self,
         running_mean: Option<T>,
         running_var: Option<T>,
@@ -10078,7 +10028,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_batch_norm_update_stats_out<T: Borrow<Tensor>>(
+    pub fn batch_norm_update_stats_out<T: Borrow<Tensor>>(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -10099,37 +10049,37 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_bernoulli(&self) -> Result<Tensor, TchError> {
+    pub fn bernoulli(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_bernoulli(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bernoulli_(&mut self, p: &Tensor) -> Result<Tensor, TchError> {
+    pub fn bernoulli_(&mut self, p: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_bernoulli_(c_tensors.as_mut_ptr(), self.c_tensor, p.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bernoulli_float_(&mut self, p: f64) -> Result<Tensor, TchError> {
+    pub fn bernoulli_float_(&mut self, p: f64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_bernoulli_float_(c_tensors.as_mut_ptr(), self.c_tensor, p));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bernoulli_p(&self, p: f64) -> Result<Tensor, TchError> {
+    pub fn bernoulli_p(&self, p: f64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_bernoulli_p(c_tensors.as_mut_ptr(), self.c_tensor, p));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bernoulli_tensor(&self, p: &Tensor) -> Result<Tensor, TchError> {
+    pub fn bernoulli_tensor(&self, p: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_bernoulli_tensor(c_tensors.as_mut_ptr(), self.c_tensor, p.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bilinear<T: Borrow<Tensor>>(
+    pub fn bilinear<T: Borrow<Tensor>>(
         input1: &Tensor,
         input2: &Tensor,
         weight: &Tensor,
@@ -10146,7 +10096,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_binary_cross_entropy<T: Borrow<Tensor>>(
+    pub fn binary_cross_entropy<T: Borrow<Tensor>>(
         &self,
         target: &Tensor,
         weight: Option<T>,
@@ -10163,7 +10113,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_binary_cross_entropy_backward<T: Borrow<Tensor>>(
+    pub fn binary_cross_entropy_backward<T: Borrow<Tensor>>(
         &self,
         grad_output: &Tensor,
         target: &Tensor,
@@ -10182,7 +10132,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_binary_cross_entropy_backward_grad_input<T: Borrow<Tensor>>(
+    pub fn binary_cross_entropy_backward_grad_input<T: Borrow<Tensor>>(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -10203,7 +10153,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_binary_cross_entropy_out<T: Borrow<Tensor>>(
+    pub fn binary_cross_entropy_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         target: &Tensor,
@@ -10222,7 +10172,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_binary_cross_entropy_with_logits<T: Borrow<Tensor>>(
+    pub fn binary_cross_entropy_with_logits<T: Borrow<Tensor>>(
         &self,
         target: &Tensor,
         weight: Option<T>,
@@ -10241,7 +10191,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_binary_cross_entropy_with_logits_out<T: Borrow<Tensor>>(
+    pub fn binary_cross_entropy_with_logits_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         target: &Tensor,
@@ -10262,7 +10212,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bincount<T: Borrow<Tensor>>(
+    pub fn bincount<T: Borrow<Tensor>>(
         &self,
         weights: Option<T>,
         minlength: i64,
@@ -10277,7 +10227,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bincount_out<T: Borrow<Tensor>>(
+    pub fn bincount_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weights: Option<T>,
@@ -10294,13 +10244,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_binomial(count: &Tensor, prob: &Tensor) -> Result<Tensor, TchError> {
+    pub fn binomial(count: &Tensor, prob: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_binomial(c_tensors.as_mut_ptr(), count.c_tensor, prob.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_binomial_out(out: &Tensor, count: &Tensor, prob: &Tensor) -> Result<Tensor, TchError> {
+    pub fn binomial_out(out: &Tensor, count: &Tensor, prob: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_binomial_out(
             c_tensors.as_mut_ptr(),
@@ -10311,7 +10261,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_and<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
+    pub fn bitwise_and<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_bitwise_and(
             c_tensors.as_mut_ptr(),
@@ -10321,7 +10271,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_and_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn bitwise_and_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_bitwise_and_(
             c_tensors.as_mut_ptr(),
@@ -10331,7 +10281,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_and_scalar_out<S: Into<Scalar>>(
+    pub fn bitwise_and_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
@@ -10346,7 +10296,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_and_scalar_tensor<S: Into<Scalar>>(
+    pub fn bitwise_and_scalar_tensor<S: Into<Scalar>>(
         self_scalar: S,
         other: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -10359,7 +10309,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_and_scalar_tensor_out<S: Into<Scalar>>(
+    pub fn bitwise_and_scalar_tensor_out<S: Into<Scalar>>(
         out: &Tensor,
         self_scalar: S,
         other: &Tensor,
@@ -10374,7 +10324,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_and_tensor(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn bitwise_and_tensor(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_bitwise_and_tensor(
             c_tensors.as_mut_ptr(),
@@ -10384,7 +10334,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_and_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn bitwise_and_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_bitwise_and_tensor_(
             c_tensors.as_mut_ptr(),
@@ -10394,11 +10344,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_and_tensor_out(
-        &self,
-        out: &Tensor,
-        other: &Tensor,
-    ) -> Result<Tensor, TchError> {
+    pub fn bitwise_and_tensor_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_bitwise_and_tensor_out(
             c_tensors.as_mut_ptr(),
@@ -10409,7 +10355,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_left_shift(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn bitwise_left_shift(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_bitwise_left_shift(
             c_tensors.as_mut_ptr(),
@@ -10419,7 +10365,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_left_shift_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn bitwise_left_shift_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_bitwise_left_shift_(
             c_tensors.as_mut_ptr(),
@@ -10429,7 +10375,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_left_shift_scalar_tensor<S: Into<Scalar>>(
+    pub fn bitwise_left_shift_scalar_tensor<S: Into<Scalar>>(
         self_scalar: S,
         other: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -10442,7 +10388,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_left_shift_scalar_tensor_out<S: Into<Scalar>>(
+    pub fn bitwise_left_shift_scalar_tensor_out<S: Into<Scalar>>(
         out: &Tensor,
         self_scalar: S,
         other: &Tensor,
@@ -10457,7 +10403,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_left_shift_tensor_out(
+    pub fn bitwise_left_shift_tensor_out(
         &self,
         out: &Tensor,
         other: &Tensor,
@@ -10472,7 +10418,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_left_shift_tensor_scalar<S: Into<Scalar>>(
+    pub fn bitwise_left_shift_tensor_scalar<S: Into<Scalar>>(
         &self,
         other: S,
     ) -> Result<Tensor, TchError> {
@@ -10485,7 +10431,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_left_shift_tensor_scalar_<S: Into<Scalar>>(
+    pub fn bitwise_left_shift_tensor_scalar_<S: Into<Scalar>>(
         &mut self,
         other: S,
     ) -> Result<Tensor, TchError> {
@@ -10498,7 +10444,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_left_shift_tensor_scalar_out<S: Into<Scalar>>(
+    pub fn bitwise_left_shift_tensor_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
@@ -10513,25 +10459,25 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_not(&self) -> Result<Tensor, TchError> {
+    pub fn bitwise_not(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_bitwise_not(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_not_(&mut self) -> Result<Tensor, TchError> {
+    pub fn bitwise_not_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_bitwise_not_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_not_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn bitwise_not_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_bitwise_not_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_or<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
+    pub fn bitwise_or<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_bitwise_or(
             c_tensors.as_mut_ptr(),
@@ -10541,7 +10487,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_or_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn bitwise_or_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_bitwise_or_(
             c_tensors.as_mut_ptr(),
@@ -10551,7 +10497,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_or_scalar_out<S: Into<Scalar>>(
+    pub fn bitwise_or_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
@@ -10566,7 +10512,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_or_scalar_tensor<S: Into<Scalar>>(
+    pub fn bitwise_or_scalar_tensor<S: Into<Scalar>>(
         self_scalar: S,
         other: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -10579,7 +10525,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_or_scalar_tensor_out<S: Into<Scalar>>(
+    pub fn bitwise_or_scalar_tensor_out<S: Into<Scalar>>(
         out: &Tensor,
         self_scalar: S,
         other: &Tensor,
@@ -10594,7 +10540,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_or_tensor(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn bitwise_or_tensor(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_bitwise_or_tensor(
             c_tensors.as_mut_ptr(),
@@ -10604,7 +10550,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_or_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn bitwise_or_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_bitwise_or_tensor_(
             c_tensors.as_mut_ptr(),
@@ -10614,11 +10560,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_or_tensor_out(
-        &self,
-        out: &Tensor,
-        other: &Tensor,
-    ) -> Result<Tensor, TchError> {
+    pub fn bitwise_or_tensor_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_bitwise_or_tensor_out(
             c_tensors.as_mut_ptr(),
@@ -10629,7 +10571,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_right_shift(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn bitwise_right_shift(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_bitwise_right_shift(
             c_tensors.as_mut_ptr(),
@@ -10639,7 +10581,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_right_shift_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn bitwise_right_shift_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_bitwise_right_shift_(
             c_tensors.as_mut_ptr(),
@@ -10649,7 +10591,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_right_shift_scalar_tensor<S: Into<Scalar>>(
+    pub fn bitwise_right_shift_scalar_tensor<S: Into<Scalar>>(
         self_scalar: S,
         other: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -10662,7 +10604,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_right_shift_scalar_tensor_out<S: Into<Scalar>>(
+    pub fn bitwise_right_shift_scalar_tensor_out<S: Into<Scalar>>(
         out: &Tensor,
         self_scalar: S,
         other: &Tensor,
@@ -10677,7 +10619,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_right_shift_tensor_out(
+    pub fn bitwise_right_shift_tensor_out(
         &self,
         out: &Tensor,
         other: &Tensor,
@@ -10692,7 +10634,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_right_shift_tensor_scalar<S: Into<Scalar>>(
+    pub fn bitwise_right_shift_tensor_scalar<S: Into<Scalar>>(
         &self,
         other: S,
     ) -> Result<Tensor, TchError> {
@@ -10705,7 +10647,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_right_shift_tensor_scalar_<S: Into<Scalar>>(
+    pub fn bitwise_right_shift_tensor_scalar_<S: Into<Scalar>>(
         &mut self,
         other: S,
     ) -> Result<Tensor, TchError> {
@@ -10718,7 +10660,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_right_shift_tensor_scalar_out<S: Into<Scalar>>(
+    pub fn bitwise_right_shift_tensor_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
@@ -10733,7 +10675,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_xor<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
+    pub fn bitwise_xor<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_bitwise_xor(
             c_tensors.as_mut_ptr(),
@@ -10743,7 +10685,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_xor_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn bitwise_xor_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_bitwise_xor_(
             c_tensors.as_mut_ptr(),
@@ -10753,7 +10695,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_xor_scalar_out<S: Into<Scalar>>(
+    pub fn bitwise_xor_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
@@ -10768,7 +10710,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_xor_scalar_tensor<S: Into<Scalar>>(
+    pub fn bitwise_xor_scalar_tensor<S: Into<Scalar>>(
         self_scalar: S,
         other: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -10781,7 +10723,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_xor_scalar_tensor_out<S: Into<Scalar>>(
+    pub fn bitwise_xor_scalar_tensor_out<S: Into<Scalar>>(
         out: &Tensor,
         self_scalar: S,
         other: &Tensor,
@@ -10796,7 +10738,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_xor_tensor(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn bitwise_xor_tensor(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_bitwise_xor_tensor(
             c_tensors.as_mut_ptr(),
@@ -10806,7 +10748,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_xor_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn bitwise_xor_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_bitwise_xor_tensor_(
             c_tensors.as_mut_ptr(),
@@ -10816,11 +10758,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bitwise_xor_tensor_out(
-        &self,
-        out: &Tensor,
-        other: &Tensor,
-    ) -> Result<Tensor, TchError> {
+    pub fn bitwise_xor_tensor_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_bitwise_xor_tensor_out(
             c_tensors.as_mut_ptr(),
@@ -10831,7 +10769,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_blackman_window(
+    pub fn blackman_window(
         window_length: i64,
         options: (Kind, Device),
     ) -> Result<Tensor, TchError> {
@@ -10845,7 +10783,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_blackman_window_out(out: &Tensor, window_length: i64) -> Result<Tensor, TchError> {
+    pub fn blackman_window_out(out: &Tensor, window_length: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_blackman_window_out(
             c_tensors.as_mut_ptr(),
@@ -10855,7 +10793,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_blackman_window_periodic(
+    pub fn blackman_window_periodic(
         window_length: i64,
         periodic: bool,
         options: (Kind, Device),
@@ -10871,7 +10809,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_blackman_window_periodic_out(
+    pub fn blackman_window_periodic_out(
         out: &Tensor,
         window_length: i64,
         periodic: bool,
@@ -10886,7 +10824,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_block_diag<T: Borrow<Tensor>>(tensors: &[T]) -> Result<Tensor, TchError> {
+    pub fn block_diag<T: Borrow<Tensor>>(tensors: &[T]) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_block_diag(
             c_tensors.as_mut_ptr(),
@@ -10896,7 +10834,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_block_diag_out<T: Borrow<Tensor>>(
+    pub fn block_diag_out<T: Borrow<Tensor>>(
         out: &Tensor,
         tensors: &[T],
     ) -> Result<Tensor, TchError> {
@@ -10910,13 +10848,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bmm(&self, mat2: &Tensor) -> Result<Tensor, TchError> {
+    pub fn bmm(&self, mat2: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_bmm(c_tensors.as_mut_ptr(), self.c_tensor, mat2.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bmm_out(&self, out: &Tensor, mat2: &Tensor) -> Result<Tensor, TchError> {
+    pub fn bmm_out(&self, out: &Tensor, mat2: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_bmm_out(
             c_tensors.as_mut_ptr(),
@@ -10927,7 +10865,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_broadcast_tensors<T: Borrow<Tensor>>(tensors: &[T]) -> Result<Vec<Tensor>, TchError> {
+    pub fn broadcast_tensors<T: Borrow<Tensor>>(tensors: &[T]) -> Result<Vec<Tensor>, TchError> {
         let c_tensors = unsafe_torch_err!(atg_broadcast_tensors(
             ptr_list(tensors).as_ptr(),
             tensors.len() as i32
@@ -10946,7 +10884,7 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_broadcast_to(&self, size: impl IntList) -> Result<Tensor, TchError> {
+    pub fn broadcast_to(&self, size: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_broadcast_to(
             c_tensors.as_mut_ptr(),
@@ -10957,7 +10895,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bucketize(
+    pub fn bucketize(
         &self,
         boundaries: &Tensor,
         out_int32: bool,
@@ -10974,7 +10912,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bucketize_scalar<S: Into<Scalar>>(
+    pub fn bucketize_scalar<S: Into<Scalar>>(
         self_scalar: S,
         boundaries: &Tensor,
         out_int32: bool,
@@ -10991,7 +10929,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bucketize_scalar_out<S: Into<Scalar>>(
+    pub fn bucketize_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         self_scalar: S,
         boundaries: &Tensor,
@@ -11010,7 +10948,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_bucketize_tensor_out(
+    pub fn bucketize_tensor_out(
         &self,
         out: &Tensor,
         boundaries: &Tensor,
@@ -11029,13 +10967,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_can_cast(from: Kind, to: Kind) -> Result<bool, TchError> {
+    pub fn can_cast(from: Kind, to: Kind) -> Result<bool, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg_can_cast(from.c_int(), to.c_int()));
         Ok(return_ != 0)
     }
 
-    pub fn f_cartesian_prod<T: Borrow<Tensor>>(tensors: &[T]) -> Result<Tensor, TchError> {
+    pub fn cartesian_prod<T: Borrow<Tensor>>(tensors: &[T]) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_cartesian_prod(
             c_tensors.as_mut_ptr(),
@@ -11045,7 +10983,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cat<T: Borrow<Tensor>>(tensors: &[T], dim: i64) -> Result<Tensor, TchError> {
+    pub fn cat<T: Borrow<Tensor>>(tensors: &[T], dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_cat(
             c_tensors.as_mut_ptr(),
@@ -11056,7 +10994,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cat_out<T: Borrow<Tensor>>(
+    pub fn cat_out<T: Borrow<Tensor>>(
         out: &Tensor,
         tensors: &[T],
         dim: i64,
@@ -11072,19 +11010,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cauchy(&self, median: f64, sigma: f64) -> Result<Tensor, TchError> {
+    pub fn cauchy(&self, median: f64, sigma: f64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_cauchy(c_tensors.as_mut_ptr(), self.c_tensor, median, sigma));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cauchy_(&mut self, median: f64, sigma: f64) -> Result<Tensor, TchError> {
+    pub fn cauchy_(&mut self, median: f64, sigma: f64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_cauchy_(c_tensors.as_mut_ptr(), self.c_tensor, median, sigma));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cauchy_out(&self, out: &Tensor, median: f64, sigma: f64) -> Result<Tensor, TchError> {
+    pub fn cauchy_out(&self, out: &Tensor, median: f64, sigma: f64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_cauchy_out(
             c_tensors.as_mut_ptr(),
@@ -11096,19 +11034,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_ccol_indices(&self) -> Result<Tensor, TchError> {
+    pub fn ccol_indices(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_ccol_indices(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_ccol_indices_copy(&self) -> Result<Tensor, TchError> {
+    pub fn ccol_indices_copy(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_ccol_indices_copy(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_ccol_indices_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn ccol_indices_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_ccol_indices_copy_out(
             c_tensors.as_mut_ptr(),
@@ -11118,7 +11056,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cdist(
+    pub fn cdist(
         x1: &Tensor,
         x2: &Tensor,
         p: f64,
@@ -11137,43 +11075,43 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_ceil(&self) -> Result<Tensor, TchError> {
+    pub fn ceil(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_ceil(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_ceil_(&mut self) -> Result<Tensor, TchError> {
+    pub fn ceil_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_ceil_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_ceil_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn ceil_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_ceil_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_celu(&self) -> Result<Tensor, TchError> {
+    pub fn celu(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_celu(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_celu_(&mut self) -> Result<Tensor, TchError> {
+    pub fn celu_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_celu_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_celu_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn celu_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_celu_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_chain_matmul<T: Borrow<Tensor>>(matrices: &[T]) -> Result<Tensor, TchError> {
+    pub fn chain_matmul<T: Borrow<Tensor>>(matrices: &[T]) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_chain_matmul(
             c_tensors.as_mut_ptr(),
@@ -11183,7 +11121,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_chain_matmul_out<T: Borrow<Tensor>>(
+    pub fn chain_matmul_out<T: Borrow<Tensor>>(
         out: &Tensor,
         matrices: &[T],
     ) -> Result<Tensor, TchError> {
@@ -11197,19 +11135,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_chalf(&self) -> Result<Tensor, TchError> {
+    pub fn chalf(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_chalf(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_channel_shuffle(&self, groups: i64) -> Result<Tensor, TchError> {
+    pub fn channel_shuffle(&self, groups: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_channel_shuffle(c_tensors.as_mut_ptr(), self.c_tensor, groups));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_channel_shuffle_out(&self, out: &Tensor, groups: i64) -> Result<Tensor, TchError> {
+    pub fn channel_shuffle_out(&self, out: &Tensor, groups: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_channel_shuffle_out(
             c_tensors.as_mut_ptr(),
@@ -11220,7 +11158,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cholesky(&self, upper: bool) -> Result<Tensor, TchError> {
+    pub fn cholesky(&self, upper: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_cholesky(
             c_tensors.as_mut_ptr(),
@@ -11230,7 +11168,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cholesky_inverse(&self, upper: bool) -> Result<Tensor, TchError> {
+    pub fn cholesky_inverse(&self, upper: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_cholesky_inverse(
             c_tensors.as_mut_ptr(),
@@ -11240,7 +11178,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cholesky_inverse_out(&self, out: &Tensor, upper: bool) -> Result<Tensor, TchError> {
+    pub fn cholesky_inverse_out(&self, out: &Tensor, upper: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_cholesky_inverse_out(
             c_tensors.as_mut_ptr(),
@@ -11251,7 +11189,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cholesky_out(&self, out: &Tensor, upper: bool) -> Result<Tensor, TchError> {
+    pub fn cholesky_out(&self, out: &Tensor, upper: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_cholesky_out(
             c_tensors.as_mut_ptr(),
@@ -11262,7 +11200,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cholesky_solve(&self, input2: &Tensor, upper: bool) -> Result<Tensor, TchError> {
+    pub fn cholesky_solve(&self, input2: &Tensor, upper: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_cholesky_solve(
             c_tensors.as_mut_ptr(),
@@ -11273,7 +11211,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cholesky_solve_out(
+    pub fn cholesky_solve_out(
         &self,
         out: &Tensor,
         input2: &Tensor,
@@ -11290,7 +11228,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_choose_qparams_optimized(
+    pub fn choose_qparams_optimized(
         &self,
         numel: i64,
         n_bins: i64,
@@ -11309,7 +11247,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_chunk(&self, chunks: i64, dim: i64) -> Result<Vec<Tensor>, TchError> {
+    pub fn chunk(&self, chunks: i64, dim: i64) -> Result<Vec<Tensor>, TchError> {
         let c_tensors = unsafe_torch_err!(atg_chunk(self.c_tensor, chunks, dim));
         let mut r__ = vec![];
         let mut i = 0;
@@ -11325,7 +11263,7 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_clamp<S: Into<Scalar>>(&self, min: S, max: S) -> Result<Tensor, TchError> {
+    pub fn clamp<S: Into<Scalar>>(&self, min: S, max: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_clamp(
             c_tensors.as_mut_ptr(),
@@ -11336,7 +11274,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_clamp_<S: Into<Scalar>>(&mut self, min: S, max: S) -> Result<Tensor, TchError> {
+    pub fn clamp_<S: Into<Scalar>>(&mut self, min: S, max: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_clamp_(
             c_tensors.as_mut_ptr(),
@@ -11347,7 +11285,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_clamp_max<S: Into<Scalar>>(&self, max: S) -> Result<Tensor, TchError> {
+    pub fn clamp_max<S: Into<Scalar>>(&self, max: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_clamp_max(
             c_tensors.as_mut_ptr(),
@@ -11357,7 +11295,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_clamp_max_<S: Into<Scalar>>(&mut self, max: S) -> Result<Tensor, TchError> {
+    pub fn clamp_max_<S: Into<Scalar>>(&mut self, max: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_clamp_max_(
             c_tensors.as_mut_ptr(),
@@ -11367,11 +11305,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_clamp_max_out<S: Into<Scalar>>(
-        &self,
-        out: &Tensor,
-        max: S,
-    ) -> Result<Tensor, TchError> {
+    pub fn clamp_max_out<S: Into<Scalar>>(&self, out: &Tensor, max: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_clamp_max_out(
             c_tensors.as_mut_ptr(),
@@ -11382,7 +11316,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_clamp_max_tensor(&self, max: &Tensor) -> Result<Tensor, TchError> {
+    pub fn clamp_max_tensor(&self, max: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_clamp_max_tensor(
             c_tensors.as_mut_ptr(),
@@ -11392,7 +11326,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_clamp_max_tensor_(&mut self, max: &Tensor) -> Result<Tensor, TchError> {
+    pub fn clamp_max_tensor_(&mut self, max: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_clamp_max_tensor_(
             c_tensors.as_mut_ptr(),
@@ -11402,7 +11336,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_clamp_max_tensor_out(&self, out: &Tensor, max: &Tensor) -> Result<Tensor, TchError> {
+    pub fn clamp_max_tensor_out(&self, out: &Tensor, max: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_clamp_max_tensor_out(
             c_tensors.as_mut_ptr(),
@@ -11413,7 +11347,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_clamp_min<S: Into<Scalar>>(&self, min: S) -> Result<Tensor, TchError> {
+    pub fn clamp_min<S: Into<Scalar>>(&self, min: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_clamp_min(
             c_tensors.as_mut_ptr(),
@@ -11423,7 +11357,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_clamp_min_<S: Into<Scalar>>(&mut self, min: S) -> Result<Tensor, TchError> {
+    pub fn clamp_min_<S: Into<Scalar>>(&mut self, min: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_clamp_min_(
             c_tensors.as_mut_ptr(),
@@ -11433,11 +11367,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_clamp_min_out<S: Into<Scalar>>(
-        &self,
-        out: &Tensor,
-        min: S,
-    ) -> Result<Tensor, TchError> {
+    pub fn clamp_min_out<S: Into<Scalar>>(&self, out: &Tensor, min: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_clamp_min_out(
             c_tensors.as_mut_ptr(),
@@ -11448,7 +11378,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_clamp_min_tensor(&self, min: &Tensor) -> Result<Tensor, TchError> {
+    pub fn clamp_min_tensor(&self, min: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_clamp_min_tensor(
             c_tensors.as_mut_ptr(),
@@ -11458,7 +11388,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_clamp_min_tensor_(&mut self, min: &Tensor) -> Result<Tensor, TchError> {
+    pub fn clamp_min_tensor_(&mut self, min: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_clamp_min_tensor_(
             c_tensors.as_mut_ptr(),
@@ -11468,7 +11398,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_clamp_min_tensor_out(&self, out: &Tensor, min: &Tensor) -> Result<Tensor, TchError> {
+    pub fn clamp_min_tensor_out(&self, out: &Tensor, min: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_clamp_min_tensor_out(
             c_tensors.as_mut_ptr(),
@@ -11479,7 +11409,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_clamp_out<S: Into<Scalar>>(
+    pub fn clamp_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         min: S,
@@ -11496,7 +11426,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_clamp_tensor<T: Borrow<Tensor>>(
+    pub fn clamp_tensor<T: Borrow<Tensor>>(
         &self,
         min: Option<T>,
         max: Option<T>,
@@ -11511,7 +11441,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_clamp_tensor_<T: Borrow<Tensor>>(
+    pub fn clamp_tensor_<T: Borrow<Tensor>>(
         &mut self,
         min: Option<T>,
         max: Option<T>,
@@ -11526,7 +11456,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_clamp_tensor_out<T: Borrow<Tensor>>(
+    pub fn clamp_tensor_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         min: Option<T>,
@@ -11543,7 +11473,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_clip<S: Into<Scalar>>(&self, min: S, max: S) -> Result<Tensor, TchError> {
+    pub fn clip<S: Into<Scalar>>(&self, min: S, max: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_clip(
             c_tensors.as_mut_ptr(),
@@ -11554,7 +11484,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_clip_<S: Into<Scalar>>(&mut self, min: S, max: S) -> Result<Tensor, TchError> {
+    pub fn clip_<S: Into<Scalar>>(&mut self, min: S, max: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_clip_(
             c_tensors.as_mut_ptr(),
@@ -11565,7 +11495,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_clip_out<S: Into<Scalar>>(
+    pub fn clip_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         min: S,
@@ -11582,7 +11512,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_clip_tensor<T: Borrow<Tensor>>(
+    pub fn clip_tensor<T: Borrow<Tensor>>(
         &self,
         min: Option<T>,
         max: Option<T>,
@@ -11597,7 +11527,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_clip_tensor_<T: Borrow<Tensor>>(
+    pub fn clip_tensor_<T: Borrow<Tensor>>(
         &mut self,
         min: Option<T>,
         max: Option<T>,
@@ -11612,7 +11542,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_clip_tensor_out<T: Borrow<Tensor>>(
+    pub fn clip_tensor_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         min: Option<T>,
@@ -11629,19 +11559,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_clone(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn clone(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_clone(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_coalesce(&self) -> Result<Tensor, TchError> {
+    pub fn coalesce(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_coalesce(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_col2im(
+    pub fn col2im(
         &self,
         output_size: impl IntList,
         kernel_size: impl IntList,
@@ -11667,7 +11597,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_col2im_out(
+    pub fn col2im_out(
         &self,
         out: &Tensor,
         output_size: impl IntList,
@@ -11695,19 +11625,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_col_indices(&self) -> Result<Tensor, TchError> {
+    pub fn col_indices(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_col_indices(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_col_indices_copy(&self) -> Result<Tensor, TchError> {
+    pub fn col_indices_copy(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_col_indices_copy(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_col_indices_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn col_indices_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_col_indices_copy_out(
             c_tensors.as_mut_ptr(),
@@ -11717,7 +11647,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_column_stack<T: Borrow<Tensor>>(tensors: &[T]) -> Result<Tensor, TchError> {
+    pub fn column_stack<T: Borrow<Tensor>>(tensors: &[T]) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_column_stack(
             c_tensors.as_mut_ptr(),
@@ -11727,7 +11657,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_column_stack_out<T: Borrow<Tensor>>(
+    pub fn column_stack_out<T: Borrow<Tensor>>(
         out: &Tensor,
         tensors: &[T],
     ) -> Result<Tensor, TchError> {
@@ -11741,7 +11671,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_combinations(&self, r: i64, with_replacement: bool) -> Result<Tensor, TchError> {
+    pub fn combinations(&self, r: i64, with_replacement: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_combinations(
             c_tensors.as_mut_ptr(),
@@ -11752,13 +11682,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_complex(real: &Tensor, imag: &Tensor) -> Result<Tensor, TchError> {
+    pub fn complex(real: &Tensor, imag: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_complex(c_tensors.as_mut_ptr(), real.c_tensor, imag.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_complex_out(out: &Tensor, real: &Tensor, imag: &Tensor) -> Result<Tensor, TchError> {
+    pub fn complex_out(out: &Tensor, real: &Tensor, imag: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_complex_out(
             c_tensors.as_mut_ptr(),
@@ -11769,7 +11699,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_concat<T: Borrow<Tensor>>(tensors: &[T], dim: i64) -> Result<Tensor, TchError> {
+    pub fn concat<T: Borrow<Tensor>>(tensors: &[T], dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_concat(
             c_tensors.as_mut_ptr(),
@@ -11780,7 +11710,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_concat_out<T: Borrow<Tensor>>(
+    pub fn concat_out<T: Borrow<Tensor>>(
         out: &Tensor,
         tensors: &[T],
         dim: i64,
@@ -11796,7 +11726,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_concatenate<T: Borrow<Tensor>>(tensors: &[T], dim: i64) -> Result<Tensor, TchError> {
+    pub fn concatenate<T: Borrow<Tensor>>(tensors: &[T], dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_concatenate(
             c_tensors.as_mut_ptr(),
@@ -11807,7 +11737,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_concatenate_out<T: Borrow<Tensor>>(
+    pub fn concatenate_out<T: Borrow<Tensor>>(
         out: &Tensor,
         tensors: &[T],
         dim: i64,
@@ -11823,25 +11753,25 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_conj(&self) -> Result<Tensor, TchError> {
+    pub fn conj(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_conj(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_conj_physical(&self) -> Result<Tensor, TchError> {
+    pub fn conj_physical(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_conj_physical(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_conj_physical_(&mut self) -> Result<Tensor, TchError> {
+    pub fn conj_physical_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_conj_physical_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_conj_physical_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn conj_physical_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_conj_physical_out(
             c_tensors.as_mut_ptr(),
@@ -11851,7 +11781,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_constant_pad_nd(&self, pad: impl IntList) -> Result<Tensor, TchError> {
+    pub fn constant_pad_nd(&self, pad: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_constant_pad_nd(
             c_tensors.as_mut_ptr(),
@@ -11862,11 +11792,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_constant_pad_nd_out(
-        &self,
-        out: &Tensor,
-        pad: impl IntList,
-    ) -> Result<Tensor, TchError> {
+    pub fn constant_pad_nd_out(&self, out: &Tensor, pad: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_constant_pad_nd_out(
             c_tensors.as_mut_ptr(),
@@ -11878,13 +11804,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_contiguous(&self) -> Result<Tensor, TchError> {
+    pub fn contiguous(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_contiguous(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_conv1d<T: Borrow<Tensor>>(
+    pub fn conv1d<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -11910,7 +11836,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_conv1d_padding<T: Borrow<Tensor>>(
+    pub fn conv1d_padding<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -11936,7 +11862,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_conv2d<T: Borrow<Tensor>>(
+    pub fn conv2d<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -11962,7 +11888,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_conv2d_padding<T: Borrow<Tensor>>(
+    pub fn conv2d_padding<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -11988,7 +11914,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_conv3d<T: Borrow<Tensor>>(
+    pub fn conv3d<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -12014,7 +11940,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_conv3d_padding<T: Borrow<Tensor>>(
+    pub fn conv3d_padding<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -12040,7 +11966,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_conv_depthwise3d<T: Borrow<Tensor>>(
+    pub fn conv_depthwise3d<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         kernel_size: impl IntList,
@@ -12067,7 +11993,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_conv_depthwise3d_out<T: Borrow<Tensor>>(
+    pub fn conv_depthwise3d_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -12096,7 +12022,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_conv_tbc(&self, weight: &Tensor, bias: &Tensor, pad: i64) -> Result<Tensor, TchError> {
+    pub fn conv_tbc(&self, weight: &Tensor, bias: &Tensor, pad: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_conv_tbc(
             c_tensors.as_mut_ptr(),
@@ -12108,7 +12034,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_conv_tbc_backward(
+    pub fn conv_tbc_backward(
         &self,
         input: &Tensor,
         weight: &Tensor,
@@ -12131,7 +12057,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_conv_tbc_out(
+    pub fn conv_tbc_out(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -12150,7 +12076,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_conv_transpose1d<T: Borrow<Tensor>>(
+    pub fn conv_transpose1d<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -12179,7 +12105,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_conv_transpose2d<T: Borrow<Tensor>>(
+    pub fn conv_transpose2d<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -12208,7 +12134,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_conv_transpose3d<T: Borrow<Tensor>>(
+    pub fn conv_transpose3d<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -12237,7 +12163,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_convolution<T: Borrow<Tensor>>(
+    pub fn convolution<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -12268,7 +12194,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_convolution_out<T: Borrow<Tensor>>(
+    pub fn convolution_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -12301,7 +12227,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_convolution_overrideable<T: Borrow<Tensor>>(
+    pub fn convolution_overrideable<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -12332,7 +12258,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_convolution_overrideable_out<T: Borrow<Tensor>>(
+    pub fn convolution_overrideable_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -12365,7 +12291,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_copy_sparse_to_sparse(
+    pub fn copy_sparse_to_sparse(
         &self,
         src: &Tensor,
         non_blocking: bool,
@@ -12380,7 +12306,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_copy_sparse_to_sparse_(
+    pub fn copy_sparse_to_sparse_(
         &mut self,
         src: &Tensor,
         non_blocking: bool,
@@ -12395,7 +12321,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_copy_sparse_to_sparse_out(
+    pub fn copy_sparse_to_sparse_out(
         &self,
         out: &Tensor,
         src: &Tensor,
@@ -12412,19 +12338,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_copysign(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn copysign(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_copysign(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_copysign_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn copysign_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_copysign_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_copysign_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn copysign_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_copysign_out(
             c_tensors.as_mut_ptr(),
@@ -12435,7 +12361,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_copysign_scalar<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
+    pub fn copysign_scalar<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_copysign_scalar(
             c_tensors.as_mut_ptr(),
@@ -12445,7 +12371,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_copysign_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn copysign_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_copysign_scalar_(
             c_tensors.as_mut_ptr(),
@@ -12455,7 +12381,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_copysign_scalar_out<S: Into<Scalar>>(
+    pub fn copysign_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
@@ -12470,49 +12396,49 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_corrcoef(&self) -> Result<Tensor, TchError> {
+    pub fn corrcoef(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_corrcoef(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cos(&self) -> Result<Tensor, TchError> {
+    pub fn cos(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_cos(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cos_(&mut self) -> Result<Tensor, TchError> {
+    pub fn cos_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_cos_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cos_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn cos_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_cos_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cosh(&self) -> Result<Tensor, TchError> {
+    pub fn cosh(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_cosh(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cosh_(&mut self) -> Result<Tensor, TchError> {
+    pub fn cosh_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_cosh_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cosh_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn cosh_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_cosh_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cosine_embedding_loss(
+    pub fn cosine_embedding_loss(
         input1: &Tensor,
         input2: &Tensor,
         target: &Tensor,
@@ -12531,7 +12457,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cosine_similarity(
+    pub fn cosine_similarity(
         x1: &Tensor,
         x2: &Tensor,
         dim: i64,
@@ -12548,7 +12474,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_count_nonzero(&self, dim: impl Into<Option<i64>>) -> Result<Tensor, TchError> {
+    pub fn count_nonzero(&self, dim: impl Into<Option<i64>>) -> Result<Tensor, TchError> {
         let dim = dim.into();
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_count_nonzero(
@@ -12560,7 +12486,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_count_nonzero_dim_intlist(&self, dim: impl IntList) -> Result<Tensor, TchError> {
+    pub fn count_nonzero_dim_intlist(&self, dim: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_count_nonzero_dim_intlist(
             c_tensors.as_mut_ptr(),
@@ -12571,7 +12497,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_count_nonzero_dim_intlist_out(
+    pub fn count_nonzero_dim_intlist_out(
         &self,
         out: &Tensor,
         dim: impl IntList,
@@ -12587,7 +12513,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_count_nonzero_out(
+    pub fn count_nonzero_out(
         &self,
         out: &Tensor,
         dim: impl Into<Option<i64>>,
@@ -12604,7 +12530,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cov<T: Borrow<Tensor>>(
+    pub fn cov<T: Borrow<Tensor>>(
         &self,
         correction: i64,
         fweights: Option<T>,
@@ -12621,7 +12547,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cross(&self, other: &Tensor, dim: impl Into<Option<i64>>) -> Result<Tensor, TchError> {
+    pub fn cross(&self, other: &Tensor, dim: impl Into<Option<i64>>) -> Result<Tensor, TchError> {
         let dim = dim.into();
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_cross(
@@ -12634,7 +12560,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cross_entropy_loss<T: Borrow<Tensor>>(
+    pub fn cross_entropy_loss<T: Borrow<Tensor>>(
         &self,
         target: &Tensor,
         weight: Option<T>,
@@ -12655,7 +12581,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cross_out(
+    pub fn cross_out(
         &self,
         out: &Tensor,
         other: &Tensor,
@@ -12674,19 +12600,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_crow_indices(&self) -> Result<Tensor, TchError> {
+    pub fn crow_indices(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_crow_indices(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_crow_indices_copy(&self) -> Result<Tensor, TchError> {
+    pub fn crow_indices_copy(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_crow_indices_copy(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_crow_indices_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn crow_indices_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_crow_indices_copy_out(
             c_tensors.as_mut_ptr(),
@@ -12696,7 +12622,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_ctc_loss(
+    pub fn ctc_loss(
         log_probs: &Tensor,
         targets: &Tensor,
         input_lengths: impl IntList,
@@ -12721,7 +12647,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_ctc_loss_tensor(
+    pub fn ctc_loss_tensor(
         log_probs: &Tensor,
         targets: &Tensor,
         input_lengths: &Tensor,
@@ -12744,7 +12670,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cudnn_affine_grid_generator(
+    pub fn cudnn_affine_grid_generator(
         theta: &Tensor,
         n: i64,
         c: i64,
@@ -12763,7 +12689,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cudnn_affine_grid_generator_backward(
+    pub fn cudnn_affine_grid_generator_backward(
         grad: &Tensor,
         n: i64,
         c: i64,
@@ -12782,7 +12708,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cudnn_affine_grid_generator_backward_out(
+    pub fn cudnn_affine_grid_generator_backward_out(
         out: &Tensor,
         grad: &Tensor,
         n: i64,
@@ -12803,7 +12729,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cudnn_affine_grid_generator_out(
+    pub fn cudnn_affine_grid_generator_out(
         out: &Tensor,
         theta: &Tensor,
         n: i64,
@@ -12824,7 +12750,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cudnn_batch_norm<T: Borrow<Tensor>>(
+    pub fn cudnn_batch_norm<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -12854,7 +12780,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_cudnn_batch_norm_backward<T: Borrow<Tensor>>(
+    pub fn cudnn_batch_norm_backward<T: Borrow<Tensor>>(
         &self,
         grad_output: &Tensor,
         weight: &Tensor,
@@ -12885,7 +12811,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_cudnn_batch_norm_backward_out<T: Borrow<Tensor>>(
+    pub fn cudnn_batch_norm_backward_out<T: Borrow<Tensor>>(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -12922,7 +12848,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_cudnn_batch_norm_out<T: Borrow<Tensor>>(
+    pub fn cudnn_batch_norm_out<T: Borrow<Tensor>>(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -12960,7 +12886,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_cudnn_convolution(
+    pub fn cudnn_convolution(
         &self,
         weight: &Tensor,
         padding: impl IntList,
@@ -12990,7 +12916,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cudnn_convolution_add_relu<T: Borrow<Tensor>, S: Into<Scalar>>(
+    pub fn cudnn_convolution_add_relu<T: Borrow<Tensor>, S: Into<Scalar>>(
         &self,
         weight: &Tensor,
         z: &Tensor,
@@ -13020,7 +12946,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cudnn_convolution_add_relu_out<T: Borrow<Tensor>, S: Into<Scalar>>(
+    pub fn cudnn_convolution_add_relu_out<T: Borrow<Tensor>, S: Into<Scalar>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -13052,7 +12978,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cudnn_convolution_out(
+    pub fn cudnn_convolution_out(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -13084,7 +13010,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cudnn_convolution_relu<T: Borrow<Tensor>>(
+    pub fn cudnn_convolution_relu<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -13110,7 +13036,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cudnn_convolution_relu_out<T: Borrow<Tensor>>(
+    pub fn cudnn_convolution_relu_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -13138,7 +13064,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cudnn_convolution_transpose(
+    pub fn cudnn_convolution_transpose(
         &self,
         weight: &Tensor,
         padding: impl IntList,
@@ -13171,7 +13097,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cudnn_convolution_transpose_out(
+    pub fn cudnn_convolution_transpose_out(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -13206,7 +13132,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cudnn_grid_sampler(&self, grid: &Tensor) -> Result<Tensor, TchError> {
+    pub fn cudnn_grid_sampler(&self, grid: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_cudnn_grid_sampler(
             c_tensors.as_mut_ptr(),
@@ -13216,7 +13142,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cudnn_grid_sampler_backward(
+    pub fn cudnn_grid_sampler_backward(
         &self,
         grid: &Tensor,
         grad_output: &Tensor,
@@ -13231,7 +13157,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_cudnn_grid_sampler_backward_out(
+    pub fn cudnn_grid_sampler_backward_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -13250,11 +13176,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_cudnn_grid_sampler_out(
-        &self,
-        out: &Tensor,
-        grid: &Tensor,
-    ) -> Result<Tensor, TchError> {
+    pub fn cudnn_grid_sampler_out(&self, out: &Tensor, grid: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_cudnn_grid_sampler_out(
             c_tensors.as_mut_ptr(),
@@ -13265,19 +13187,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cudnn_is_acceptable(&self) -> Result<bool, TchError> {
+    pub fn cudnn_is_acceptable(&self) -> Result<bool, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg_cudnn_is_acceptable(self.c_tensor));
         Ok(return_ != 0)
     }
 
-    pub fn f_cummax(&self, dim: i64) -> Result<(Tensor, Tensor), TchError> {
+    pub fn cummax(&self, dim: i64) -> Result<(Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 2];
         unsafe_torch_err!(atg_cummax(c_tensors.as_mut_ptr(), self.c_tensor, dim));
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_cummax_out(
+    pub fn cummax_out(
         &self,
         values: &Tensor,
         indices: &Tensor,
@@ -13294,7 +13216,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_cummaxmin_backward(
+    pub fn cummaxmin_backward(
         &self,
         grad: &Tensor,
         indices: &Tensor,
@@ -13311,13 +13233,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cummin(&self, dim: i64) -> Result<(Tensor, Tensor), TchError> {
+    pub fn cummin(&self, dim: i64) -> Result<(Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 2];
         unsafe_torch_err!(atg_cummin(c_tensors.as_mut_ptr(), self.c_tensor, dim));
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_cummin_out(
+    pub fn cummin_out(
         &self,
         values: &Tensor,
         indices: &Tensor,
@@ -13334,7 +13256,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_cumprod(&self, dim: i64, dtype: impl Into<Option<Kind>>) -> Result<Tensor, TchError> {
+    pub fn cumprod(&self, dim: i64, dtype: impl Into<Option<Kind>>) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_cumprod(
             c_tensors.as_mut_ptr(),
@@ -13345,7 +13267,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cumprod_(
+    pub fn cumprod_(
         &mut self,
         dim: i64,
         dtype: impl Into<Option<Kind>>,
@@ -13360,7 +13282,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cumprod_backward(
+    pub fn cumprod_backward(
         &self,
         grad: &Tensor,
         dim: i64,
@@ -13377,7 +13299,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cumprod_out(
+    pub fn cumprod_out(
         &self,
         out: &Tensor,
         dim: i64,
@@ -13394,7 +13316,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cumsum(&self, dim: i64, dtype: impl Into<Option<Kind>>) -> Result<Tensor, TchError> {
+    pub fn cumsum(&self, dim: i64, dtype: impl Into<Option<Kind>>) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_cumsum(
             c_tensors.as_mut_ptr(),
@@ -13405,7 +13327,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cumsum_(
+    pub fn cumsum_(
         &mut self,
         dim: i64,
         dtype: impl Into<Option<Kind>>,
@@ -13420,7 +13342,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cumsum_out(
+    pub fn cumsum_out(
         &self,
         out: &Tensor,
         dim: i64,
@@ -13437,13 +13359,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cumulative_trapezoid(y: &Tensor, dim: i64) -> Result<Tensor, TchError> {
+    pub fn cumulative_trapezoid(y: &Tensor, dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_cumulative_trapezoid(c_tensors.as_mut_ptr(), y.c_tensor, dim));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_cumulative_trapezoid_x(y: &Tensor, x: &Tensor, dim: i64) -> Result<Tensor, TchError> {
+    pub fn cumulative_trapezoid_x(y: &Tensor, x: &Tensor, dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_cumulative_trapezoid_x(
             c_tensors.as_mut_ptr(),
@@ -13454,43 +13376,43 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_data(&self) -> Result<Tensor, TchError> {
+    pub fn data(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_data(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_deg2rad(&self) -> Result<Tensor, TchError> {
+    pub fn deg2rad(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_deg2rad(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_deg2rad_(&mut self) -> Result<Tensor, TchError> {
+    pub fn deg2rad_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_deg2rad_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_deg2rad_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn deg2rad_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_deg2rad_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_dense_dim(&self) -> Result<i64, TchError> {
+    pub fn dense_dim(&self) -> Result<i64, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg_dense_dim(self.c_tensor));
         Ok(return_)
     }
 
-    pub fn f_dequantize(&self) -> Result<Tensor, TchError> {
+    pub fn dequantize(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_dequantize(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_dequantize_self_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn dequantize_self_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_dequantize_self_out(
             c_tensors.as_mut_ptr(),
@@ -13500,7 +13422,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_dequantize_tensors<T: Borrow<Tensor>>(tensors: &[T]) -> Result<Vec<Tensor>, TchError> {
+    pub fn dequantize_tensors<T: Borrow<Tensor>>(tensors: &[T]) -> Result<Vec<Tensor>, TchError> {
         let c_tensors = unsafe_torch_err!(atg_dequantize_tensors(
             ptr_list(tensors).as_ptr(),
             tensors.len() as i32
@@ -13519,7 +13441,7 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_dequantize_tensors_out<T: Borrow<Tensor>>(
+    pub fn dequantize_tensors_out<T: Borrow<Tensor>>(
         out: &[T],
         tensors: &[T],
     ) -> Result<(), TchError> {
@@ -13532,43 +13454,43 @@ impl Tensor {
         Ok(())
     }
 
-    pub fn f_det(&self) -> Result<Tensor, TchError> {
+    pub fn det(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_det(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_detach(&self) -> Result<Tensor, TchError> {
+    pub fn detach(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_detach(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_detach_(&mut self) -> Result<Tensor, TchError> {
+    pub fn detach_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_detach_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_detach_copy(&self) -> Result<Tensor, TchError> {
+    pub fn detach_copy(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_detach_copy(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_detach_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn detach_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_detach_copy_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_diag(&self, diagonal: i64) -> Result<Tensor, TchError> {
+    pub fn diag(&self, diagonal: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_diag(c_tensors.as_mut_ptr(), self.c_tensor, diagonal));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_diag_embed(&self, offset: i64, dim1: i64, dim2: i64) -> Result<Tensor, TchError> {
+    pub fn diag_embed(&self, offset: i64, dim1: i64, dim2: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_diag_embed(
             c_tensors.as_mut_ptr(),
@@ -13580,7 +13502,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_diag_embed_out(
+    pub fn diag_embed_out(
         &self,
         out: &Tensor,
         offset: i64,
@@ -13599,7 +13521,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_diag_out(&self, out: &Tensor, diagonal: i64) -> Result<Tensor, TchError> {
+    pub fn diag_out(&self, out: &Tensor, diagonal: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_diag_out(
             c_tensors.as_mut_ptr(),
@@ -13610,19 +13532,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_diagflat(&self, offset: i64) -> Result<Tensor, TchError> {
+    pub fn diagflat(&self, offset: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_diagflat(c_tensors.as_mut_ptr(), self.c_tensor, offset));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_diagonal(&self, offset: i64, dim1: i64, dim2: i64) -> Result<Tensor, TchError> {
+    pub fn diagonal(&self, offset: i64, dim1: i64, dim2: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_diagonal(c_tensors.as_mut_ptr(), self.c_tensor, offset, dim1, dim2));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_diagonal_backward(
+    pub fn diagonal_backward(
         grad_output: &Tensor,
         input_sizes: impl IntList,
         offset: i64,
@@ -13642,7 +13564,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_diagonal_backward_out(
+    pub fn diagonal_backward_out(
         out: &Tensor,
         grad_output: &Tensor,
         input_sizes: impl IntList,
@@ -13664,7 +13586,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_diagonal_copy(&self, offset: i64, dim1: i64, dim2: i64) -> Result<Tensor, TchError> {
+    pub fn diagonal_copy(&self, offset: i64, dim1: i64, dim2: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_diagonal_copy(
             c_tensors.as_mut_ptr(),
@@ -13676,7 +13598,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_diagonal_copy_out(
+    pub fn diagonal_copy_out(
         &self,
         out: &Tensor,
         offset: i64,
@@ -13695,7 +13617,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_diagonal_scatter(
+    pub fn diagonal_scatter(
         &self,
         src: &Tensor,
         offset: i64,
@@ -13714,7 +13636,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_diagonal_scatter_out(
+    pub fn diagonal_scatter_out(
         &self,
         out: &Tensor,
         src: &Tensor,
@@ -13735,7 +13657,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_diff<T: Borrow<Tensor>>(
+    pub fn diff<T: Borrow<Tensor>>(
         &self,
         n: i64,
         dim: i64,
@@ -13754,7 +13676,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_diff_out<T: Borrow<Tensor>>(
+    pub fn diff_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         n: i64,
@@ -13775,31 +13697,31 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_digamma(&self) -> Result<Tensor, TchError> {
+    pub fn digamma(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_digamma(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_digamma_(&mut self) -> Result<Tensor, TchError> {
+    pub fn digamma_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_digamma_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_digamma_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn digamma_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_digamma_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_dist(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn dist(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_dist(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_dist_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn dist_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_dist_out(
             c_tensors.as_mut_ptr(),
@@ -13810,19 +13732,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_div(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn g_div(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_div(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_div_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn g_div_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_div_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_div_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn div_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_div_out(
             c_tensors.as_mut_ptr(),
@@ -13833,7 +13755,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_div_out_mode(
+    pub fn div_out_mode(
         &self,
         out: &Tensor,
         other: &Tensor,
@@ -13851,7 +13773,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_div_scalar<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
+    pub fn g_div_scalar<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_div_scalar(
             c_tensors.as_mut_ptr(),
@@ -13861,7 +13783,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_div_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn g_div_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_div_scalar_(
             c_tensors.as_mut_ptr(),
@@ -13871,7 +13793,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_div_scalar_mode<S: Into<Scalar>>(
+    pub fn g_div_scalar_mode<S: Into<Scalar>>(
         &self,
         other: S,
         rounding_mode: &str,
@@ -13887,7 +13809,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_div_scalar_mode_<S: Into<Scalar>>(
+    pub fn g_div_scalar_mode_<S: Into<Scalar>>(
         &mut self,
         other: S,
         rounding_mode: &str,
@@ -13903,7 +13825,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_div_scalar_mode_out<S: Into<Scalar>>(
+    pub fn div_scalar_mode_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
@@ -13921,7 +13843,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_div_scalar_out<S: Into<Scalar>>(
+    pub fn div_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
@@ -13936,7 +13858,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_div_tensor_mode(
+    pub fn g_div_tensor_mode(
         &self,
         other: &Tensor,
         rounding_mode: &str,
@@ -13952,7 +13874,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_div_tensor_mode_(
+    pub fn g_div_tensor_mode_(
         &mut self,
         other: &Tensor,
         rounding_mode: &str,
@@ -13968,19 +13890,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_divide(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn divide(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_divide(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_divide_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn divide_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_divide_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_divide_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn divide_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_divide_out(
             c_tensors.as_mut_ptr(),
@@ -13991,7 +13913,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_divide_out_mode(
+    pub fn divide_out_mode(
         &self,
         out: &Tensor,
         other: &Tensor,
@@ -14009,7 +13931,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_divide_scalar<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
+    pub fn divide_scalar<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_divide_scalar(
             c_tensors.as_mut_ptr(),
@@ -14019,7 +13941,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_divide_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn divide_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_divide_scalar_(
             c_tensors.as_mut_ptr(),
@@ -14029,7 +13951,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_divide_scalar_mode<S: Into<Scalar>>(
+    pub fn divide_scalar_mode<S: Into<Scalar>>(
         &self,
         other: S,
         rounding_mode: &str,
@@ -14045,7 +13967,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_divide_scalar_mode_<S: Into<Scalar>>(
+    pub fn divide_scalar_mode_<S: Into<Scalar>>(
         &mut self,
         other: S,
         rounding_mode: &str,
@@ -14061,7 +13983,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_divide_tensor_mode(
+    pub fn divide_tensor_mode(
         &self,
         other: &Tensor,
         rounding_mode: &str,
@@ -14077,7 +13999,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_divide_tensor_mode_(
+    pub fn divide_tensor_mode_(
         &mut self,
         other: &Tensor,
         rounding_mode: &str,
@@ -14093,13 +14015,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_dot(&self, tensor: &Tensor) -> Result<Tensor, TchError> {
+    pub fn dot(&self, tensor: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_dot(c_tensors.as_mut_ptr(), self.c_tensor, tensor.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_dot_out(&self, out: &Tensor, tensor: &Tensor) -> Result<Tensor, TchError> {
+    pub fn dot_out(&self, out: &Tensor, tensor: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_dot_out(
             c_tensors.as_mut_ptr(),
@@ -14110,7 +14032,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_dropout(&self, p: f64, train: bool) -> Result<Tensor, TchError> {
+    pub fn dropout(&self, p: f64, train: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_dropout(
             c_tensors.as_mut_ptr(),
@@ -14121,7 +14043,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_dropout_(&mut self, p: f64, train: bool) -> Result<Tensor, TchError> {
+    pub fn dropout_(&mut self, p: f64, train: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_dropout_(
             c_tensors.as_mut_ptr(),
@@ -14132,7 +14054,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_dsplit(&self, sections: i64) -> Result<Vec<Tensor>, TchError> {
+    pub fn dsplit(&self, sections: i64) -> Result<Vec<Tensor>, TchError> {
         let c_tensors = unsafe_torch_err!(atg_dsplit(self.c_tensor, sections));
         let mut r__ = vec![];
         let mut i = 0;
@@ -14148,7 +14070,7 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_dsplit_array(&self, indices: impl IntList) -> Result<Vec<Tensor>, TchError> {
+    pub fn dsplit_array(&self, indices: impl IntList) -> Result<Vec<Tensor>, TchError> {
         let c_tensors =
             unsafe_torch_err!(atg_dsplit_array(self.c_tensor, indices.as_ptr(), indices.len_i32()));
         let mut r__ = vec![];
@@ -14165,7 +14087,7 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_dstack<T: Borrow<Tensor>>(tensors: &[T]) -> Result<Tensor, TchError> {
+    pub fn dstack<T: Borrow<Tensor>>(tensors: &[T]) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_dstack(
             c_tensors.as_mut_ptr(),
@@ -14175,10 +14097,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_dstack_out<T: Borrow<Tensor>>(
-        out: &Tensor,
-        tensors: &[T],
-    ) -> Result<Tensor, TchError> {
+    pub fn dstack_out<T: Borrow<Tensor>>(out: &Tensor, tensors: &[T]) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_dstack_out(
             c_tensors.as_mut_ptr(),
@@ -14189,7 +14108,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_einsum<T: Borrow<Tensor>>(
+    pub fn einsum<T: Borrow<Tensor>>(
         equation: &str,
         tensors: &[T],
         path: impl IntListOption,
@@ -14207,19 +14126,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_elu(&self) -> Result<Tensor, TchError> {
+    pub fn elu(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_elu(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_elu_(&mut self) -> Result<Tensor, TchError> {
+    pub fn elu_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_elu_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_elu_backward<S: Into<Scalar>>(
+    pub fn elu_backward<S: Into<Scalar>>(
         grad_output: &Tensor,
         alpha: S,
         scale: S,
@@ -14240,7 +14159,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_elu_backward_grad_input<S: Into<Scalar>>(
+    pub fn elu_backward_grad_input<S: Into<Scalar>>(
         grad_input: &Tensor,
         grad_output: &Tensor,
         alpha: S,
@@ -14263,13 +14182,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_elu_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn elu_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_elu_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_embedding(
+    pub fn embedding(
         weight: &Tensor,
         indices: &Tensor,
         padding_idx: i64,
@@ -14288,7 +14207,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_embedding_backward(
+    pub fn embedding_backward(
         grad: &Tensor,
         indices: &Tensor,
         num_weights: i64,
@@ -14309,7 +14228,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_embedding_bag<T: Borrow<Tensor>>(
+    pub fn embedding_bag<T: Borrow<Tensor>>(
         weight: &Tensor,
         indices: &Tensor,
         offsets: &Tensor,
@@ -14339,7 +14258,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_embedding_bag_padding_idx<T: Borrow<Tensor>>(
+    pub fn embedding_bag_padding_idx<T: Borrow<Tensor>>(
         weight: &Tensor,
         indices: &Tensor,
         offsets: &Tensor,
@@ -14373,7 +14292,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_embedding_dense_backward(
+    pub fn embedding_dense_backward(
         grad_output: &Tensor,
         indices: &Tensor,
         num_weights: i64,
@@ -14392,7 +14311,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_embedding_dense_backward_out(
+    pub fn embedding_dense_backward_out(
         out: &Tensor,
         grad_output: &Tensor,
         indices: &Tensor,
@@ -14413,7 +14332,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_embedding_out(
+    pub fn embedding_out(
         out: &Tensor,
         weight: &Tensor,
         indices: &Tensor,
@@ -14434,7 +14353,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_embedding_renorm(
+    pub fn embedding_renorm(
         &self,
         indices: &Tensor,
         max_norm: f64,
@@ -14451,7 +14370,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_embedding_renorm_(
+    pub fn embedding_renorm_(
         &mut self,
         indices: &Tensor,
         max_norm: f64,
@@ -14468,7 +14387,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_embedding_renorm_out(
+    pub fn embedding_renorm_out(
         &self,
         out: &Tensor,
         indices: &Tensor,
@@ -14487,7 +14406,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_embedding_sparse_backward(
+    pub fn embedding_sparse_backward(
         grad: &Tensor,
         indices: &Tensor,
         num_weights: i64,
@@ -14506,7 +14425,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_empty(size: impl IntList, options: (Kind, Device)) -> Result<Tensor, TchError> {
+    pub fn empty(size: impl IntList, options: (Kind, Device)) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_empty(
             c_tensors.as_mut_ptr(),
@@ -14518,19 +14437,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_empty_like(&self) -> Result<Tensor, TchError> {
+    pub fn empty_like(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_empty_like(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_empty_like_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn empty_like_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_empty_like_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_empty_out(out: &Tensor, size: impl IntList) -> Result<Tensor, TchError> {
+    pub fn empty_out(out: &Tensor, size: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_empty_out(
             c_tensors.as_mut_ptr(),
@@ -14541,7 +14460,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_empty_quantized(
+    pub fn empty_quantized(
         size: impl IntList,
         qtensor: &Tensor,
         options: (Kind, Device),
@@ -14558,7 +14477,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_empty_quantized_out(
+    pub fn empty_quantized_out(
         out: &Tensor,
         size: impl IntList,
         qtensor: &Tensor,
@@ -14574,7 +14493,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_empty_strided(
+    pub fn empty_strided(
         size: impl IntList,
         stride: impl IntList,
         options: (Kind, Device),
@@ -14592,7 +14511,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_empty_strided_out(
+    pub fn empty_strided_out(
         out: &Tensor,
         size: impl IntList,
         stride: impl IntList,
@@ -14609,19 +14528,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_eq<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
+    pub fn eq<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_eq(c_tensors.as_mut_ptr(), self.c_tensor, other.into().c_scalar));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_eq_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn eq_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_eq_(c_tensors.as_mut_ptr(), self.c_tensor, other.into().c_scalar));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_eq_scalar_out<S: Into<Scalar>>(
+    pub fn eq_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
@@ -14636,19 +14555,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_eq_tensor(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn eq_tensor(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_eq_tensor(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_eq_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn eq_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_eq_tensor_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_eq_tensor_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn eq_tensor_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_eq_tensor_out(
             c_tensors.as_mut_ptr(),
@@ -14659,103 +14578,103 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_equal(&self, other: &Tensor) -> Result<bool, TchError> {
+    pub fn equal(&self, other: &Tensor) -> Result<bool, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg_equal(self.c_tensor, other.c_tensor));
         Ok(return_ != 0)
     }
 
-    pub fn f_erf(&self) -> Result<Tensor, TchError> {
+    pub fn erf(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_erf(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_erf_(&mut self) -> Result<Tensor, TchError> {
+    pub fn erf_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_erf_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_erf_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn erf_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_erf_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_erfc(&self) -> Result<Tensor, TchError> {
+    pub fn erfc(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_erfc(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_erfc_(&mut self) -> Result<Tensor, TchError> {
+    pub fn erfc_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_erfc_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_erfc_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn erfc_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_erfc_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_erfinv(&self) -> Result<Tensor, TchError> {
+    pub fn erfinv(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_erfinv(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_erfinv_(&mut self) -> Result<Tensor, TchError> {
+    pub fn erfinv_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_erfinv_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_erfinv_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn erfinv_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_erfinv_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_exp(&self) -> Result<Tensor, TchError> {
+    pub fn exp(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_exp(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_exp2(&self) -> Result<Tensor, TchError> {
+    pub fn exp2(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_exp2(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_exp2_(&mut self) -> Result<Tensor, TchError> {
+    pub fn exp2_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_exp2_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_exp2_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn exp2_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_exp2_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_exp_(&mut self) -> Result<Tensor, TchError> {
+    pub fn exp_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_exp_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_exp_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn exp_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_exp_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_expand(&self, size: impl IntList, implicit: bool) -> Result<Tensor, TchError> {
+    pub fn expand(&self, size: impl IntList, implicit: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_expand(
             c_tensors.as_mut_ptr(),
@@ -14767,13 +14686,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_expand_as(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn expand_as(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_expand_as(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_expand_copy(&self, size: impl IntList, implicit: bool) -> Result<Tensor, TchError> {
+    pub fn expand_copy(&self, size: impl IntList, implicit: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_expand_copy(
             c_tensors.as_mut_ptr(),
@@ -14785,7 +14704,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_expand_copy_out(
+    pub fn expand_copy_out(
         &self,
         out: &Tensor,
         size: impl IntList,
@@ -14803,37 +14722,37 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_expm1(&self) -> Result<Tensor, TchError> {
+    pub fn expm1(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_expm1(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_expm1_(&mut self) -> Result<Tensor, TchError> {
+    pub fn expm1_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_expm1_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_expm1_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn expm1_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_expm1_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_exponential(&self, lambd: f64) -> Result<Tensor, TchError> {
+    pub fn exponential(&self, lambd: f64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_exponential(c_tensors.as_mut_ptr(), self.c_tensor, lambd));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_exponential_(&mut self, lambd: f64) -> Result<Tensor, TchError> {
+    pub fn exponential_(&mut self, lambd: f64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_exponential_(c_tensors.as_mut_ptr(), self.c_tensor, lambd));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_exponential_out(&self, out: &Tensor, lambd: f64) -> Result<Tensor, TchError> {
+    pub fn exponential_out(&self, out: &Tensor, lambd: f64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_exponential_out(
             c_tensors.as_mut_ptr(),
@@ -14844,13 +14763,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_eye(n: i64, options: (Kind, Device)) -> Result<Tensor, TchError> {
+    pub fn eye(n: i64, options: (Kind, Device)) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_eye(c_tensors.as_mut_ptr(), n, options.0.c_int(), options.1.c_int()));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_eye_m(n: i64, m: i64, options: (Kind, Device)) -> Result<Tensor, TchError> {
+    pub fn eye_m(n: i64, m: i64, options: (Kind, Device)) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_eye_m(
             c_tensors.as_mut_ptr(),
@@ -14862,19 +14781,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_eye_m_out(out: &Tensor, n: i64, m: i64) -> Result<Tensor, TchError> {
+    pub fn eye_m_out(out: &Tensor, n: i64, m: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_eye_m_out(c_tensors.as_mut_ptr(), out.c_tensor, n, m));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_eye_out(out: &Tensor, n: i64) -> Result<Tensor, TchError> {
+    pub fn eye_out(out: &Tensor, n: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_eye_out(c_tensors.as_mut_ptr(), out.c_tensor, n));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fake_quantize_per_channel_affine(
+    pub fn fake_quantize_per_channel_affine(
         &self,
         scale: &Tensor,
         zero_point: &Tensor,
@@ -14895,7 +14814,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fake_quantize_per_channel_affine_cachemask(
+    pub fn fake_quantize_per_channel_affine_cachemask(
         &self,
         scale: &Tensor,
         zero_point: &Tensor,
@@ -14916,7 +14835,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_fake_quantize_per_channel_affine_cachemask_backward(
+    pub fn fake_quantize_per_channel_affine_cachemask_backward(
         grad: &Tensor,
         mask: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -14929,7 +14848,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fake_quantize_per_channel_affine_cachemask_out(
+    pub fn fake_quantize_per_channel_affine_cachemask_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -14954,7 +14873,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_fake_quantize_per_tensor_affine(
+    pub fn fake_quantize_per_tensor_affine(
         &self,
         scale: f64,
         zero_point: i64,
@@ -14973,7 +14892,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fake_quantize_per_tensor_affine_cachemask(
+    pub fn fake_quantize_per_tensor_affine_cachemask(
         &self,
         scale: f64,
         zero_point: i64,
@@ -14992,7 +14911,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_fake_quantize_per_tensor_affine_cachemask_backward(
+    pub fn fake_quantize_per_tensor_affine_cachemask_backward(
         grad: &Tensor,
         mask: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -15005,7 +14924,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fake_quantize_per_tensor_affine_cachemask_out(
+    pub fn fake_quantize_per_tensor_affine_cachemask_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -15028,7 +14947,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_fake_quantize_per_tensor_affine_tensor_qparams(
+    pub fn fake_quantize_per_tensor_affine_tensor_qparams(
         &self,
         scale: &Tensor,
         zero_point: &Tensor,
@@ -15047,7 +14966,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fbgemm_linear_fp16_weight(
+    pub fn fbgemm_linear_fp16_weight(
         &self,
         packed_weight: &Tensor,
         bias: &Tensor,
@@ -15062,7 +14981,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fbgemm_linear_fp16_weight_fp32_activation(
+    pub fn fbgemm_linear_fp16_weight_fp32_activation(
         &self,
         packed_weight: &Tensor,
         bias: &Tensor,
@@ -15077,7 +14996,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fbgemm_linear_int8_weight<S: Into<Scalar>>(
+    pub fn fbgemm_linear_int8_weight<S: Into<Scalar>>(
         &self,
         weight: &Tensor,
         packed: &Tensor,
@@ -15100,7 +15019,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fbgemm_linear_int8_weight_fp32_activation<S: Into<Scalar>>(
+    pub fn fbgemm_linear_int8_weight_fp32_activation<S: Into<Scalar>>(
         &self,
         weight: &Tensor,
         packed: &Tensor,
@@ -15123,19 +15042,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fbgemm_pack_gemm_matrix_fp16(&self) -> Result<Tensor, TchError> {
+    pub fn fbgemm_pack_gemm_matrix_fp16(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_fbgemm_pack_gemm_matrix_fp16(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fbgemm_pack_quantized_matrix(&self) -> Result<Tensor, TchError> {
+    pub fn fbgemm_pack_quantized_matrix(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_fbgemm_pack_quantized_matrix(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fbgemm_pack_quantized_matrix_kn(&self, k: i64, n: i64) -> Result<Tensor, TchError> {
+    pub fn fbgemm_pack_quantized_matrix_kn(&self, k: i64, n: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_fbgemm_pack_quantized_matrix_kn(
             c_tensors.as_mut_ptr(),
@@ -15146,7 +15065,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_feature_alpha_dropout(&self, p: f64, train: bool) -> Result<Tensor, TchError> {
+    pub fn feature_alpha_dropout(&self, p: f64, train: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_feature_alpha_dropout(
             c_tensors.as_mut_ptr(),
@@ -15157,7 +15076,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_feature_alpha_dropout_(&mut self, p: f64, train: bool) -> Result<Tensor, TchError> {
+    pub fn feature_alpha_dropout_(&mut self, p: f64, train: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_feature_alpha_dropout_(
             c_tensors.as_mut_ptr(),
@@ -15168,7 +15087,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_feature_dropout(&self, p: f64, train: bool) -> Result<Tensor, TchError> {
+    pub fn feature_dropout(&self, p: f64, train: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_feature_dropout(
             c_tensors.as_mut_ptr(),
@@ -15179,7 +15098,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_feature_dropout_(&mut self, p: f64, train: bool) -> Result<Tensor, TchError> {
+    pub fn feature_dropout_(&mut self, p: f64, train: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_feature_dropout_(
             c_tensors.as_mut_ptr(),
@@ -15190,7 +15109,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_fft(
+    pub fn fft_fft(
         &self,
         n: impl Into<Option<i64>>,
         dim: i64,
@@ -15210,7 +15129,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_fft2(
+    pub fn fft_fft2(
         &self,
         s: impl IntListOption,
         dim: impl IntList,
@@ -15230,7 +15149,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_fft2_out(
+    pub fn fft_fft2_out(
         &self,
         out: &Tensor,
         s: impl IntListOption,
@@ -15252,7 +15171,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_fft_out(
+    pub fn fft_fft_out(
         &self,
         out: &Tensor,
         n: impl Into<Option<i64>>,
@@ -15274,7 +15193,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_fftfreq(n: i64, d: f64, options: (Kind, Device)) -> Result<Tensor, TchError> {
+    pub fn fft_fftfreq(n: i64, d: f64, options: (Kind, Device)) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_fft_fftfreq(
             c_tensors.as_mut_ptr(),
@@ -15286,13 +15205,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_fftfreq_out(out: &Tensor, n: i64, d: f64) -> Result<Tensor, TchError> {
+    pub fn fft_fftfreq_out(out: &Tensor, n: i64, d: f64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_fft_fftfreq_out(c_tensors.as_mut_ptr(), out.c_tensor, n, d));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_fftn(
+    pub fn fft_fftn(
         &self,
         s: impl IntListOption,
         dim: impl IntListOption,
@@ -15312,7 +15231,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_fftn_out(
+    pub fn fft_fftn_out(
         &self,
         out: &Tensor,
         s: impl IntListOption,
@@ -15334,7 +15253,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_fftshift(&self, dim: impl IntListOption) -> Result<Tensor, TchError> {
+    pub fn fft_fftshift(&self, dim: impl IntListOption) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_fft_fftshift(
             c_tensors.as_mut_ptr(),
@@ -15345,7 +15264,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_hfft(
+    pub fn fft_hfft(
         &self,
         n: impl Into<Option<i64>>,
         dim: i64,
@@ -15365,7 +15284,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_hfft2(
+    pub fn fft_hfft2(
         &self,
         s: impl IntListOption,
         dim: impl IntList,
@@ -15385,7 +15304,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_hfft2_out(
+    pub fn fft_hfft2_out(
         &self,
         out: &Tensor,
         s: impl IntListOption,
@@ -15407,7 +15326,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_hfft_out(
+    pub fn fft_hfft_out(
         &self,
         out: &Tensor,
         n: impl Into<Option<i64>>,
@@ -15429,7 +15348,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_hfftn(
+    pub fn fft_hfftn(
         &self,
         s: impl IntListOption,
         dim: impl IntListOption,
@@ -15449,7 +15368,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_hfftn_out(
+    pub fn fft_hfftn_out(
         &self,
         out: &Tensor,
         s: impl IntListOption,
@@ -15471,7 +15390,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_ifft(
+    pub fn fft_ifft(
         &self,
         n: impl Into<Option<i64>>,
         dim: i64,
@@ -15491,7 +15410,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_ifft2(
+    pub fn fft_ifft2(
         &self,
         s: impl IntListOption,
         dim: impl IntList,
@@ -15511,7 +15430,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_ifft2_out(
+    pub fn fft_ifft2_out(
         &self,
         out: &Tensor,
         s: impl IntListOption,
@@ -15533,7 +15452,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_ifft_out(
+    pub fn fft_ifft_out(
         &self,
         out: &Tensor,
         n: impl Into<Option<i64>>,
@@ -15555,7 +15474,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_ifftn(
+    pub fn fft_ifftn(
         &self,
         s: impl IntListOption,
         dim: impl IntListOption,
@@ -15575,7 +15494,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_ifftn_out(
+    pub fn fft_ifftn_out(
         &self,
         out: &Tensor,
         s: impl IntListOption,
@@ -15597,7 +15516,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_ifftshift(&self, dim: impl IntListOption) -> Result<Tensor, TchError> {
+    pub fn fft_ifftshift(&self, dim: impl IntListOption) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_fft_ifftshift(
             c_tensors.as_mut_ptr(),
@@ -15608,7 +15527,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_ihfft(
+    pub fn fft_ihfft(
         &self,
         n: impl Into<Option<i64>>,
         dim: i64,
@@ -15628,7 +15547,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_ihfft2(
+    pub fn fft_ihfft2(
         &self,
         s: impl IntListOption,
         dim: impl IntList,
@@ -15648,7 +15567,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_ihfft2_out(
+    pub fn fft_ihfft2_out(
         &self,
         out: &Tensor,
         s: impl IntListOption,
@@ -15670,7 +15589,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_ihfft_out(
+    pub fn fft_ihfft_out(
         &self,
         out: &Tensor,
         n: impl Into<Option<i64>>,
@@ -15692,7 +15611,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_ihfftn(
+    pub fn fft_ihfftn(
         &self,
         s: impl IntListOption,
         dim: impl IntListOption,
@@ -15712,7 +15631,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_ihfftn_out(
+    pub fn fft_ihfftn_out(
         &self,
         out: &Tensor,
         s: impl IntListOption,
@@ -15734,7 +15653,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_irfft(
+    pub fn fft_irfft(
         &self,
         n: impl Into<Option<i64>>,
         dim: i64,
@@ -15754,7 +15673,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_irfft2(
+    pub fn fft_irfft2(
         &self,
         s: impl IntListOption,
         dim: impl IntList,
@@ -15774,7 +15693,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_irfft2_out(
+    pub fn fft_irfft2_out(
         &self,
         out: &Tensor,
         s: impl IntListOption,
@@ -15796,7 +15715,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_irfft_out(
+    pub fn fft_irfft_out(
         &self,
         out: &Tensor,
         n: impl Into<Option<i64>>,
@@ -15818,7 +15737,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_irfftn(
+    pub fn fft_irfftn(
         &self,
         s: impl IntListOption,
         dim: impl IntListOption,
@@ -15838,7 +15757,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_irfftn_out(
+    pub fn fft_irfftn_out(
         &self,
         out: &Tensor,
         s: impl IntListOption,
@@ -15860,7 +15779,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_rfft(
+    pub fn fft_rfft(
         &self,
         n: impl Into<Option<i64>>,
         dim: i64,
@@ -15880,7 +15799,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_rfft2(
+    pub fn fft_rfft2(
         &self,
         s: impl IntListOption,
         dim: impl IntList,
@@ -15900,7 +15819,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_rfft2_out(
+    pub fn fft_rfft2_out(
         &self,
         out: &Tensor,
         s: impl IntListOption,
@@ -15922,7 +15841,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_rfft_out(
+    pub fn fft_rfft_out(
         &self,
         out: &Tensor,
         n: impl Into<Option<i64>>,
@@ -15944,7 +15863,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_rfftfreq(n: i64, d: f64, options: (Kind, Device)) -> Result<Tensor, TchError> {
+    pub fn fft_rfftfreq(n: i64, d: f64, options: (Kind, Device)) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_fft_rfftfreq(
             c_tensors.as_mut_ptr(),
@@ -15956,13 +15875,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_rfftfreq_out(out: &Tensor, n: i64, d: f64) -> Result<Tensor, TchError> {
+    pub fn fft_rfftfreq_out(out: &Tensor, n: i64, d: f64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_fft_rfftfreq_out(c_tensors.as_mut_ptr(), out.c_tensor, n, d));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_rfftn(
+    pub fn fft_rfftn(
         &self,
         s: impl IntListOption,
         dim: impl IntListOption,
@@ -15982,7 +15901,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fft_rfftn_out(
+    pub fn fft_rfftn_out(
         &self,
         out: &Tensor,
         s: impl IntListOption,
@@ -16004,19 +15923,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fill<S: Into<Scalar>>(&self, value: S) -> Result<Tensor, TchError> {
+    pub fn fill<S: Into<Scalar>>(&self, value: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_fill(c_tensors.as_mut_ptr(), self.c_tensor, value.into().c_scalar));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fill_<S: Into<Scalar>>(&mut self, value: S) -> Result<Tensor, TchError> {
+    pub fn fill_<S: Into<Scalar>>(&mut self, value: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_fill_(c_tensors.as_mut_ptr(), self.c_tensor, value.into().c_scalar));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fill_diagonal_<S: Into<Scalar>>(
+    pub fn fill_diagonal_<S: Into<Scalar>>(
         &mut self,
         fill_value: S,
         wrap: bool,
@@ -16031,7 +15950,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fill_scalar_out<S: Into<Scalar>>(
+    pub fn fill_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         value: S,
@@ -16046,19 +15965,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fill_tensor(&self, value: &Tensor) -> Result<Tensor, TchError> {
+    pub fn fill_tensor(&self, value: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_fill_tensor(c_tensors.as_mut_ptr(), self.c_tensor, value.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fill_tensor_(&mut self, value: &Tensor) -> Result<Tensor, TchError> {
+    pub fn fill_tensor_(&mut self, value: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_fill_tensor_(c_tensors.as_mut_ptr(), self.c_tensor, value.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fill_tensor_out(&self, out: &Tensor, value: &Tensor) -> Result<Tensor, TchError> {
+    pub fn fill_tensor_out(&self, out: &Tensor, value: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_fill_tensor_out(
             c_tensors.as_mut_ptr(),
@@ -16069,31 +15988,31 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fix(&self) -> Result<Tensor, TchError> {
+    pub fn fix(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_fix(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fix_(&mut self) -> Result<Tensor, TchError> {
+    pub fn fix_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_fix_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fix_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn fix_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_fix_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_flatten(&self, start_dim: i64, end_dim: i64) -> Result<Tensor, TchError> {
+    pub fn flatten(&self, start_dim: i64, end_dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_flatten(c_tensors.as_mut_ptr(), self.c_tensor, start_dim, end_dim));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_flatten_dense_tensors<T: Borrow<Tensor>>(tensors: &[T]) -> Result<Tensor, TchError> {
+    pub fn flatten_dense_tensors<T: Borrow<Tensor>>(tensors: &[T]) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_flatten_dense_tensors(
             c_tensors.as_mut_ptr(),
@@ -16103,7 +16022,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_flip(&self, dims: impl IntList) -> Result<Tensor, TchError> {
+    pub fn flip(&self, dims: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_flip(
             c_tensors.as_mut_ptr(),
@@ -16114,7 +16033,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_flip_out(&self, out: &Tensor, dims: impl IntList) -> Result<Tensor, TchError> {
+    pub fn flip_out(&self, out: &Tensor, dims: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_flip_out(
             c_tensors.as_mut_ptr(),
@@ -16126,19 +16045,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fliplr(&self) -> Result<Tensor, TchError> {
+    pub fn fliplr(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_fliplr(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_flipud(&self) -> Result<Tensor, TchError> {
+    pub fn flipud(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_flipud(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_float_power(&self, exponent: &Tensor) -> Result<Tensor, TchError> {
+    pub fn float_power(&self, exponent: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_float_power(
             c_tensors.as_mut_ptr(),
@@ -16148,7 +16067,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_float_power_<S: Into<Scalar>>(&mut self, exponent: S) -> Result<Tensor, TchError> {
+    pub fn float_power_<S: Into<Scalar>>(&mut self, exponent: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_float_power_(
             c_tensors.as_mut_ptr(),
@@ -16158,7 +16077,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_float_power_scalar<S: Into<Scalar>>(
+    pub fn float_power_scalar<S: Into<Scalar>>(
         self_scalar: S,
         exponent: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -16171,7 +16090,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_float_power_scalar_out<S: Into<Scalar>>(
+    pub fn float_power_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         self_scalar: S,
         exponent: &Tensor,
@@ -16186,7 +16105,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_float_power_tensor_(&mut self, exponent: &Tensor) -> Result<Tensor, TchError> {
+    pub fn float_power_tensor_(&mut self, exponent: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_float_power_tensor_(
             c_tensors.as_mut_ptr(),
@@ -16196,7 +16115,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_float_power_tensor_scalar<S: Into<Scalar>>(
+    pub fn float_power_tensor_scalar<S: Into<Scalar>>(
         &self,
         exponent: S,
     ) -> Result<Tensor, TchError> {
@@ -16209,7 +16128,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_float_power_tensor_scalar_out<S: Into<Scalar>>(
+    pub fn float_power_tensor_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         exponent: S,
@@ -16224,7 +16143,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_float_power_tensor_tensor_out(
+    pub fn float_power_tensor_tensor_out(
         &self,
         out: &Tensor,
         exponent: &Tensor,
@@ -16239,31 +16158,31 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_floor(&self) -> Result<Tensor, TchError> {
+    pub fn floor(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_floor(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_floor_(&mut self) -> Result<Tensor, TchError> {
+    pub fn floor_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_floor_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_floor_divide(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn floor_divide(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_floor_divide(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_floor_divide_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn floor_divide_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_floor_divide_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_floor_divide_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn floor_divide_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_floor_divide_out(
             c_tensors.as_mut_ptr(),
@@ -16274,7 +16193,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_floor_divide_scalar<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
+    pub fn floor_divide_scalar<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_floor_divide_scalar(
             c_tensors.as_mut_ptr(),
@@ -16284,10 +16203,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_floor_divide_scalar_<S: Into<Scalar>>(
-        &mut self,
-        other: S,
-    ) -> Result<Tensor, TchError> {
+    pub fn floor_divide_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_floor_divide_scalar_(
             c_tensors.as_mut_ptr(),
@@ -16297,19 +16213,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_floor_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn floor_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_floor_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fmax(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn fmax(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_fmax(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fmax_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn fmax_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_fmax_out(
             c_tensors.as_mut_ptr(),
@@ -16320,13 +16236,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fmin(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn fmin(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_fmin(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fmin_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn fmin_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_fmin_out(
             c_tensors.as_mut_ptr(),
@@ -16337,19 +16253,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fmod<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
+    pub fn fmod<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_fmod(c_tensors.as_mut_ptr(), self.c_tensor, other.into().c_scalar));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fmod_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn fmod_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_fmod_(c_tensors.as_mut_ptr(), self.c_tensor, other.into().c_scalar));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fmod_scalar_out<S: Into<Scalar>>(
+    pub fn fmod_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
@@ -16364,19 +16280,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fmod_tensor(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn fmod_tensor(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_fmod_tensor(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fmod_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn fmod_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_fmod_tensor_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fmod_tensor_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn fmod_tensor_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_fmod_tensor_out(
             c_tensors.as_mut_ptr(),
@@ -16387,25 +16303,25 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_frac(&self) -> Result<Tensor, TchError> {
+    pub fn frac(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_frac(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_frac_(&mut self) -> Result<Tensor, TchError> {
+    pub fn frac_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_frac_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_frac_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn frac_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_frac_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fractional_max_pool2d(
+    pub fn fractional_max_pool2d(
         &self,
         kernel_size: impl IntList,
         output_size: impl IntList,
@@ -16424,7 +16340,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_fractional_max_pool2d_backward(
+    pub fn fractional_max_pool2d_backward(
         &self,
         grad_output: &Tensor,
         kernel_size: impl IntList,
@@ -16445,7 +16361,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fractional_max_pool2d_backward_grad_input(
+    pub fn fractional_max_pool2d_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -16468,7 +16384,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fractional_max_pool2d_output(
+    pub fn fractional_max_pool2d_output(
         &self,
         output: &Tensor,
         indices: &Tensor,
@@ -16491,7 +16407,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_fractional_max_pool3d(
+    pub fn fractional_max_pool3d(
         &self,
         kernel_size: impl IntList,
         output_size: impl IntList,
@@ -16510,7 +16426,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_fractional_max_pool3d_backward(
+    pub fn fractional_max_pool3d_backward(
         &self,
         grad_output: &Tensor,
         kernel_size: impl IntList,
@@ -16531,7 +16447,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fractional_max_pool3d_backward_grad_input(
+    pub fn fractional_max_pool3d_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -16554,7 +16470,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fractional_max_pool3d_output(
+    pub fn fractional_max_pool3d_output(
         &self,
         output: &Tensor,
         indices: &Tensor,
@@ -16577,13 +16493,13 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_frexp(&self) -> Result<(Tensor, Tensor), TchError> {
+    pub fn frexp(&self) -> Result<(Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 2];
         unsafe_torch_err!(atg_frexp(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_frexp_tensor_out(
+    pub fn frexp_tensor_out(
         &self,
         mantissa: &Tensor,
         exponent: &Tensor,
@@ -16598,7 +16514,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_frobenius_norm(&self, dim: impl IntList, keepdim: bool) -> Result<Tensor, TchError> {
+    pub fn frobenius_norm(&self, dim: impl IntList, keepdim: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_frobenius_norm(
             c_tensors.as_mut_ptr(),
@@ -16610,7 +16526,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_frobenius_norm_out(
+    pub fn frobenius_norm_out(
         &self,
         out: &Tensor,
         dim: impl IntList,
@@ -16628,7 +16544,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_from_file(
+    pub fn from_file(
         filename: &str,
         shared: bool,
         size: impl Into<Option<i64>>,
@@ -16649,7 +16565,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_from_file_out(
+    pub fn from_file_out(
         out: &Tensor,
         filename: &str,
         shared: bool,
@@ -16669,7 +16585,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_full<S: Into<Scalar>>(
+    pub fn full<S: Into<Scalar>>(
         size: impl IntList,
         fill_value: S,
         options: (Kind, Device),
@@ -16686,7 +16602,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_full_like<S: Into<Scalar>>(&self, fill_value: S) -> Result<Tensor, TchError> {
+    pub fn full_like<S: Into<Scalar>>(&self, fill_value: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_full_like(
             c_tensors.as_mut_ptr(),
@@ -16696,7 +16612,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_full_like_out<S: Into<Scalar>>(
+    pub fn full_like_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         fill_value: S,
@@ -16711,7 +16627,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_full_out<S: Into<Scalar>>(
+    pub fn full_out<S: Into<Scalar>>(
         out: &Tensor,
         size: impl IntList,
         fill_value: S,
@@ -16727,7 +16643,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_fused_moving_avg_obs_fake_quant(
+    pub fn fused_moving_avg_obs_fake_quant(
         &self,
         observer_on: &Tensor,
         fake_quant_on: &Tensor,
@@ -16762,12 +16678,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_gather(
-        &self,
-        dim: i64,
-        index: &Tensor,
-        sparse_grad: bool,
-    ) -> Result<Tensor, TchError> {
+    pub fn gather(&self, dim: i64, index: &Tensor, sparse_grad: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_gather(
             c_tensors.as_mut_ptr(),
@@ -16779,7 +16690,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_gather_backward(
+    pub fn gather_backward(
         &self,
         grad: &Tensor,
         dim: i64,
@@ -16798,7 +16709,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_gather_out(
+    pub fn gather_out(
         &self,
         out: &Tensor,
         dim: i64,
@@ -16817,19 +16728,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_gcd(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn gcd(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_gcd(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_gcd_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn gcd_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_gcd_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_gcd_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn gcd_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_gcd_out(
             c_tensors.as_mut_ptr(),
@@ -16840,19 +16751,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_ge<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
+    pub fn ge<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_ge(c_tensors.as_mut_ptr(), self.c_tensor, other.into().c_scalar));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_ge_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn ge_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_ge_(c_tensors.as_mut_ptr(), self.c_tensor, other.into().c_scalar));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_ge_scalar_out<S: Into<Scalar>>(
+    pub fn ge_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
@@ -16867,19 +16778,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_ge_tensor(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn ge_tensor(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_ge_tensor(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_ge_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn ge_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_ge_tensor_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_ge_tensor_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn ge_tensor_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_ge_tensor_out(
             c_tensors.as_mut_ptr(),
@@ -16890,7 +16801,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_gelu(&self, approximate: &str) -> Result<Tensor, TchError> {
+    pub fn gelu(&self, approximate: &str) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_gelu(
             c_tensors.as_mut_ptr(),
@@ -16901,7 +16812,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_gelu_(&mut self, approximate: &str) -> Result<Tensor, TchError> {
+    pub fn gelu_(&mut self, approximate: &str) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_gelu_(
             c_tensors.as_mut_ptr(),
@@ -16912,7 +16823,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_gelu_backward(
+    pub fn gelu_backward(
         &self,
         grad_output: &Tensor,
         approximate: &str,
@@ -16928,7 +16839,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_gelu_backward_grad_input(
+    pub fn gelu_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -16946,7 +16857,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_gelu_out(&self, out: &Tensor, approximate: &str) -> Result<Tensor, TchError> {
+    pub fn gelu_out(&self, out: &Tensor, approximate: &str) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_gelu_out(
             c_tensors.as_mut_ptr(),
@@ -16958,19 +16869,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_geometric(&self, p: f64) -> Result<Tensor, TchError> {
+    pub fn geometric(&self, p: f64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_geometric(c_tensors.as_mut_ptr(), self.c_tensor, p));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_geometric_(&mut self, p: f64) -> Result<Tensor, TchError> {
+    pub fn geometric_(&mut self, p: f64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_geometric_(c_tensors.as_mut_ptr(), self.c_tensor, p));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_geometric_out(&self, out: &Tensor, p: f64) -> Result<Tensor, TchError> {
+    pub fn geometric_out(&self, out: &Tensor, p: f64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_geometric_out(
             c_tensors.as_mut_ptr(),
@@ -16981,13 +16892,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_geqrf(&self) -> Result<(Tensor, Tensor), TchError> {
+    pub fn geqrf(&self) -> Result<(Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 2];
         unsafe_torch_err!(atg_geqrf(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_geqrf_a(&self, a: &Tensor, tau: &Tensor) -> Result<(Tensor, Tensor), TchError> {
+    pub fn geqrf_a(&self, a: &Tensor, tau: &Tensor) -> Result<(Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 2];
         unsafe_torch_err!(atg_geqrf_a(
             c_tensors.as_mut_ptr(),
@@ -16998,13 +16909,13 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_ger(&self, vec2: &Tensor) -> Result<Tensor, TchError> {
+    pub fn ger(&self, vec2: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_ger(c_tensors.as_mut_ptr(), self.c_tensor, vec2.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_ger_out(&self, out: &Tensor, vec2: &Tensor) -> Result<Tensor, TchError> {
+    pub fn ger_out(&self, out: &Tensor, vec2: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_ger_out(
             c_tensors.as_mut_ptr(),
@@ -17015,13 +16926,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_glu(&self, dim: i64) -> Result<Tensor, TchError> {
+    pub fn glu(&self, dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_glu(c_tensors.as_mut_ptr(), self.c_tensor, dim));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_glu_backward(&self, grad_output: &Tensor, dim: i64) -> Result<Tensor, TchError> {
+    pub fn glu_backward(&self, grad_output: &Tensor, dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_glu_backward(
             c_tensors.as_mut_ptr(),
@@ -17032,7 +16943,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_glu_backward_grad_input(
+    pub fn glu_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -17049,7 +16960,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_glu_backward_jvp(
+    pub fn glu_backward_jvp(
         grad_x: &Tensor,
         grad_glu: &Tensor,
         x: &Tensor,
@@ -17070,7 +16981,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_glu_backward_jvp_out(
+    pub fn glu_backward_jvp_out(
         out: &Tensor,
         grad_x: &Tensor,
         grad_glu: &Tensor,
@@ -17093,7 +17004,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_glu_jvp(glu: &Tensor, x: &Tensor, dx: &Tensor, dim: i64) -> Result<Tensor, TchError> {
+    pub fn glu_jvp(glu: &Tensor, x: &Tensor, dx: &Tensor, dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_glu_jvp(
             c_tensors.as_mut_ptr(),
@@ -17105,7 +17016,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_glu_jvp_out(
+    pub fn glu_jvp_out(
         out: &Tensor,
         glu: &Tensor,
         x: &Tensor,
@@ -17124,19 +17035,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_glu_out(&self, out: &Tensor, dim: i64) -> Result<Tensor, TchError> {
+    pub fn glu_out(&self, out: &Tensor, dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_glu_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor, dim));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_grad(&self) -> Result<Tensor, TchError> {
+    pub fn grad(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_grad(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_greater<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
+    pub fn greater<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_greater(
             c_tensors.as_mut_ptr(),
@@ -17146,7 +17057,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_greater_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn greater_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_greater_(
             c_tensors.as_mut_ptr(),
@@ -17156,7 +17067,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_greater_equal<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
+    pub fn greater_equal<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_greater_equal(
             c_tensors.as_mut_ptr(),
@@ -17166,7 +17077,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_greater_equal_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn greater_equal_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_greater_equal_(
             c_tensors.as_mut_ptr(),
@@ -17176,7 +17087,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_greater_equal_scalar_out<S: Into<Scalar>>(
+    pub fn greater_equal_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
@@ -17191,7 +17102,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_greater_equal_tensor(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn greater_equal_tensor(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_greater_equal_tensor(
             c_tensors.as_mut_ptr(),
@@ -17201,7 +17112,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_greater_equal_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn greater_equal_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_greater_equal_tensor_(
             c_tensors.as_mut_ptr(),
@@ -17211,7 +17122,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_greater_equal_tensor_out(
+    pub fn greater_equal_tensor_out(
         &self,
         out: &Tensor,
         other: &Tensor,
@@ -17226,7 +17137,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_greater_scalar_out<S: Into<Scalar>>(
+    pub fn greater_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
@@ -17241,7 +17152,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_greater_tensor(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn greater_tensor(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_greater_tensor(
             c_tensors.as_mut_ptr(),
@@ -17251,7 +17162,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_greater_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn greater_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_greater_tensor_(
             c_tensors.as_mut_ptr(),
@@ -17261,7 +17172,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_greater_tensor_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn greater_tensor_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_greater_tensor_out(
             c_tensors.as_mut_ptr(),
@@ -17272,7 +17183,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_grid_sampler(
+    pub fn grid_sampler(
         &self,
         grid: &Tensor,
         interpolation_mode: i64,
@@ -17291,7 +17202,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_grid_sampler_2d(
+    pub fn grid_sampler_2d(
         &self,
         grid: &Tensor,
         interpolation_mode: i64,
@@ -17310,7 +17221,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_grid_sampler_2d_out(
+    pub fn grid_sampler_2d_out(
         &self,
         out: &Tensor,
         grid: &Tensor,
@@ -17331,7 +17242,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_grid_sampler_3d(
+    pub fn grid_sampler_3d(
         &self,
         grid: &Tensor,
         interpolation_mode: i64,
@@ -17350,7 +17261,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_grid_sampler_3d_out(
+    pub fn grid_sampler_3d_out(
         &self,
         out: &Tensor,
         grid: &Tensor,
@@ -17371,7 +17282,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_group_norm<T: Borrow<Tensor>>(
+    pub fn group_norm<T: Borrow<Tensor>>(
         &self,
         num_groups: i64,
         weight: Option<T>,
@@ -17392,7 +17303,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_gru<T: Borrow<Tensor>>(
+    pub fn gru<T: Borrow<Tensor>>(
         &self,
         hx: &Tensor,
         params: &[T],
@@ -17420,7 +17331,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_gru_cell<T: Borrow<Tensor>>(
+    pub fn gru_cell<T: Borrow<Tensor>>(
         &self,
         hx: &Tensor,
         w_ih: &Tensor,
@@ -17441,7 +17352,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_gru_data<T: Borrow<Tensor>>(
+    pub fn gru_data<T: Borrow<Tensor>>(
         data: &Tensor,
         batch_sizes: &Tensor,
         hx: &Tensor,
@@ -17469,19 +17380,19 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_gt<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
+    pub fn gt<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_gt(c_tensors.as_mut_ptr(), self.c_tensor, other.into().c_scalar));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_gt_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn gt_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_gt_(c_tensors.as_mut_ptr(), self.c_tensor, other.into().c_scalar));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_gt_scalar_out<S: Into<Scalar>>(
+    pub fn gt_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
@@ -17496,19 +17407,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_gt_tensor(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn gt_tensor(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_gt_tensor(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_gt_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn gt_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_gt_tensor_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_gt_tensor_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn gt_tensor_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_gt_tensor_out(
             c_tensors.as_mut_ptr(),
@@ -17519,10 +17430,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hamming_window(
-        window_length: i64,
-        options: (Kind, Device),
-    ) -> Result<Tensor, TchError> {
+    pub fn hamming_window(window_length: i64, options: (Kind, Device)) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_hamming_window(
             c_tensors.as_mut_ptr(),
@@ -17533,7 +17441,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hamming_window_out(out: &Tensor, window_length: i64) -> Result<Tensor, TchError> {
+    pub fn hamming_window_out(out: &Tensor, window_length: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_hamming_window_out(
             c_tensors.as_mut_ptr(),
@@ -17543,7 +17451,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hamming_window_periodic(
+    pub fn hamming_window_periodic(
         window_length: i64,
         periodic: bool,
         options: (Kind, Device),
@@ -17559,7 +17467,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hamming_window_periodic_alpha(
+    pub fn hamming_window_periodic_alpha(
         window_length: i64,
         periodic: bool,
         alpha: f64,
@@ -17577,7 +17485,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hamming_window_periodic_alpha_beta(
+    pub fn hamming_window_periodic_alpha_beta(
         window_length: i64,
         periodic: bool,
         alpha: f64,
@@ -17597,7 +17505,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hamming_window_periodic_alpha_beta_out(
+    pub fn hamming_window_periodic_alpha_beta_out(
         out: &Tensor,
         window_length: i64,
         periodic: bool,
@@ -17616,7 +17524,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hamming_window_periodic_alpha_out(
+    pub fn hamming_window_periodic_alpha_out(
         out: &Tensor,
         window_length: i64,
         periodic: bool,
@@ -17633,7 +17541,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hamming_window_periodic_out(
+    pub fn hamming_window_periodic_out(
         out: &Tensor,
         window_length: i64,
         periodic: bool,
@@ -17648,7 +17556,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hann_window(window_length: i64, options: (Kind, Device)) -> Result<Tensor, TchError> {
+    pub fn hann_window(window_length: i64, options: (Kind, Device)) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_hann_window(
             c_tensors.as_mut_ptr(),
@@ -17659,13 +17567,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hann_window_out(out: &Tensor, window_length: i64) -> Result<Tensor, TchError> {
+    pub fn hann_window_out(out: &Tensor, window_length: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_hann_window_out(c_tensors.as_mut_ptr(), out.c_tensor, window_length));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hann_window_periodic(
+    pub fn hann_window_periodic(
         window_length: i64,
         periodic: bool,
         options: (Kind, Device),
@@ -17681,7 +17589,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hann_window_periodic_out(
+    pub fn hann_window_periodic_out(
         out: &Tensor,
         window_length: i64,
         periodic: bool,
@@ -17696,13 +17604,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hardshrink(&self) -> Result<Tensor, TchError> {
+    pub fn hardshrink(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_hardshrink(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hardshrink_backward<S: Into<Scalar>>(
+    pub fn hardshrink_backward<S: Into<Scalar>>(
         &self,
         grad_out: &Tensor,
         lambd: S,
@@ -17717,7 +17625,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hardshrink_backward_grad_input<S: Into<Scalar>>(
+    pub fn hardshrink_backward_grad_input<S: Into<Scalar>>(
         &self,
         grad_input: &Tensor,
         grad_out: &Tensor,
@@ -17734,25 +17642,25 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hardshrink_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn hardshrink_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_hardshrink_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hardsigmoid(&self) -> Result<Tensor, TchError> {
+    pub fn hardsigmoid(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_hardsigmoid(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hardsigmoid_(&mut self) -> Result<Tensor, TchError> {
+    pub fn hardsigmoid_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_hardsigmoid_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hardsigmoid_backward(&self, grad_output: &Tensor) -> Result<Tensor, TchError> {
+    pub fn hardsigmoid_backward(&self, grad_output: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_hardsigmoid_backward(
             c_tensors.as_mut_ptr(),
@@ -17762,7 +17670,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hardsigmoid_backward_grad_input(
+    pub fn hardsigmoid_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -17777,25 +17685,25 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hardsigmoid_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn hardsigmoid_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_hardsigmoid_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hardswish(&self) -> Result<Tensor, TchError> {
+    pub fn hardswish(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_hardswish(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hardswish_(&mut self) -> Result<Tensor, TchError> {
+    pub fn hardswish_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_hardswish_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hardswish_backward(&self, grad_output: &Tensor) -> Result<Tensor, TchError> {
+    pub fn hardswish_backward(&self, grad_output: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_hardswish_backward(
             c_tensors.as_mut_ptr(),
@@ -17805,7 +17713,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hardswish_backward_out(
+    pub fn hardswish_backward_out(
         &self,
         out: &Tensor,
         grad_output: &Tensor,
@@ -17820,25 +17728,25 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hardswish_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn hardswish_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_hardswish_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hardtanh(&self) -> Result<Tensor, TchError> {
+    pub fn hardtanh(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_hardtanh(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hardtanh_(&mut self) -> Result<Tensor, TchError> {
+    pub fn hardtanh_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_hardtanh_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hardtanh_backward<S: Into<Scalar>>(
+    pub fn hardtanh_backward<S: Into<Scalar>>(
         &self,
         grad_output: &Tensor,
         min_val: S,
@@ -17855,7 +17763,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hardtanh_backward_grad_input<S: Into<Scalar>>(
+    pub fn hardtanh_backward_grad_input<S: Into<Scalar>>(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -17874,25 +17782,25 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hardtanh_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn hardtanh_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_hardtanh_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_heaviside(&self, values: &Tensor) -> Result<Tensor, TchError> {
+    pub fn heaviside(&self, values: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_heaviside(c_tensors.as_mut_ptr(), self.c_tensor, values.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_heaviside_(&mut self, values: &Tensor) -> Result<Tensor, TchError> {
+    pub fn heaviside_(&mut self, values: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_heaviside_(c_tensors.as_mut_ptr(), self.c_tensor, values.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_heaviside_out(&self, out: &Tensor, values: &Tensor) -> Result<Tensor, TchError> {
+    pub fn heaviside_out(&self, out: &Tensor, values: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_heaviside_out(
             c_tensors.as_mut_ptr(),
@@ -17903,7 +17811,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hinge_embedding_loss(
+    pub fn hinge_embedding_loss(
         &self,
         target: &Tensor,
         margin: f64,
@@ -17920,19 +17828,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_histc(&self, bins: i64) -> Result<Tensor, TchError> {
+    pub fn histc(&self, bins: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_histc(c_tensors.as_mut_ptr(), self.c_tensor, bins));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_histc_out(&self, out: &Tensor, bins: i64) -> Result<Tensor, TchError> {
+    pub fn histc_out(&self, out: &Tensor, bins: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_histc_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor, bins));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_histogram<T: Borrow<Tensor>>(
+    pub fn histogram<T: Borrow<Tensor>>(
         &self,
         bins: &Tensor,
         weight: Option<T>,
@@ -17949,7 +17857,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_histogram_bin_ct<T: Borrow<Tensor>>(
+    pub fn histogram_bin_ct<T: Borrow<Tensor>>(
         &self,
         bins: i64,
         range: impl DoubleList,
@@ -17969,7 +17877,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_histogram_bin_ct_out<T: Borrow<Tensor>>(
+    pub fn histogram_bin_ct_out<T: Borrow<Tensor>>(
         &self,
         hist: &Tensor,
         bin_edges: &Tensor,
@@ -17993,7 +17901,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_histogram_bins_tensor_out<T: Borrow<Tensor>>(
+    pub fn histogram_bins_tensor_out<T: Borrow<Tensor>>(
         &self,
         hist: &Tensor,
         bin_edges: &Tensor,
@@ -18014,7 +17922,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_hsplit(&self, sections: i64) -> Result<Vec<Tensor>, TchError> {
+    pub fn hsplit(&self, sections: i64) -> Result<Vec<Tensor>, TchError> {
         let c_tensors = unsafe_torch_err!(atg_hsplit(self.c_tensor, sections));
         let mut r__ = vec![];
         let mut i = 0;
@@ -18030,7 +17938,7 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_hsplit_array(&self, indices: impl IntList) -> Result<Vec<Tensor>, TchError> {
+    pub fn hsplit_array(&self, indices: impl IntList) -> Result<Vec<Tensor>, TchError> {
         let c_tensors =
             unsafe_torch_err!(atg_hsplit_array(self.c_tensor, indices.as_ptr(), indices.len_i32()));
         let mut r__ = vec![];
@@ -18047,13 +17955,13 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_hspmm(mat1: &Tensor, mat2: &Tensor) -> Result<Tensor, TchError> {
+    pub fn hspmm(mat1: &Tensor, mat2: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_hspmm(c_tensors.as_mut_ptr(), mat1.c_tensor, mat2.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hspmm_out(out: &Tensor, mat1: &Tensor, mat2: &Tensor) -> Result<Tensor, TchError> {
+    pub fn hspmm_out(out: &Tensor, mat1: &Tensor, mat2: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_hspmm_out(
             c_tensors.as_mut_ptr(),
@@ -18064,7 +17972,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hstack<T: Borrow<Tensor>>(tensors: &[T]) -> Result<Tensor, TchError> {
+    pub fn hstack<T: Borrow<Tensor>>(tensors: &[T]) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_hstack(
             c_tensors.as_mut_ptr(),
@@ -18074,10 +17982,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hstack_out<T: Borrow<Tensor>>(
-        out: &Tensor,
-        tensors: &[T],
-    ) -> Result<Tensor, TchError> {
+    pub fn hstack_out<T: Borrow<Tensor>>(out: &Tensor, tensors: &[T]) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_hstack_out(
             c_tensors.as_mut_ptr(),
@@ -18088,7 +17993,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_huber_loss(
+    pub fn huber_loss(
         &self,
         target: &Tensor,
         reduction: crate::Reduction,
@@ -18105,7 +18010,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_huber_loss_backward(
+    pub fn huber_loss_backward(
         &self,
         grad_output: &Tensor,
         target: &Tensor,
@@ -18124,7 +18029,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_huber_loss_backward_out(
+    pub fn huber_loss_backward_out(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -18145,7 +18050,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_huber_loss_out(
+    pub fn huber_loss_out(
         &self,
         out: &Tensor,
         target: &Tensor,
@@ -18164,19 +18069,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hypot(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn hypot(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_hypot(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hypot_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn hypot_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_hypot_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_hypot_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn hypot_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_hypot_out(
             c_tensors.as_mut_ptr(),
@@ -18187,37 +18092,37 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_i0(&self) -> Result<Tensor, TchError> {
+    pub fn i0(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_i0(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_i0_(&mut self) -> Result<Tensor, TchError> {
+    pub fn i0_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_i0_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_i0_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn i0_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_i0_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_igamma(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn igamma(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_igamma(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_igamma_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn igamma_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_igamma_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_igamma_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn igamma_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_igamma_out(
             c_tensors.as_mut_ptr(),
@@ -18228,19 +18133,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_igammac(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn igammac(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_igammac(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_igammac_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn igammac_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_igammac_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_igammac_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn igammac_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_igammac_out(
             c_tensors.as_mut_ptr(),
@@ -18251,7 +18156,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_im2col(
+    pub fn im2col(
         &self,
         kernel_size: impl IntList,
         dilation: impl IntList,
@@ -18274,7 +18179,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_im2col_out(
+    pub fn im2col_out(
         &self,
         out: &Tensor,
         kernel_size: impl IntList,
@@ -18299,13 +18204,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_imag(&self) -> Result<Tensor, TchError> {
+    pub fn imag(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_imag(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_index<T: Borrow<Tensor>>(&self, indices: &[Option<T>]) -> Result<Tensor, TchError> {
+    pub fn index<T: Borrow<Tensor>>(&self, indices: &[Option<T>]) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_index(
             c_tensors.as_mut_ptr(),
@@ -18316,12 +18221,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_index_add(
-        &self,
-        dim: i64,
-        index: &Tensor,
-        source: &Tensor,
-    ) -> Result<Tensor, TchError> {
+    pub fn index_add(&self, dim: i64, index: &Tensor, source: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_index_add(
             c_tensors.as_mut_ptr(),
@@ -18333,7 +18233,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_index_add_(
+    pub fn index_add_(
         &mut self,
         dim: i64,
         index: &Tensor,
@@ -18350,7 +18250,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_index_add_out(
+    pub fn index_add_out(
         &self,
         out: &Tensor,
         dim: i64,
@@ -18369,7 +18269,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_index_copy(
+    pub fn index_copy(
         &self,
         dim: i64,
         index: &Tensor,
@@ -18386,7 +18286,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_index_copy_(
+    pub fn index_copy_(
         &mut self,
         dim: i64,
         index: &Tensor,
@@ -18403,7 +18303,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_index_copy_out(
+    pub fn index_copy_out(
         &self,
         out: &Tensor,
         dim: i64,
@@ -18422,7 +18322,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_index_fill<S: Into<Scalar>>(
+    pub fn index_fill<S: Into<Scalar>>(
         &self,
         dim: i64,
         index: &Tensor,
@@ -18439,7 +18339,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_index_fill_<S: Into<Scalar>>(
+    pub fn index_fill_<S: Into<Scalar>>(
         &mut self,
         dim: i64,
         index: &Tensor,
@@ -18456,7 +18356,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_index_fill_int_scalar_out<S: Into<Scalar>>(
+    pub fn index_fill_int_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         dim: i64,
@@ -18475,7 +18375,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_index_fill_int_tensor(
+    pub fn index_fill_int_tensor(
         &self,
         dim: i64,
         index: &Tensor,
@@ -18492,7 +18392,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_index_fill_int_tensor_(
+    pub fn index_fill_int_tensor_(
         &mut self,
         dim: i64,
         index: &Tensor,
@@ -18509,7 +18409,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_index_fill_int_tensor_out(
+    pub fn index_fill_int_tensor_out(
         &self,
         out: &Tensor,
         dim: i64,
@@ -18528,7 +18428,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_index_put<T: Borrow<Tensor>>(
+    pub fn index_put<T: Borrow<Tensor>>(
         &self,
         indices: &[Option<T>],
         values: &Tensor,
@@ -18546,7 +18446,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_index_put_<T: Borrow<Tensor>>(
+    pub fn index_put_<T: Borrow<Tensor>>(
         &mut self,
         indices: &[Option<T>],
         values: &Tensor,
@@ -18564,7 +18464,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_index_put_out<T: Borrow<Tensor>>(
+    pub fn index_put_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         indices: &[Option<T>],
@@ -18584,7 +18484,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_index_reduce(
+    pub fn index_reduce(
         &self,
         dim: i64,
         index: &Tensor,
@@ -18606,7 +18506,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_index_reduce_(
+    pub fn index_reduce_(
         &mut self,
         dim: i64,
         index: &Tensor,
@@ -18628,7 +18528,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_index_reduce_out(
+    pub fn index_reduce_out(
         &self,
         out: &Tensor,
         dim: i64,
@@ -18652,7 +18552,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_index_select(&self, dim: i64, index: &Tensor) -> Result<Tensor, TchError> {
+    pub fn index_select(&self, dim: i64, index: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_index_select(
             c_tensors.as_mut_ptr(),
@@ -18663,7 +18563,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_index_select_backward(
+    pub fn index_select_backward(
         grad: &Tensor,
         self_sizes: impl IntList,
         dim: i64,
@@ -18681,7 +18581,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_index_select_out(
+    pub fn index_select_out(
         &self,
         out: &Tensor,
         dim: i64,
@@ -18698,7 +18598,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_index_tensor_out<T: Borrow<Tensor>>(
+    pub fn index_tensor_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         indices: &[Option<T>],
@@ -18714,19 +18614,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_indices(&self) -> Result<Tensor, TchError> {
+    pub fn indices(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_indices(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_indices_copy(&self) -> Result<Tensor, TchError> {
+    pub fn indices_copy(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_indices_copy(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_indices_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn indices_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_indices_copy_out(
             c_tensors.as_mut_ptr(),
@@ -18736,7 +18636,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_infinitely_differentiable_gelu_backward(
+    pub fn infinitely_differentiable_gelu_backward(
         &self,
         grad: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -18749,13 +18649,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_inner(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn inner(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_inner(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_inner_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn inner_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_inner_out(
             c_tensors.as_mut_ptr(),
@@ -18766,7 +18666,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_instance_norm<T: Borrow<Tensor>>(
+    pub fn instance_norm<T: Borrow<Tensor>>(
         &self,
         weight: Option<T>,
         bias: Option<T>,
@@ -18793,115 +18693,115 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_int_repr(&self) -> Result<Tensor, TchError> {
+    pub fn int_repr(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_int_repr(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_int_repr_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn int_repr_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_int_repr_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_inverse(&self) -> Result<Tensor, TchError> {
+    pub fn inverse(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_inverse(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_inverse_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn inverse_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_inverse_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_is_coalesced(&self) -> Result<bool, TchError> {
+    pub fn is_coalesced(&self) -> Result<bool, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg_is_coalesced(self.c_tensor));
         Ok(return_ != 0)
     }
 
-    pub fn f_is_complex(&self) -> Result<bool, TchError> {
+    pub fn is_complex(&self) -> Result<bool, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg_is_complex(self.c_tensor));
         Ok(return_ != 0)
     }
 
-    pub fn f_is_conj(&self) -> Result<bool, TchError> {
+    pub fn is_conj(&self) -> Result<bool, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg_is_conj(self.c_tensor));
         Ok(return_ != 0)
     }
 
-    pub fn f_is_distributed(&self) -> Result<bool, TchError> {
+    pub fn is_distributed(&self) -> Result<bool, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg_is_distributed(self.c_tensor));
         Ok(return_ != 0)
     }
 
-    pub fn f_is_floating_point(&self) -> Result<bool, TchError> {
+    pub fn is_floating_point(&self) -> Result<bool, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg_is_floating_point(self.c_tensor));
         Ok(return_ != 0)
     }
 
-    pub fn f_is_inference(&self) -> Result<bool, TchError> {
+    pub fn is_inference(&self) -> Result<bool, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg_is_inference(self.c_tensor));
         Ok(return_ != 0)
     }
 
-    pub fn f_is_leaf(&self) -> Result<bool, TchError> {
+    pub fn is_leaf(&self) -> Result<bool, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg_is_leaf(self.c_tensor));
         Ok(return_ != 0)
     }
 
-    pub fn f_is_neg(&self) -> Result<bool, TchError> {
+    pub fn is_neg(&self) -> Result<bool, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg_is_neg(self.c_tensor));
         Ok(return_ != 0)
     }
 
-    pub fn f_is_nonzero(&self) -> Result<bool, TchError> {
+    pub fn is_nonzero(&self) -> Result<bool, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg_is_nonzero(self.c_tensor));
         Ok(return_ != 0)
     }
 
-    pub fn f_is_pinned(&self, device: Device) -> Result<bool, TchError> {
+    pub fn is_pinned(&self, device: Device) -> Result<bool, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg_is_pinned(self.c_tensor, device.c_int()));
         Ok(return_ != 0)
     }
 
-    pub fn f_is_same_size(&self, other: &Tensor) -> Result<bool, TchError> {
+    pub fn is_same_size(&self, other: &Tensor) -> Result<bool, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg_is_same_size(self.c_tensor, other.c_tensor));
         Ok(return_ != 0)
     }
 
-    pub fn f_is_set_to(&self, tensor: &Tensor) -> Result<bool, TchError> {
+    pub fn is_set_to(&self, tensor: &Tensor) -> Result<bool, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg_is_set_to(self.c_tensor, tensor.c_tensor));
         Ok(return_ != 0)
     }
 
-    pub fn f_is_signed(&self) -> Result<bool, TchError> {
+    pub fn is_signed(&self) -> Result<bool, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg_is_signed(self.c_tensor));
         Ok(return_ != 0)
     }
 
-    pub fn f_is_vulkan_available() -> Result<bool, TchError> {
+    pub fn is_vulkan_available() -> Result<bool, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg_is_vulkan_available());
         Ok(return_ != 0)
     }
 
-    pub fn f_isclose(
+    pub fn isclose(
         &self,
         other: &Tensor,
         rtol: f64,
@@ -18920,13 +18820,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_isfinite(&self) -> Result<Tensor, TchError> {
+    pub fn isfinite(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_isfinite(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_isin(
+    pub fn isin(
         elements: &Tensor,
         test_elements: &Tensor,
         assume_unique: bool,
@@ -18943,7 +18843,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_isin_scalar_tensor<S: Into<Scalar>>(
+    pub fn isin_scalar_tensor<S: Into<Scalar>>(
         element: S,
         test_elements: &Tensor,
         assume_unique: bool,
@@ -18960,7 +18860,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_isin_scalar_tensor_out<S: Into<Scalar>>(
+    pub fn isin_scalar_tensor_out<S: Into<Scalar>>(
         out: &Tensor,
         element: S,
         test_elements: &Tensor,
@@ -18979,7 +18879,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_isin_tensor_scalar<S: Into<Scalar>>(
+    pub fn isin_tensor_scalar<S: Into<Scalar>>(
         elements: &Tensor,
         test_element: S,
         assume_unique: bool,
@@ -18996,7 +18896,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_isin_tensor_scalar_out<S: Into<Scalar>>(
+    pub fn isin_tensor_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         elements: &Tensor,
         test_element: S,
@@ -19015,7 +18915,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_isin_tensor_tensor_out(
+    pub fn isin_tensor_tensor_out(
         out: &Tensor,
         elements: &Tensor,
         test_elements: &Tensor,
@@ -19034,61 +18934,61 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_isinf(&self) -> Result<Tensor, TchError> {
+    pub fn isinf(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_isinf(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_isinf_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn isinf_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_isinf_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_isnan(&self) -> Result<Tensor, TchError> {
+    pub fn isnan(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_isnan(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_isnan_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn isnan_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_isnan_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_isneginf(&self) -> Result<Tensor, TchError> {
+    pub fn isneginf(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_isneginf(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_isneginf_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn isneginf_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_isneginf_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_isposinf(&self) -> Result<Tensor, TchError> {
+    pub fn isposinf(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_isposinf(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_isposinf_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn isposinf_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_isposinf_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_isreal(&self) -> Result<Tensor, TchError> {
+    pub fn isreal(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_isreal(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_istft<T: Borrow<Tensor>>(
+    pub fn istft<T: Borrow<Tensor>>(
         &self,
         n_fft: i64,
         hop_length: impl Into<Option<i64>>,
@@ -19123,10 +19023,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_kaiser_window(
-        window_length: i64,
-        options: (Kind, Device),
-    ) -> Result<Tensor, TchError> {
+    pub fn kaiser_window(window_length: i64, options: (Kind, Device)) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_kaiser_window(
             c_tensors.as_mut_ptr(),
@@ -19137,7 +19034,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_kaiser_window_beta(
+    pub fn kaiser_window_beta(
         window_length: i64,
         periodic: bool,
         beta: f64,
@@ -19155,7 +19052,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_kaiser_window_beta_out(
+    pub fn kaiser_window_beta_out(
         out: &Tensor,
         window_length: i64,
         periodic: bool,
@@ -19172,7 +19069,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_kaiser_window_out(out: &Tensor, window_length: i64) -> Result<Tensor, TchError> {
+    pub fn kaiser_window_out(out: &Tensor, window_length: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_kaiser_window_out(
             c_tensors.as_mut_ptr(),
@@ -19182,7 +19079,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_kaiser_window_periodic(
+    pub fn kaiser_window_periodic(
         window_length: i64,
         periodic: bool,
         options: (Kind, Device),
@@ -19198,7 +19095,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_kaiser_window_periodic_out(
+    pub fn kaiser_window_periodic_out(
         out: &Tensor,
         window_length: i64,
         periodic: bool,
@@ -19213,7 +19110,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_kl_div(
+    pub fn kl_div(
         &self,
         target: &Tensor,
         reduction: crate::Reduction,
@@ -19230,13 +19127,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_kron(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn kron(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_kron(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_kron_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn kron_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_kron_out(
             c_tensors.as_mut_ptr(),
@@ -19247,12 +19144,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_kthvalue(
-        &self,
-        k: i64,
-        dim: i64,
-        keepdim: bool,
-    ) -> Result<(Tensor, Tensor), TchError> {
+    pub fn kthvalue(&self, k: i64, dim: i64, keepdim: bool) -> Result<(Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 2];
         unsafe_torch_err!(atg_kthvalue(
             c_tensors.as_mut_ptr(),
@@ -19264,7 +19156,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_kthvalue_values(
+    pub fn kthvalue_values(
         &self,
         values: &Tensor,
         indices: &Tensor,
@@ -19285,7 +19177,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_l1_loss(
+    pub fn l1_loss(
         &self,
         target: &Tensor,
         reduction: crate::Reduction,
@@ -19300,7 +19192,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_layer_norm<T: Borrow<Tensor>>(
+    pub fn layer_norm<T: Borrow<Tensor>>(
         &self,
         normalized_shape: impl IntList,
         weight: Option<T>,
@@ -19322,19 +19214,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_lcm(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn lcm(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_lcm(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_lcm_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn lcm_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_lcm_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_lcm_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn lcm_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_lcm_out(
             c_tensors.as_mut_ptr(),
@@ -19345,19 +19237,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_ldexp(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn ldexp(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_ldexp(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_ldexp_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn ldexp_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_ldexp_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_ldexp_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn ldexp_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_ldexp_out(
             c_tensors.as_mut_ptr(),
@@ -19368,19 +19260,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_le<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
+    pub fn le<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_le(c_tensors.as_mut_ptr(), self.c_tensor, other.into().c_scalar));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_le_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn le_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_le_(c_tensors.as_mut_ptr(), self.c_tensor, other.into().c_scalar));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_le_scalar_out<S: Into<Scalar>>(
+    pub fn le_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
@@ -19395,19 +19287,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_le_tensor(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn le_tensor(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_le_tensor(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_le_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn le_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_le_tensor_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_le_tensor_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn le_tensor_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_le_tensor_out(
             c_tensors.as_mut_ptr(),
@@ -19418,19 +19310,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_leaky_relu(&self) -> Result<Tensor, TchError> {
+    pub fn leaky_relu(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_leaky_relu(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_leaky_relu_(&mut self) -> Result<Tensor, TchError> {
+    pub fn leaky_relu_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_leaky_relu_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_leaky_relu_backward<S: Into<Scalar>>(
+    pub fn leaky_relu_backward<S: Into<Scalar>>(
         &self,
         grad_output: &Tensor,
         negative_slope: S,
@@ -19447,7 +19339,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_leaky_relu_backward_grad_input<S: Into<Scalar>>(
+    pub fn leaky_relu_backward_grad_input<S: Into<Scalar>>(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -19466,13 +19358,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_leaky_relu_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn leaky_relu_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_leaky_relu_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_lerp<S: Into<Scalar>>(&self, end: &Tensor, weight: S) -> Result<Tensor, TchError> {
+    pub fn lerp<S: Into<Scalar>>(&self, end: &Tensor, weight: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_lerp(
             c_tensors.as_mut_ptr(),
@@ -19483,11 +19375,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_lerp_<S: Into<Scalar>>(
-        &mut self,
-        end: &Tensor,
-        weight: S,
-    ) -> Result<Tensor, TchError> {
+    pub fn lerp_<S: Into<Scalar>>(&mut self, end: &Tensor, weight: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_lerp_(
             c_tensors.as_mut_ptr(),
@@ -19498,7 +19386,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_lerp_scalar_out<S: Into<Scalar>>(
+    pub fn lerp_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         end: &Tensor,
@@ -19515,7 +19403,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_lerp_tensor(&self, end: &Tensor, weight: &Tensor) -> Result<Tensor, TchError> {
+    pub fn lerp_tensor(&self, end: &Tensor, weight: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_lerp_tensor(
             c_tensors.as_mut_ptr(),
@@ -19526,7 +19414,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_lerp_tensor_(&mut self, end: &Tensor, weight: &Tensor) -> Result<Tensor, TchError> {
+    pub fn lerp_tensor_(&mut self, end: &Tensor, weight: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_lerp_tensor_(
             c_tensors.as_mut_ptr(),
@@ -19537,7 +19425,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_lerp_tensor_out(
+    pub fn lerp_tensor_out(
         &self,
         out: &Tensor,
         end: &Tensor,
@@ -19554,19 +19442,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_less<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
+    pub fn less<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_less(c_tensors.as_mut_ptr(), self.c_tensor, other.into().c_scalar));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_less_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn less_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_less_(c_tensors.as_mut_ptr(), self.c_tensor, other.into().c_scalar));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_less_equal<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
+    pub fn less_equal<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_less_equal(
             c_tensors.as_mut_ptr(),
@@ -19576,7 +19464,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_less_equal_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn less_equal_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_less_equal_(
             c_tensors.as_mut_ptr(),
@@ -19586,7 +19474,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_less_equal_scalar_out<S: Into<Scalar>>(
+    pub fn less_equal_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
@@ -19601,7 +19489,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_less_equal_tensor(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn less_equal_tensor(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_less_equal_tensor(
             c_tensors.as_mut_ptr(),
@@ -19611,7 +19499,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_less_equal_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn less_equal_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_less_equal_tensor_(
             c_tensors.as_mut_ptr(),
@@ -19621,11 +19509,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_less_equal_tensor_out(
-        &self,
-        out: &Tensor,
-        other: &Tensor,
-    ) -> Result<Tensor, TchError> {
+    pub fn less_equal_tensor_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_less_equal_tensor_out(
             c_tensors.as_mut_ptr(),
@@ -19636,7 +19520,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_less_scalar_out<S: Into<Scalar>>(
+    pub fn less_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
@@ -19651,19 +19535,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_less_tensor(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn less_tensor(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_less_tensor(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_less_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn less_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_less_tensor_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_less_tensor_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn less_tensor_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_less_tensor_out(
             c_tensors.as_mut_ptr(),
@@ -19674,43 +19558,43 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_lgamma(&self) -> Result<Tensor, TchError> {
+    pub fn lgamma(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_lgamma(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_lgamma_(&mut self) -> Result<Tensor, TchError> {
+    pub fn lgamma_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_lgamma_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_lgamma_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn lgamma_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_lgamma_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_lift(&self) -> Result<Tensor, TchError> {
+    pub fn lift(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_lift(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_lift_fresh(&self) -> Result<Tensor, TchError> {
+    pub fn lift_fresh(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_lift_fresh(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_lift_fresh_copy(&self) -> Result<Tensor, TchError> {
+    pub fn lift_fresh_copy(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_lift_fresh_copy(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_lift_fresh_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn lift_fresh_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_lift_fresh_copy_out(
             c_tensors.as_mut_ptr(),
@@ -19720,13 +19604,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_lift_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn lift_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_lift_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_cholesky(&self, upper: bool) -> Result<Tensor, TchError> {
+    pub fn linalg_cholesky(&self, upper: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_linalg_cholesky(
             c_tensors.as_mut_ptr(),
@@ -19736,7 +19620,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_cholesky_ex(
+    pub fn linalg_cholesky_ex(
         &self,
         upper: bool,
         check_errors: bool,
@@ -19751,7 +19635,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_linalg_cholesky_ex_l(
+    pub fn linalg_cholesky_ex_l(
         &self,
         l: &Tensor,
         info: &Tensor,
@@ -19770,7 +19654,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_linalg_cholesky_out(&self, out: &Tensor, upper: bool) -> Result<Tensor, TchError> {
+    pub fn linalg_cholesky_out(&self, out: &Tensor, upper: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_linalg_cholesky_out(
             c_tensors.as_mut_ptr(),
@@ -19781,7 +19665,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_cond<S: Into<Scalar>>(&self, p: S) -> Result<Tensor, TchError> {
+    pub fn linalg_cond<S: Into<Scalar>>(&self, p: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_linalg_cond(
             c_tensors.as_mut_ptr(),
@@ -19791,11 +19675,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_cond_out<S: Into<Scalar>>(
-        &self,
-        out: &Tensor,
-        p: S,
-    ) -> Result<Tensor, TchError> {
+    pub fn linalg_cond_out<S: Into<Scalar>>(&self, out: &Tensor, p: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_linalg_cond_out(
             c_tensors.as_mut_ptr(),
@@ -19806,7 +19686,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_cond_p_str(&self, p: &str) -> Result<Tensor, TchError> {
+    pub fn linalg_cond_p_str(&self, p: &str) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_linalg_cond_p_str(
             c_tensors.as_mut_ptr(),
@@ -19817,7 +19697,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_cond_p_str_out(&self, out: &Tensor, p: &str) -> Result<Tensor, TchError> {
+    pub fn linalg_cond_p_str_out(&self, out: &Tensor, p: &str) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_linalg_cond_p_str_out(
             c_tensors.as_mut_ptr(),
@@ -19829,7 +19709,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_cross(&self, other: &Tensor, dim: i64) -> Result<Tensor, TchError> {
+    pub fn linalg_cross(&self, other: &Tensor, dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_linalg_cross(
             c_tensors.as_mut_ptr(),
@@ -19840,7 +19720,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_cross_out(
+    pub fn linalg_cross_out(
         &self,
         out: &Tensor,
         other: &Tensor,
@@ -19857,19 +19737,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_det(a: &Tensor) -> Result<Tensor, TchError> {
+    pub fn linalg_det(a: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_linalg_det(c_tensors.as_mut_ptr(), a.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_det_out(out: &Tensor, a: &Tensor) -> Result<Tensor, TchError> {
+    pub fn linalg_det_out(out: &Tensor, a: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_linalg_det_out(c_tensors.as_mut_ptr(), out.c_tensor, a.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_diagonal(
+    pub fn linalg_diagonal(
         a: &Tensor,
         offset: i64,
         dim1: i64,
@@ -19886,13 +19766,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_eig(&self) -> Result<(Tensor, Tensor), TchError> {
+    pub fn linalg_eig(&self) -> Result<(Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 2];
         unsafe_torch_err!(atg_linalg_eig(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_linalg_eig_out(
+    pub fn linalg_eig_out(
         &self,
         eigenvalues: &Tensor,
         eigenvectors: &Tensor,
@@ -19907,7 +19787,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_linalg_eigh(&self, uplo: &str) -> Result<(Tensor, Tensor), TchError> {
+    pub fn linalg_eigh(&self, uplo: &str) -> Result<(Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 2];
         unsafe_torch_err!(atg_linalg_eigh(
             c_tensors.as_mut_ptr(),
@@ -19918,7 +19798,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_linalg_eigh_eigvals(
+    pub fn linalg_eigh_eigvals(
         &self,
         eigvals: &Tensor,
         eigvecs: &Tensor,
@@ -19936,13 +19816,13 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_linalg_eigvals(&self) -> Result<Tensor, TchError> {
+    pub fn linalg_eigvals(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_linalg_eigvals(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_eigvals_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn linalg_eigvals_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_linalg_eigvals_out(
             c_tensors.as_mut_ptr(),
@@ -19952,7 +19832,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_eigvalsh(&self, uplo: &str) -> Result<Tensor, TchError> {
+    pub fn linalg_eigvalsh(&self, uplo: &str) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_linalg_eigvalsh(
             c_tensors.as_mut_ptr(),
@@ -19963,7 +19843,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_eigvalsh_out(&self, out: &Tensor, uplo: &str) -> Result<Tensor, TchError> {
+    pub fn linalg_eigvalsh_out(&self, out: &Tensor, uplo: &str) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_linalg_eigvalsh_out(
             c_tensors.as_mut_ptr(),
@@ -19975,7 +19855,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_householder_product(&self, tau: &Tensor) -> Result<Tensor, TchError> {
+    pub fn linalg_householder_product(&self, tau: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_linalg_householder_product(
             c_tensors.as_mut_ptr(),
@@ -19985,7 +19865,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_householder_product_out(
+    pub fn linalg_householder_product_out(
         &self,
         out: &Tensor,
         tau: &Tensor,
@@ -20000,13 +19880,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_inv(a: &Tensor) -> Result<Tensor, TchError> {
+    pub fn linalg_inv(a: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_linalg_inv(c_tensors.as_mut_ptr(), a.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_inv_ex(a: &Tensor, check_errors: bool) -> Result<(Tensor, Tensor), TchError> {
+    pub fn linalg_inv_ex(a: &Tensor, check_errors: bool) -> Result<(Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 2];
         unsafe_torch_err!(atg_linalg_inv_ex(
             c_tensors.as_mut_ptr(),
@@ -20016,7 +19896,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_linalg_inv_ex_inverse(
+    pub fn linalg_inv_ex_inverse(
         inverse: &Tensor,
         info: &Tensor,
         a: &Tensor,
@@ -20033,13 +19913,13 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_linalg_inv_out(out: &Tensor, a: &Tensor) -> Result<Tensor, TchError> {
+    pub fn linalg_inv_out(out: &Tensor, a: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_linalg_inv_out(c_tensors.as_mut_ptr(), out.c_tensor, a.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_ldl_factor(&self, hermitian: bool) -> Result<(Tensor, Tensor), TchError> {
+    pub fn linalg_ldl_factor(&self, hermitian: bool) -> Result<(Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 2];
         unsafe_torch_err!(atg_linalg_ldl_factor(
             c_tensors.as_mut_ptr(),
@@ -20049,7 +19929,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_linalg_ldl_factor_ex(
+    pub fn linalg_ldl_factor_ex(
         &self,
         hermitian: bool,
         check_errors: bool,
@@ -20068,7 +19948,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_linalg_ldl_factor_ex_out(
+    pub fn linalg_ldl_factor_ex_out(
         &self,
         ld: &Tensor,
         pivots: &Tensor,
@@ -20093,7 +19973,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_linalg_ldl_factor_out(
+    pub fn linalg_ldl_factor_out(
         &self,
         ld: &Tensor,
         pivots: &Tensor,
@@ -20110,7 +19990,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_linalg_ldl_solve(
+    pub fn linalg_ldl_solve(
         ld: &Tensor,
         pivots: &Tensor,
         b: &Tensor,
@@ -20127,7 +20007,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_ldl_solve_out(
+    pub fn linalg_ldl_solve_out(
         out: &Tensor,
         ld: &Tensor,
         pivots: &Tensor,
@@ -20146,7 +20026,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_lstsq(
+    pub fn linalg_lstsq(
         &self,
         b: &Tensor,
         rcond: impl Into<Option<f64>>,
@@ -20171,7 +20051,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_linalg_lstsq_out(
+    pub fn linalg_lstsq_out(
         &self,
         solution: &Tensor,
         residuals: &Tensor,
@@ -20204,7 +20084,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_linalg_lu(a: &Tensor, pivot: bool) -> Result<(Tensor, Tensor, Tensor), TchError> {
+    pub fn linalg_lu(a: &Tensor, pivot: bool) -> Result<(Tensor, Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 3];
         unsafe_torch_err!(atg_linalg_lu(
             c_tensors.as_mut_ptr(),
@@ -20218,7 +20098,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_linalg_lu_factor(a: &Tensor, pivot: bool) -> Result<(Tensor, Tensor), TchError> {
+    pub fn linalg_lu_factor(a: &Tensor, pivot: bool) -> Result<(Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 2];
         unsafe_torch_err!(atg_linalg_lu_factor(
             c_tensors.as_mut_ptr(),
@@ -20228,7 +20108,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_linalg_lu_factor_ex(
+    pub fn linalg_lu_factor_ex(
         a: &Tensor,
         pivot: bool,
         check_errors: bool,
@@ -20247,7 +20127,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_linalg_lu_factor_ex_out(
+    pub fn linalg_lu_factor_ex_out(
         lu: &Tensor,
         pivots: &Tensor,
         info: &Tensor,
@@ -20272,7 +20152,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_linalg_lu_factor_out(
+    pub fn linalg_lu_factor_out(
         lu: &Tensor,
         pivots: &Tensor,
         a: &Tensor,
@@ -20289,7 +20169,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_linalg_lu_out(
+    pub fn linalg_lu_out(
         p: &Tensor,
         l: &Tensor,
         u: &Tensor,
@@ -20312,7 +20192,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_linalg_lu_solve(
+    pub fn linalg_lu_solve(
         lu: &Tensor,
         pivots: &Tensor,
         b: &Tensor,
@@ -20331,7 +20211,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_lu_solve_out(
+    pub fn linalg_lu_solve_out(
         out: &Tensor,
         lu: &Tensor,
         pivots: &Tensor,
@@ -20352,13 +20232,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_matmul(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn linalg_matmul(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_linalg_matmul(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_matmul_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn linalg_matmul_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_linalg_matmul_out(
             c_tensors.as_mut_ptr(),
@@ -20369,13 +20249,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_matrix_exp(&self) -> Result<Tensor, TchError> {
+    pub fn linalg_matrix_exp(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_linalg_matrix_exp(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_matrix_exp_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn linalg_matrix_exp_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_linalg_matrix_exp_out(
             c_tensors.as_mut_ptr(),
@@ -20385,13 +20265,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_matrix_power(&self, n: i64) -> Result<Tensor, TchError> {
+    pub fn linalg_matrix_power(&self, n: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_linalg_matrix_power(c_tensors.as_mut_ptr(), self.c_tensor, n));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_matrix_power_out(&self, out: &Tensor, n: i64) -> Result<Tensor, TchError> {
+    pub fn linalg_matrix_power_out(&self, out: &Tensor, n: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_linalg_matrix_power_out(
             c_tensors.as_mut_ptr(),
@@ -20402,7 +20282,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_matrix_rank(&self, tol: f64, hermitian: bool) -> Result<Tensor, TchError> {
+    pub fn linalg_matrix_rank(&self, tol: f64, hermitian: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_linalg_matrix_rank(
             c_tensors.as_mut_ptr(),
@@ -20413,7 +20293,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_matrix_rank_atol_rtol_float(
+    pub fn linalg_matrix_rank_atol_rtol_float(
         &self,
         atol: impl Into<Option<f64>>,
         rtol: impl Into<Option<f64>>,
@@ -20434,7 +20314,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_matrix_rank_atol_rtol_float_out(
+    pub fn linalg_matrix_rank_atol_rtol_float_out(
         &self,
         out: &Tensor,
         atol: impl Into<Option<f64>>,
@@ -20457,7 +20337,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_matrix_rank_atol_rtol_tensor<T: Borrow<Tensor>>(
+    pub fn linalg_matrix_rank_atol_rtol_tensor<T: Borrow<Tensor>>(
         &self,
         atol: Option<T>,
         rtol: Option<T>,
@@ -20474,7 +20354,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_matrix_rank_atol_rtol_tensor_out<T: Borrow<Tensor>>(
+    pub fn linalg_matrix_rank_atol_rtol_tensor_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         atol: Option<T>,
@@ -20493,7 +20373,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_matrix_rank_out(
+    pub fn linalg_matrix_rank_out(
         &self,
         out: &Tensor,
         tol: f64,
@@ -20510,7 +20390,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_matrix_rank_out_tol_tensor(
+    pub fn linalg_matrix_rank_out_tol_tensor(
         &self,
         out: &Tensor,
         tol: &Tensor,
@@ -20527,7 +20407,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_matrix_rank_tol_tensor(
+    pub fn linalg_matrix_rank_tol_tensor(
         &self,
         tol: &Tensor,
         hermitian: bool,
@@ -20542,7 +20422,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_multi_dot<T: Borrow<Tensor>>(tensors: &[T]) -> Result<Tensor, TchError> {
+    pub fn linalg_multi_dot<T: Borrow<Tensor>>(tensors: &[T]) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_linalg_multi_dot(
             c_tensors.as_mut_ptr(),
@@ -20552,7 +20432,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_multi_dot_out<T: Borrow<Tensor>>(
+    pub fn linalg_multi_dot_out<T: Borrow<Tensor>>(
         out: &Tensor,
         tensors: &[T],
     ) -> Result<Tensor, TchError> {
@@ -20566,7 +20446,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_norm<S: Into<Scalar>>(
+    pub fn linalg_norm<S: Into<Scalar>>(
         &self,
         ord: S,
         dim: impl IntListOption,
@@ -20586,7 +20466,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_norm_ord_str(
+    pub fn linalg_norm_ord_str(
         &self,
         ord: &str,
         dim: impl IntListOption,
@@ -20607,7 +20487,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_norm_ord_str_out(
+    pub fn linalg_norm_ord_str_out(
         &self,
         out: &Tensor,
         ord: &str,
@@ -20630,7 +20510,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_norm_out<S: Into<Scalar>>(
+    pub fn linalg_norm_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         ord: S,
@@ -20652,7 +20532,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_pinv(&self, rcond: f64, hermitian: bool) -> Result<Tensor, TchError> {
+    pub fn linalg_pinv(&self, rcond: f64, hermitian: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_linalg_pinv(
             c_tensors.as_mut_ptr(),
@@ -20663,7 +20543,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_pinv_atol_rtol_float(
+    pub fn linalg_pinv_atol_rtol_float(
         &self,
         atol: impl Into<Option<f64>>,
         rtol: impl Into<Option<f64>>,
@@ -20684,7 +20564,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_pinv_atol_rtol_float_out(
+    pub fn linalg_pinv_atol_rtol_float_out(
         &self,
         out: &Tensor,
         atol: impl Into<Option<f64>>,
@@ -20707,7 +20587,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_pinv_atol_rtol_tensor<T: Borrow<Tensor>>(
+    pub fn linalg_pinv_atol_rtol_tensor<T: Borrow<Tensor>>(
         &self,
         atol: Option<T>,
         rtol: Option<T>,
@@ -20724,7 +20604,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_pinv_atol_rtol_tensor_out<T: Borrow<Tensor>>(
+    pub fn linalg_pinv_atol_rtol_tensor_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         atol: Option<T>,
@@ -20743,7 +20623,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_pinv_out(
+    pub fn linalg_pinv_out(
         &self,
         out: &Tensor,
         rcond: f64,
@@ -20760,7 +20640,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_pinv_out_rcond_tensor(
+    pub fn linalg_pinv_out_rcond_tensor(
         &self,
         out: &Tensor,
         rcond: &Tensor,
@@ -20777,7 +20657,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_pinv_rcond_tensor(
+    pub fn linalg_pinv_rcond_tensor(
         &self,
         rcond: &Tensor,
         hermitian: bool,
@@ -20792,7 +20672,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_qr(a: &Tensor, mode: &str) -> Result<(Tensor, Tensor), TchError> {
+    pub fn linalg_qr(a: &Tensor, mode: &str) -> Result<(Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 2];
         unsafe_torch_err!(atg_linalg_qr(
             c_tensors.as_mut_ptr(),
@@ -20803,7 +20683,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_linalg_qr_out(
+    pub fn linalg_qr_out(
         q: &Tensor,
         r: &Tensor,
         a: &Tensor,
@@ -20821,13 +20701,13 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_linalg_slogdet(a: &Tensor) -> Result<(Tensor, Tensor), TchError> {
+    pub fn linalg_slogdet(a: &Tensor) -> Result<(Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 2];
         unsafe_torch_err!(atg_linalg_slogdet(c_tensors.as_mut_ptr(), a.c_tensor));
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_linalg_slogdet_out(
+    pub fn linalg_slogdet_out(
         sign: &Tensor,
         logabsdet: &Tensor,
         a: &Tensor,
@@ -20842,7 +20722,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_linalg_solve(a: &Tensor, b: &Tensor, left: bool) -> Result<Tensor, TchError> {
+    pub fn linalg_solve(a: &Tensor, b: &Tensor, left: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_linalg_solve(
             c_tensors.as_mut_ptr(),
@@ -20853,7 +20733,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_solve_ex(
+    pub fn linalg_solve_ex(
         a: &Tensor,
         b: &Tensor,
         left: bool,
@@ -20870,7 +20750,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_linalg_solve_ex_out(
+    pub fn linalg_solve_ex_out(
         result: &Tensor,
         info: &Tensor,
         a: &Tensor,
@@ -20891,7 +20771,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_linalg_solve_out(
+    pub fn linalg_solve_out(
         out: &Tensor,
         a: &Tensor,
         b: &Tensor,
@@ -20908,7 +20788,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_solve_triangular(
+    pub fn linalg_solve_triangular(
         &self,
         b: &Tensor,
         upper: bool,
@@ -20927,7 +20807,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_solve_triangular_out(
+    pub fn linalg_solve_triangular_out(
         &self,
         out: &Tensor,
         b: &Tensor,
@@ -20948,7 +20828,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_svd(
+    pub fn linalg_svd(
         a: &Tensor,
         full_matrices: bool,
         driver: &str,
@@ -20968,7 +20848,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_linalg_svd_u(
+    pub fn linalg_svd_u(
         u: &Tensor,
         s: &Tensor,
         vh: &Tensor,
@@ -20994,7 +20874,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_linalg_svdvals(a: &Tensor, driver: &str) -> Result<Tensor, TchError> {
+    pub fn linalg_svdvals(a: &Tensor, driver: &str) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_linalg_svdvals(
             c_tensors.as_mut_ptr(),
@@ -21005,11 +20885,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_svdvals_out(
-        out: &Tensor,
-        a: &Tensor,
-        driver: &str,
-    ) -> Result<Tensor, TchError> {
+    pub fn linalg_svdvals_out(out: &Tensor, a: &Tensor, driver: &str) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_linalg_svdvals_out(
             c_tensors.as_mut_ptr(),
@@ -21021,13 +20897,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_tensorinv(&self, ind: i64) -> Result<Tensor, TchError> {
+    pub fn linalg_tensorinv(&self, ind: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_linalg_tensorinv(c_tensors.as_mut_ptr(), self.c_tensor, ind));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_tensorinv_out(&self, out: &Tensor, ind: i64) -> Result<Tensor, TchError> {
+    pub fn linalg_tensorinv_out(&self, out: &Tensor, ind: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_linalg_tensorinv_out(
             c_tensors.as_mut_ptr(),
@@ -21038,7 +20914,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_tensorsolve(
+    pub fn linalg_tensorsolve(
         &self,
         other: &Tensor,
         dims: impl IntListOption,
@@ -21054,7 +20930,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_tensorsolve_out(
+    pub fn linalg_tensorsolve_out(
         &self,
         out: &Tensor,
         other: &Tensor,
@@ -21072,7 +20948,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_vander(x: &Tensor, n: impl Into<Option<i64>>) -> Result<Tensor, TchError> {
+    pub fn linalg_vander(x: &Tensor, n: impl Into<Option<i64>>) -> Result<Tensor, TchError> {
         let n = n.into();
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_linalg_vander(
@@ -21084,13 +20960,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_vecdot(x: &Tensor, y: &Tensor, dim: i64) -> Result<Tensor, TchError> {
+    pub fn linalg_vecdot(x: &Tensor, y: &Tensor, dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_linalg_vecdot(c_tensors.as_mut_ptr(), x.c_tensor, y.c_tensor, dim));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linalg_vecdot_out(
+    pub fn linalg_vecdot_out(
         out: &Tensor,
         x: &Tensor,
         y: &Tensor,
@@ -21107,7 +20983,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linear<T: Borrow<Tensor>>(
+    pub fn linear<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -21122,7 +20998,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linear_out<T: Borrow<Tensor>>(
+    pub fn linear_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -21139,7 +21015,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linspace<S: Into<Scalar>>(
+    pub fn linspace<S: Into<Scalar>>(
         start: S,
         end: S,
         steps: i64,
@@ -21157,7 +21033,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_linspace_out<S: Into<Scalar>>(
+    pub fn linspace_out<S: Into<Scalar>>(
         out: &Tensor,
         start: S,
         end: S,
@@ -21174,85 +21050,85 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_log(&self) -> Result<Tensor, TchError> {
+    pub fn log(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_log(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_log10(&self) -> Result<Tensor, TchError> {
+    pub fn log10(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_log10(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_log10_(&mut self) -> Result<Tensor, TchError> {
+    pub fn log10_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_log10_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_log10_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn log10_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_log10_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_log1p(&self) -> Result<Tensor, TchError> {
+    pub fn log1p(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_log1p(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_log1p_(&mut self) -> Result<Tensor, TchError> {
+    pub fn log1p_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_log1p_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_log1p_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn log1p_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_log1p_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_log2(&self) -> Result<Tensor, TchError> {
+    pub fn log2(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_log2(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_log2_(&mut self) -> Result<Tensor, TchError> {
+    pub fn log2_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_log2_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_log2_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn log2_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_log2_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_log_(&mut self) -> Result<Tensor, TchError> {
+    pub fn log_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_log_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_log_normal(&self, mean: f64, std: f64) -> Result<Tensor, TchError> {
+    pub fn log_normal(&self, mean: f64, std: f64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_log_normal(c_tensors.as_mut_ptr(), self.c_tensor, mean, std));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_log_normal_(&mut self, mean: f64, std: f64) -> Result<Tensor, TchError> {
+    pub fn log_normal_(&mut self, mean: f64, std: f64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_log_normal_(c_tensors.as_mut_ptr(), self.c_tensor, mean, std));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_log_normal_out(&self, out: &Tensor, mean: f64, std: f64) -> Result<Tensor, TchError> {
+    pub fn log_normal_out(&self, out: &Tensor, mean: f64, std: f64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_log_normal_out(
             c_tensors.as_mut_ptr(),
@@ -21264,19 +21140,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_log_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn log_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_log_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_log_sigmoid(&self) -> Result<Tensor, TchError> {
+    pub fn log_sigmoid(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_log_sigmoid(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_log_sigmoid_backward(
+    pub fn log_sigmoid_backward(
         &self,
         grad_output: &Tensor,
         buffer: &Tensor,
@@ -21291,7 +21167,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_log_sigmoid_backward_grad_input(
+    pub fn log_sigmoid_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -21308,13 +21184,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_log_sigmoid_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn log_sigmoid_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_log_sigmoid_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_log_softmax(
+    pub fn log_softmax(
         &self,
         dim: i64,
         dtype: impl Into<Option<Kind>>,
@@ -21329,7 +21205,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_log_softmax_int_out(
+    pub fn log_softmax_int_out(
         &self,
         out: &Tensor,
         dim: i64,
@@ -21346,19 +21222,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_logaddexp(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn logaddexp(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_logaddexp(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_logaddexp2(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn logaddexp2(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_logaddexp2(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_logaddexp2_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn logaddexp2_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_logaddexp2_out(
             c_tensors.as_mut_ptr(),
@@ -21369,7 +21245,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_logaddexp_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn logaddexp_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_logaddexp_out(
             c_tensors.as_mut_ptr(),
@@ -21380,13 +21256,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_logcumsumexp(&self, dim: i64) -> Result<Tensor, TchError> {
+    pub fn logcumsumexp(&self, dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_logcumsumexp(c_tensors.as_mut_ptr(), self.c_tensor, dim));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_logcumsumexp_out(&self, out: &Tensor, dim: i64) -> Result<Tensor, TchError> {
+    pub fn logcumsumexp_out(&self, out: &Tensor, dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_logcumsumexp_out(
             c_tensors.as_mut_ptr(),
@@ -21397,25 +21273,25 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_logdet(&self) -> Result<Tensor, TchError> {
+    pub fn logdet(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_logdet(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_logical_and(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn logical_and(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_logical_and(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_logical_and_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn logical_and_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_logical_and_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_logical_and_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn logical_and_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_logical_and_out(
             c_tensors.as_mut_ptr(),
@@ -21426,37 +21302,37 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_logical_not(&self) -> Result<Tensor, TchError> {
+    pub fn logical_not(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_logical_not(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_logical_not_(&mut self) -> Result<Tensor, TchError> {
+    pub fn logical_not_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_logical_not_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_logical_not_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn logical_not_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_logical_not_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_logical_or(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn logical_or(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_logical_or(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_logical_or_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn logical_or_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_logical_or_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_logical_or_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn logical_or_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_logical_or_out(
             c_tensors.as_mut_ptr(),
@@ -21467,19 +21343,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_logical_xor(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn logical_xor(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_logical_xor(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_logical_xor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn logical_xor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_logical_xor_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_logical_xor_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn logical_xor_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_logical_xor_out(
             c_tensors.as_mut_ptr(),
@@ -21490,7 +21366,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_logit(&self, eps: impl Into<Option<f64>>) -> Result<Tensor, TchError> {
+    pub fn logit(&self, eps: impl Into<Option<f64>>) -> Result<Tensor, TchError> {
         let eps = eps.into();
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_logit(
@@ -21502,7 +21378,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_logit_(&mut self, eps: impl Into<Option<f64>>) -> Result<Tensor, TchError> {
+    pub fn logit_(&mut self, eps: impl Into<Option<f64>>) -> Result<Tensor, TchError> {
         let eps = eps.into();
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_logit_(
@@ -21514,7 +21390,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_logit_backward(
+    pub fn logit_backward(
         &self,
         grad_output: &Tensor,
         eps: impl Into<Option<f64>>,
@@ -21531,7 +21407,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_logit_backward_grad_input(
+    pub fn logit_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -21550,11 +21426,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_logit_out(
-        &self,
-        out: &Tensor,
-        eps: impl Into<Option<f64>>,
-    ) -> Result<Tensor, TchError> {
+    pub fn logit_out(&self, out: &Tensor, eps: impl Into<Option<f64>>) -> Result<Tensor, TchError> {
         let eps = eps.into();
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_logit_out(
@@ -21567,7 +21439,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_logspace<S: Into<Scalar>>(
+    pub fn logspace<S: Into<Scalar>>(
         start: S,
         end: S,
         steps: i64,
@@ -21587,7 +21459,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_logspace_out<S: Into<Scalar>>(
+    pub fn logspace_out<S: Into<Scalar>>(
         out: &Tensor,
         start: S,
         end: S,
@@ -21606,7 +21478,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_logsumexp(&self, dim: impl IntList, keepdim: bool) -> Result<Tensor, TchError> {
+    pub fn logsumexp(&self, dim: impl IntList, keepdim: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_logsumexp(
             c_tensors.as_mut_ptr(),
@@ -21618,7 +21490,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_logsumexp_out(
+    pub fn logsumexp_out(
         &self,
         out: &Tensor,
         dim: impl IntList,
@@ -21636,7 +21508,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_lstm<T: Borrow<Tensor>>(
+    pub fn lstm<T: Borrow<Tensor>>(
         &self,
         hx: &[T],
         params: &[T],
@@ -21669,7 +21541,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_lstm_cell<T: Borrow<Tensor>>(
+    pub fn lstm_cell<T: Borrow<Tensor>>(
         &self,
         hx: &[T],
         w_ih: &Tensor,
@@ -21691,7 +21563,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_lstm_data<T: Borrow<Tensor>>(
+    pub fn lstm_data<T: Borrow<Tensor>>(
         data: &Tensor,
         batch_sizes: &Tensor,
         hx: &[T],
@@ -21724,7 +21596,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_lstm_mps_backward<T: Borrow<Tensor>>(
+    pub fn lstm_mps_backward<T: Borrow<Tensor>>(
         &self,
         out0: &Tensor,
         out1: &[T],
@@ -21771,19 +21643,19 @@ impl Tensor {
         Ok(())
     }
 
-    pub fn f_lt<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
+    pub fn lt<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_lt(c_tensors.as_mut_ptr(), self.c_tensor, other.into().c_scalar));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_lt_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn lt_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_lt_(c_tensors.as_mut_ptr(), self.c_tensor, other.into().c_scalar));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_lt_scalar_out<S: Into<Scalar>>(
+    pub fn lt_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
@@ -21798,19 +21670,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_lt_tensor(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn lt_tensor(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_lt_tensor(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_lt_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn lt_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_lt_tensor_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_lt_tensor_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn lt_tensor_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_lt_tensor_out(
             c_tensors.as_mut_ptr(),
@@ -21821,7 +21693,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_lu_solve(&self, lu_data: &Tensor, lu_pivots: &Tensor) -> Result<Tensor, TchError> {
+    pub fn lu_solve(&self, lu_data: &Tensor, lu_pivots: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_lu_solve(
             c_tensors.as_mut_ptr(),
@@ -21832,7 +21704,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_lu_solve_out(
+    pub fn lu_solve_out(
         &self,
         out: &Tensor,
         lu_data: &Tensor,
@@ -21849,7 +21721,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_lu_unpack(
+    pub fn lu_unpack(
         lu_data: &Tensor,
         lu_pivots: &Tensor,
         unpack_data: bool,
@@ -21870,7 +21742,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_lu_unpack_out(
+    pub fn lu_unpack_out(
         p: &Tensor,
         l: &Tensor,
         u: &Tensor,
@@ -21897,7 +21769,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_margin_ranking_loss(
+    pub fn margin_ranking_loss(
         input1: &Tensor,
         input2: &Tensor,
         target: &Tensor,
@@ -21916,7 +21788,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_masked_fill<S: Into<Scalar>>(
+    pub fn masked_fill<S: Into<Scalar>>(
         &self,
         mask: &Tensor,
         value: S,
@@ -21931,7 +21803,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_masked_fill_<S: Into<Scalar>>(
+    pub fn masked_fill_<S: Into<Scalar>>(
         &mut self,
         mask: &Tensor,
         value: S,
@@ -21946,7 +21818,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_masked_fill_scalar_out<S: Into<Scalar>>(
+    pub fn masked_fill_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         mask: &Tensor,
@@ -21963,7 +21835,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_masked_fill_tensor(&self, mask: &Tensor, value: &Tensor) -> Result<Tensor, TchError> {
+    pub fn masked_fill_tensor(&self, mask: &Tensor, value: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_masked_fill_tensor(
             c_tensors.as_mut_ptr(),
@@ -21974,7 +21846,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_masked_fill_tensor_(
+    pub fn masked_fill_tensor_(
         &mut self,
         mask: &Tensor,
         value: &Tensor,
@@ -21989,7 +21861,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_masked_fill_tensor_out(
+    pub fn masked_fill_tensor_out(
         &self,
         out: &Tensor,
         mask: &Tensor,
@@ -22006,7 +21878,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_masked_scatter(&self, mask: &Tensor, source: &Tensor) -> Result<Tensor, TchError> {
+    pub fn masked_scatter(&self, mask: &Tensor, source: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_masked_scatter(
             c_tensors.as_mut_ptr(),
@@ -22017,11 +21889,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_masked_scatter_(
-        &mut self,
-        mask: &Tensor,
-        source: &Tensor,
-    ) -> Result<Tensor, TchError> {
+    pub fn masked_scatter_(&mut self, mask: &Tensor, source: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_masked_scatter_(
             c_tensors.as_mut_ptr(),
@@ -22032,7 +21900,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_masked_scatter_out(
+    pub fn masked_scatter_out(
         &self,
         out: &Tensor,
         mask: &Tensor,
@@ -22049,17 +21917,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_masked_select(&self, mask: &Tensor) -> Result<Tensor, TchError> {
+    pub fn masked_select(&self, mask: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_masked_select(c_tensors.as_mut_ptr(), self.c_tensor, mask.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_masked_select_backward(
-        &self,
-        grad: &Tensor,
-        mask: &Tensor,
-    ) -> Result<Tensor, TchError> {
+    pub fn masked_select_backward(&self, grad: &Tensor, mask: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_masked_select_backward(
             c_tensors.as_mut_ptr(),
@@ -22070,7 +21934,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_masked_select_out(&self, out: &Tensor, mask: &Tensor) -> Result<Tensor, TchError> {
+    pub fn masked_select_out(&self, out: &Tensor, mask: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_masked_select_out(
             c_tensors.as_mut_ptr(),
@@ -22081,13 +21945,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_matmul(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn matmul(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_matmul(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_matmul_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn matmul_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_matmul_out(
             c_tensors.as_mut_ptr(),
@@ -22098,13 +21962,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_matrix_exp(&self) -> Result<Tensor, TchError> {
+    pub fn matrix_exp(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_matrix_exp(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_matrix_exp_backward(&self, grad: &Tensor) -> Result<Tensor, TchError> {
+    pub fn matrix_exp_backward(&self, grad: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_matrix_exp_backward(
             c_tensors.as_mut_ptr(),
@@ -22114,19 +21978,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_matrix_h(&self) -> Result<Tensor, TchError> {
+    pub fn matrix_h(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_matrix_h(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_matrix_power(&self, n: i64) -> Result<Tensor, TchError> {
+    pub fn matrix_power(&self, n: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_matrix_power(c_tensors.as_mut_ptr(), self.c_tensor, n));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_matrix_power_out(&self, out: &Tensor, n: i64) -> Result<Tensor, TchError> {
+    pub fn matrix_power_out(&self, out: &Tensor, n: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_matrix_power_out(
             c_tensors.as_mut_ptr(),
@@ -22137,13 +22001,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_max(&self) -> Result<Tensor, TchError> {
+    pub fn max(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_max(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_max_dim(&self, dim: i64, keepdim: bool) -> Result<(Tensor, Tensor), TchError> {
+    pub fn max_dim(&self, dim: i64, keepdim: bool) -> Result<(Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 2];
         unsafe_torch_err!(atg_max_dim(
             c_tensors.as_mut_ptr(),
@@ -22154,7 +22018,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_max_dim_max(
+    pub fn max_dim_max(
         &self,
         max: &Tensor,
         max_values: &Tensor,
@@ -22173,13 +22037,13 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_max_other(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn max_other(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_max_other(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_max_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn max_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_max_out(
             c_tensors.as_mut_ptr(),
@@ -22190,7 +22054,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_max_pool1d(
+    pub fn max_pool1d(
         &self,
         kernel_size: impl IntList,
         stride: impl IntList,
@@ -22215,7 +22079,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_max_pool1d_with_indices(
+    pub fn max_pool1d_with_indices(
         &self,
         kernel_size: impl IntList,
         stride: impl IntList,
@@ -22240,7 +22104,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_max_pool2d(
+    pub fn max_pool2d(
         &self,
         kernel_size: impl IntList,
         stride: impl IntList,
@@ -22265,7 +22129,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_max_pool2d_backward(
+    pub fn max_pool2d_backward(
         &self,
         grad_output: &Tensor,
         kernel_size: impl IntList,
@@ -22292,7 +22156,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_max_pool2d_backward_out(
+    pub fn max_pool2d_backward_out(
         &self,
         out: &Tensor,
         grad_output: &Tensor,
@@ -22321,7 +22185,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_max_pool2d_with_indices(
+    pub fn max_pool2d_with_indices(
         &self,
         kernel_size: impl IntList,
         stride: impl IntList,
@@ -22346,7 +22210,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_max_pool2d_with_indices_backward(
+    pub fn max_pool2d_with_indices_backward(
         &self,
         grad_output: &Tensor,
         kernel_size: impl IntList,
@@ -22375,7 +22239,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_max_pool2d_with_indices_backward_grad_input(
+    pub fn max_pool2d_with_indices_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -22406,7 +22270,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_max_pool2d_with_indices_out(
+    pub fn max_pool2d_with_indices_out(
         &self,
         out: &Tensor,
         indices: &Tensor,
@@ -22435,7 +22299,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_max_pool3d(
+    pub fn max_pool3d(
         &self,
         kernel_size: impl IntList,
         stride: impl IntList,
@@ -22460,7 +22324,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_max_pool3d_with_indices(
+    pub fn max_pool3d_with_indices(
         &self,
         kernel_size: impl IntList,
         stride: impl IntList,
@@ -22485,7 +22349,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_max_pool3d_with_indices_backward(
+    pub fn max_pool3d_with_indices_backward(
         &self,
         grad_output: &Tensor,
         kernel_size: impl IntList,
@@ -22514,7 +22378,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_max_pool3d_with_indices_backward_grad_input(
+    pub fn max_pool3d_with_indices_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -22545,7 +22409,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_max_pool3d_with_indices_out(
+    pub fn max_pool3d_with_indices_out(
         &self,
         out: &Tensor,
         indices: &Tensor,
@@ -22574,13 +22438,13 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_max_unary_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn max_unary_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_max_unary_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_max_unpool2d(
+    pub fn max_unpool2d(
         &self,
         indices: &Tensor,
         output_size: impl IntList,
@@ -22596,7 +22460,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_max_unpool2d_out(
+    pub fn max_unpool2d_out(
         &self,
         out: &Tensor,
         indices: &Tensor,
@@ -22614,7 +22478,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_max_unpool3d(
+    pub fn max_unpool3d(
         &self,
         indices: &Tensor,
         output_size: impl IntList,
@@ -22636,7 +22500,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_max_unpool3d_out(
+    pub fn max_unpool3d_out(
         &self,
         out: &Tensor,
         indices: &Tensor,
@@ -22660,13 +22524,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_maximum(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn maximum(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_maximum(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_maximum_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn maximum_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_maximum_out(
             c_tensors.as_mut_ptr(),
@@ -22677,7 +22541,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mean(&self, dtype: impl Into<Option<Kind>>) -> Result<Tensor, TchError> {
+    pub fn mean(&self, dtype: impl Into<Option<Kind>>) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_mean(
             c_tensors.as_mut_ptr(),
@@ -22687,7 +22551,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mean_dim(
+    pub fn mean_dim(
         &self,
         dim: impl IntListOption,
         keepdim: bool,
@@ -22705,7 +22569,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mean_out(
+    pub fn mean_out(
         &self,
         out: &Tensor,
         dim: impl IntListOption,
@@ -22725,13 +22589,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_median(&self) -> Result<Tensor, TchError> {
+    pub fn median(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_median(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_median_dim(&self, dim: i64, keepdim: bool) -> Result<(Tensor, Tensor), TchError> {
+    pub fn median_dim(&self, dim: i64, keepdim: bool) -> Result<(Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 2];
         unsafe_torch_err!(atg_median_dim(
             c_tensors.as_mut_ptr(),
@@ -22742,7 +22606,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_median_dim_values(
+    pub fn median_dim_values(
         &self,
         values: &Tensor,
         indices: &Tensor,
@@ -22761,13 +22625,13 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_median_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn median_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_median_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_meshgrid<T: Borrow<Tensor>>(tensors: &[T]) -> Result<Vec<Tensor>, TchError> {
+    pub fn meshgrid<T: Borrow<Tensor>>(tensors: &[T]) -> Result<Vec<Tensor>, TchError> {
         let c_tensors =
             unsafe_torch_err!(atg_meshgrid(ptr_list(tensors).as_ptr(), tensors.len() as i32));
         let mut r__ = vec![];
@@ -22784,7 +22648,7 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_meshgrid_indexing<T: Borrow<Tensor>>(
+    pub fn meshgrid_indexing<T: Borrow<Tensor>>(
         tensors: &[T],
         indexing: &str,
     ) -> Result<Vec<Tensor>, TchError> {
@@ -22808,19 +22672,19 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_mh(&self) -> Result<Tensor, TchError> {
+    pub fn mh(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_mh(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_min(&self) -> Result<Tensor, TchError> {
+    pub fn min(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_min(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_min_dim(&self, dim: i64, keepdim: bool) -> Result<(Tensor, Tensor), TchError> {
+    pub fn min_dim(&self, dim: i64, keepdim: bool) -> Result<(Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 2];
         unsafe_torch_err!(atg_min_dim(
             c_tensors.as_mut_ptr(),
@@ -22831,7 +22695,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_min_dim_min(
+    pub fn min_dim_min(
         &self,
         min: &Tensor,
         min_indices: &Tensor,
@@ -22850,13 +22714,13 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_min_other(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn min_other(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_min_other(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_min_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn min_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_min_out(
             c_tensors.as_mut_ptr(),
@@ -22867,13 +22731,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_minimum(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn minimum(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_minimum(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_minimum_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn minimum_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_minimum_out(
             c_tensors.as_mut_ptr(),
@@ -22884,7 +22748,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_miopen_batch_norm<T: Borrow<Tensor>>(
+    pub fn miopen_batch_norm<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -22913,7 +22777,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_miopen_batch_norm_backward<T: Borrow<Tensor>>(
+    pub fn miopen_batch_norm_backward<T: Borrow<Tensor>>(
         &self,
         grad_output: &Tensor,
         weight: &Tensor,
@@ -22942,7 +22806,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_miopen_batch_norm_backward_out<T: Borrow<Tensor>>(
+    pub fn miopen_batch_norm_backward_out<T: Borrow<Tensor>>(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -22977,7 +22841,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_miopen_batch_norm_out<T: Borrow<Tensor>>(
+    pub fn miopen_batch_norm_out<T: Borrow<Tensor>>(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -23012,7 +22876,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_miopen_convolution<T: Borrow<Tensor>>(
+    pub fn miopen_convolution<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -23042,7 +22906,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_miopen_convolution_add_relu<T: Borrow<Tensor>, S: Into<Scalar>>(
+    pub fn miopen_convolution_add_relu<T: Borrow<Tensor>, S: Into<Scalar>>(
         &self,
         weight: &Tensor,
         z: &Tensor,
@@ -23072,7 +22936,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_miopen_convolution_out<T: Borrow<Tensor>>(
+    pub fn miopen_convolution_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -23104,7 +22968,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_miopen_convolution_relu<T: Borrow<Tensor>>(
+    pub fn miopen_convolution_relu<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -23130,7 +22994,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_miopen_convolution_transpose<T: Borrow<Tensor>>(
+    pub fn miopen_convolution_transpose<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -23163,7 +23027,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_miopen_convolution_transpose_out<T: Borrow<Tensor>>(
+    pub fn miopen_convolution_transpose_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -23198,7 +23062,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_miopen_depthwise_convolution<T: Borrow<Tensor>>(
+    pub fn miopen_depthwise_convolution<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -23228,7 +23092,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_miopen_depthwise_convolution_out<T: Borrow<Tensor>>(
+    pub fn miopen_depthwise_convolution_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -23260,7 +23124,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_miopen_rnn<T: Borrow<Tensor>>(
+    pub fn miopen_rnn<T: Borrow<Tensor>>(
         &self,
         weight: &[T],
         weight_stride0: i64,
@@ -23305,7 +23169,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_miopen_rnn_out<T: Borrow<Tensor>>(
+    pub fn miopen_rnn_out<T: Borrow<Tensor>>(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -23360,19 +23224,19 @@ impl Tensor {
         ))
     }
 
-    pub fn f_mish(&self) -> Result<Tensor, TchError> {
+    pub fn mish(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_mish(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mish_(&mut self) -> Result<Tensor, TchError> {
+    pub fn mish_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_mish_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mish_backward(&self, grad_output: &Tensor) -> Result<Tensor, TchError> {
+    pub fn mish_backward(&self, grad_output: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_mish_backward(
             c_tensors.as_mut_ptr(),
@@ -23382,13 +23246,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mish_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn mish_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_mish_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mkldnn_adaptive_avg_pool2d(
+    pub fn mkldnn_adaptive_avg_pool2d(
         &self,
         output_size: impl IntList,
     ) -> Result<Tensor, TchError> {
@@ -23402,7 +23266,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mkldnn_adaptive_avg_pool2d_backward(
+    pub fn mkldnn_adaptive_avg_pool2d_backward(
         &self,
         grad_output: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -23415,7 +23279,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mkldnn_adaptive_avg_pool2d_backward_out(
+    pub fn mkldnn_adaptive_avg_pool2d_backward_out(
         &self,
         out: &Tensor,
         grad_output: &Tensor,
@@ -23430,7 +23294,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mkldnn_adaptive_avg_pool2d_out(
+    pub fn mkldnn_adaptive_avg_pool2d_out(
         &self,
         out: &Tensor,
         output_size: impl IntList,
@@ -23446,7 +23310,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mkldnn_convolution<T: Borrow<Tensor>>(
+    pub fn mkldnn_convolution<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -23472,7 +23336,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mkldnn_convolution_out<T: Borrow<Tensor>>(
+    pub fn mkldnn_convolution_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -23500,7 +23364,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mkldnn_linear<T: Borrow<Tensor>>(
+    pub fn mkldnn_linear<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -23515,7 +23379,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mkldnn_linear_backward_input(
+    pub fn mkldnn_linear_backward_input(
         input_size: impl IntList,
         grad_output: &Tensor,
         weight: &Tensor,
@@ -23531,7 +23395,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mkldnn_linear_backward_input_out(
+    pub fn mkldnn_linear_backward_input_out(
         out: &Tensor,
         input_size: impl IntList,
         grad_output: &Tensor,
@@ -23549,7 +23413,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mkldnn_linear_backward_weights(
+    pub fn mkldnn_linear_backward_weights(
         &self,
         grad_output: &Tensor,
         weight: &Tensor,
@@ -23566,7 +23430,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_mkldnn_linear_backward_weights_out(
+    pub fn mkldnn_linear_backward_weights_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -23587,7 +23451,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_mkldnn_linear_out<T: Borrow<Tensor>>(
+    pub fn mkldnn_linear_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -23604,7 +23468,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mkldnn_max_pool2d(
+    pub fn mkldnn_max_pool2d(
         &self,
         kernel_size: impl IntList,
         stride: impl IntList,
@@ -23629,7 +23493,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mkldnn_max_pool2d_backward(
+    pub fn mkldnn_max_pool2d_backward(
         &self,
         grad_output: &Tensor,
         output: &Tensor,
@@ -23658,7 +23522,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mkldnn_max_pool2d_backward_out(
+    pub fn mkldnn_max_pool2d_backward_out(
         &self,
         out: &Tensor,
         grad_output: &Tensor,
@@ -23689,7 +23553,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mkldnn_max_pool2d_out(
+    pub fn mkldnn_max_pool2d_out(
         &self,
         out: &Tensor,
         kernel_size: impl IntList,
@@ -23716,7 +23580,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mkldnn_max_pool3d(
+    pub fn mkldnn_max_pool3d(
         &self,
         kernel_size: impl IntList,
         stride: impl IntList,
@@ -23741,7 +23605,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mkldnn_max_pool3d_backward(
+    pub fn mkldnn_max_pool3d_backward(
         &self,
         grad_output: &Tensor,
         output: &Tensor,
@@ -23770,7 +23634,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mkldnn_max_pool3d_backward_out(
+    pub fn mkldnn_max_pool3d_backward_out(
         &self,
         out: &Tensor,
         grad_output: &Tensor,
@@ -23801,7 +23665,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mkldnn_max_pool3d_out(
+    pub fn mkldnn_max_pool3d_out(
         &self,
         out: &Tensor,
         kernel_size: impl IntList,
@@ -23828,7 +23692,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mkldnn_reorder_conv2d_weight(
+    pub fn mkldnn_reorder_conv2d_weight(
         &self,
         padding: impl IntList,
         stride: impl IntList,
@@ -23853,7 +23717,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mkldnn_reorder_conv2d_weight_out(
+    pub fn mkldnn_reorder_conv2d_weight_out(
         &self,
         out: &Tensor,
         padding: impl IntList,
@@ -23880,7 +23744,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mkldnn_reorder_conv3d_weight(
+    pub fn mkldnn_reorder_conv3d_weight(
         &self,
         padding: impl IntList,
         stride: impl IntList,
@@ -23902,7 +23766,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mkldnn_reorder_conv3d_weight_out(
+    pub fn mkldnn_reorder_conv3d_weight_out(
         &self,
         out: &Tensor,
         padding: impl IntList,
@@ -23926,7 +23790,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mkldnn_rnn_layer(
+    pub fn mkldnn_rnn_layer(
         &self,
         weight0: &Tensor,
         weight1: &Tensor,
@@ -23973,7 +23837,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_mkldnn_rnn_layer_backward<T: Borrow<Tensor>>(
+    pub fn mkldnn_rnn_layer_backward<T: Borrow<Tensor>>(
         &self,
         weight1: &Tensor,
         weight2: &Tensor,
@@ -24037,7 +23901,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_mkldnn_rnn_layer_backward_out<T: Borrow<Tensor>>(
+    pub fn mkldnn_rnn_layer_backward_out<T: Borrow<Tensor>>(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -24115,7 +23979,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_mkldnn_rnn_layer_out(
+    pub fn mkldnn_rnn_layer_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -24170,13 +24034,13 @@ impl Tensor {
         ))
     }
 
-    pub fn f_mm(&self, mat2: &Tensor) -> Result<Tensor, TchError> {
+    pub fn mm(&self, mat2: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_mm(c_tensors.as_mut_ptr(), self.c_tensor, mat2.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mm_out(&self, out: &Tensor, mat2: &Tensor) -> Result<Tensor, TchError> {
+    pub fn mm_out(&self, out: &Tensor, mat2: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_mm_out(
             c_tensors.as_mut_ptr(),
@@ -24187,7 +24051,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mode(&self, dim: i64, keepdim: bool) -> Result<(Tensor, Tensor), TchError> {
+    pub fn mode(&self, dim: i64, keepdim: bool) -> Result<(Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 2];
         unsafe_torch_err!(atg_mode(
             c_tensors.as_mut_ptr(),
@@ -24198,7 +24062,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_mode_values(
+    pub fn mode_values(
         &self,
         values: &Tensor,
         indices: &Tensor,
@@ -24217,7 +24081,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_moveaxis(
+    pub fn moveaxis(
         &self,
         source: impl IntList,
         destination: impl IntList,
@@ -24234,7 +24098,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_moveaxis_int(&self, source: i64, destination: i64) -> Result<Tensor, TchError> {
+    pub fn moveaxis_int(&self, source: i64, destination: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_moveaxis_int(
             c_tensors.as_mut_ptr(),
@@ -24245,7 +24109,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_movedim(
+    pub fn movedim(
         &self,
         source: impl IntList,
         destination: impl IntList,
@@ -24262,7 +24126,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_movedim_int(&self, source: i64, destination: i64) -> Result<Tensor, TchError> {
+    pub fn movedim_int(&self, source: i64, destination: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_movedim_int(
             c_tensors.as_mut_ptr(),
@@ -24273,7 +24137,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mse_loss(
+    pub fn mse_loss(
         &self,
         target: &Tensor,
         reduction: crate::Reduction,
@@ -24288,7 +24152,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mse_loss_backward(
+    pub fn mse_loss_backward(
         &self,
         grad_output: &Tensor,
         target: &Tensor,
@@ -24305,7 +24169,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mse_loss_backward_grad_input(
+    pub fn mse_loss_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -24324,7 +24188,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mse_loss_out(
+    pub fn mse_loss_out(
         &self,
         out: &Tensor,
         target: &Tensor,
@@ -24341,37 +24205,37 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_msort(&self) -> Result<Tensor, TchError> {
+    pub fn msort(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_msort(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_msort_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn msort_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_msort_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mt(&self) -> Result<Tensor, TchError> {
+    pub fn mt(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_mt(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mul(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn g_mul(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_mul(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mul_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn g_mul_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_mul_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mul_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn mul_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_mul_out(
             c_tensors.as_mut_ptr(),
@@ -24382,7 +24246,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mul_scalar<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
+    pub fn g_mul_scalar<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_mul_scalar(
             c_tensors.as_mut_ptr(),
@@ -24392,7 +24256,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mul_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn g_mul_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_mul_scalar_(
             c_tensors.as_mut_ptr(),
@@ -24402,7 +24266,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mul_scalar_out<S: Into<Scalar>>(
+    pub fn mul_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
@@ -24417,7 +24281,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_multi_margin_loss_backward<T: Borrow<Tensor>, S: Into<Scalar>>(
+    pub fn multi_margin_loss_backward<T: Borrow<Tensor>, S: Into<Scalar>>(
         &self,
         grad_output: &Tensor,
         target: &Tensor,
@@ -24440,7 +24304,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_multi_margin_loss_backward_grad_input<T: Borrow<Tensor>, S: Into<Scalar>>(
+    pub fn multi_margin_loss_backward_grad_input<T: Borrow<Tensor>, S: Into<Scalar>>(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -24465,7 +24329,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_multilabel_margin_loss(
+    pub fn multilabel_margin_loss(
         &self,
         target: &Tensor,
         reduction: crate::Reduction,
@@ -24480,7 +24344,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_multilabel_margin_loss_backward(
+    pub fn multilabel_margin_loss_backward(
         &self,
         grad_output: &Tensor,
         target: &Tensor,
@@ -24499,7 +24363,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_multilabel_margin_loss_backward_grad_input(
+    pub fn multilabel_margin_loss_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -24520,7 +24384,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_multilabel_margin_loss_out(
+    pub fn multilabel_margin_loss_out(
         &self,
         out: &Tensor,
         target: &Tensor,
@@ -24537,7 +24401,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_multinomial(&self, num_samples: i64, replacement: bool) -> Result<Tensor, TchError> {
+    pub fn multinomial(&self, num_samples: i64, replacement: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_multinomial(
             c_tensors.as_mut_ptr(),
@@ -24548,7 +24412,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_multinomial_out(
+    pub fn multinomial_out(
         &self,
         out: &Tensor,
         num_samples: i64,
@@ -24565,19 +24429,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_multiply(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn multiply(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_multiply(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_multiply_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn multiply_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_multiply_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_multiply_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn multiply_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_multiply_out(
             c_tensors.as_mut_ptr(),
@@ -24588,7 +24452,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_multiply_scalar<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
+    pub fn multiply_scalar<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_multiply_scalar(
             c_tensors.as_mut_ptr(),
@@ -24598,7 +24462,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_multiply_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn multiply_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_multiply_scalar_(
             c_tensors.as_mut_ptr(),
@@ -24608,13 +24472,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mv(&self, vec: &Tensor) -> Result<Tensor, TchError> {
+    pub fn mv(&self, vec: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_mv(c_tensors.as_mut_ptr(), self.c_tensor, vec.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mv_out(&self, out: &Tensor, vec: &Tensor) -> Result<Tensor, TchError> {
+    pub fn mv_out(&self, out: &Tensor, vec: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_mv_out(
             c_tensors.as_mut_ptr(),
@@ -24625,25 +24489,25 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mvlgamma(&self, p: i64) -> Result<Tensor, TchError> {
+    pub fn mvlgamma(&self, p: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_mvlgamma(c_tensors.as_mut_ptr(), self.c_tensor, p));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mvlgamma_(&mut self, p: i64) -> Result<Tensor, TchError> {
+    pub fn mvlgamma_(&mut self, p: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_mvlgamma_(c_tensors.as_mut_ptr(), self.c_tensor, p));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_mvlgamma_out(&self, out: &Tensor, p: i64) -> Result<Tensor, TchError> {
+    pub fn mvlgamma_out(&self, out: &Tensor, p: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_mvlgamma_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor, p));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_nan_to_num(
+    pub fn nan_to_num(
         &self,
         nan: impl Into<Option<f64>>,
         posinf: impl Into<Option<f64>>,
@@ -24666,7 +24530,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_nan_to_num_(
+    pub fn nan_to_num_(
         &mut self,
         nan: impl Into<Option<f64>>,
         posinf: impl Into<Option<f64>>,
@@ -24689,7 +24553,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_nan_to_num_out(
+    pub fn nan_to_num_out(
         &self,
         out: &Tensor,
         nan: impl Into<Option<f64>>,
@@ -24714,7 +24578,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_nanmean(
+    pub fn nanmean(
         &self,
         dim: impl IntListOption,
         keepdim: bool,
@@ -24732,7 +24596,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_nanmean_out(
+    pub fn nanmean_out(
         &self,
         out: &Tensor,
         dim: impl IntListOption,
@@ -24752,13 +24616,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_nanmedian(&self) -> Result<Tensor, TchError> {
+    pub fn nanmedian(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_nanmedian(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_nanmedian_dim(&self, dim: i64, keepdim: bool) -> Result<(Tensor, Tensor), TchError> {
+    pub fn nanmedian_dim(&self, dim: i64, keepdim: bool) -> Result<(Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 2];
         unsafe_torch_err!(atg_nanmedian_dim(
             c_tensors.as_mut_ptr(),
@@ -24769,7 +24633,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_nanmedian_dim_values(
+    pub fn nanmedian_dim_values(
         &self,
         values: &Tensor,
         indices: &Tensor,
@@ -24788,13 +24652,13 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_nanmedian_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn nanmedian_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_nanmedian_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_nanquantile(
+    pub fn nanquantile(
         &self,
         q: &Tensor,
         dim: impl Into<Option<i64>>,
@@ -24816,7 +24680,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_nanquantile_out(
+    pub fn nanquantile_out(
         &self,
         out: &Tensor,
         q: &Tensor,
@@ -24840,7 +24704,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_nanquantile_scalar(
+    pub fn nanquantile_scalar(
         &self,
         q: f64,
         dim: impl Into<Option<i64>>,
@@ -24862,7 +24726,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_nanquantile_scalar_out(
+    pub fn nanquantile_scalar_out(
         &self,
         out: &Tensor,
         q: f64,
@@ -24886,7 +24750,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_nansum(
+    pub fn nansum(
         &self,
         dim: impl IntListOption,
         keepdim: bool,
@@ -24904,7 +24768,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_nansum_out(
+    pub fn nansum_out(
         &self,
         out: &Tensor,
         dim: impl IntListOption,
@@ -24924,13 +24788,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_narrow(&self, dim: i64, start: i64, length: i64) -> Result<Tensor, TchError> {
+    pub fn narrow(&self, dim: i64, start: i64, length: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_narrow(c_tensors.as_mut_ptr(), self.c_tensor, dim, start, length));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_narrow_copy(&self, dim: i64, start: i64, length: i64) -> Result<Tensor, TchError> {
+    pub fn narrow_copy(&self, dim: i64, start: i64, length: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_narrow_copy(
             c_tensors.as_mut_ptr(),
@@ -24942,7 +24806,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_narrow_copy_out(
+    pub fn narrow_copy_out(
         &self,
         out: &Tensor,
         dim: i64,
@@ -24961,12 +24825,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_narrow_tensor(
-        &self,
-        dim: i64,
-        start: &Tensor,
-        length: i64,
-    ) -> Result<Tensor, TchError> {
+    pub fn narrow_tensor(&self, dim: i64, start: &Tensor, length: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_narrow_tensor(
             c_tensors.as_mut_ptr(),
@@ -24978,7 +24837,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_native_batch_norm<T: Borrow<Tensor>>(
+    pub fn native_batch_norm<T: Borrow<Tensor>>(
         &self,
         weight: Option<T>,
         bias: Option<T>,
@@ -25007,7 +24866,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_native_batch_norm_out<T: Borrow<Tensor>>(
+    pub fn native_batch_norm_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         save_mean: &Tensor,
@@ -25042,7 +24901,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_native_channel_shuffle(&self, groups: i64) -> Result<Tensor, TchError> {
+    pub fn native_channel_shuffle(&self, groups: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_native_channel_shuffle(
             c_tensors.as_mut_ptr(),
@@ -25052,7 +24911,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_native_dropout(&self, p: f64, train: bool) -> Result<(Tensor, Tensor), TchError> {
+    pub fn native_dropout(&self, p: f64, train: bool) -> Result<(Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 2];
         unsafe_torch_err!(atg_native_dropout(
             c_tensors.as_mut_ptr(),
@@ -25063,7 +24922,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_native_dropout_backward(
+    pub fn native_dropout_backward(
         grad_output: &Tensor,
         mask: &Tensor,
         scale: f64,
@@ -25078,7 +24937,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_native_dropout_backward_out(
+    pub fn native_dropout_backward_out(
         out: &Tensor,
         grad_output: &Tensor,
         mask: &Tensor,
@@ -25095,7 +24954,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_native_dropout_out(
+    pub fn native_dropout_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -25114,7 +24973,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_native_group_norm<T: Borrow<Tensor>>(
+    pub fn native_group_norm<T: Borrow<Tensor>>(
         &self,
         weight: Option<T>,
         bias: Option<T>,
@@ -25143,7 +25002,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_native_group_norm_out<T: Borrow<Tensor>>(
+    pub fn native_group_norm_out<T: Borrow<Tensor>>(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -25178,7 +25037,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_native_layer_norm<T: Borrow<Tensor>>(
+    pub fn native_layer_norm<T: Borrow<Tensor>>(
         &self,
         normalized_shape: impl IntList,
         weight: Option<T>,
@@ -25202,7 +25061,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_native_layer_norm_out<T: Borrow<Tensor>>(
+    pub fn native_layer_norm_out<T: Borrow<Tensor>>(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -25232,19 +25091,19 @@ impl Tensor {
         ))
     }
 
-    pub fn f_native_norm(&self) -> Result<Tensor, TchError> {
+    pub fn native_norm(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_native_norm(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_native_norm_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn native_norm_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_native_norm_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_native_norm_scalaropt_dim_dtype<S: Into<Scalar>>(
+    pub fn native_norm_scalaropt_dim_dtype<S: Into<Scalar>>(
         &self,
         p: S,
         dim: impl IntList,
@@ -25264,7 +25123,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_native_norm_scalaropt_dim_dtype_out<S: Into<Scalar>>(
+    pub fn native_norm_scalaropt_dim_dtype_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         p: S,
@@ -25286,19 +25145,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_ne<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
+    pub fn ne<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_ne(c_tensors.as_mut_ptr(), self.c_tensor, other.into().c_scalar));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_ne_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn ne_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_ne_(c_tensors.as_mut_ptr(), self.c_tensor, other.into().c_scalar));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_ne_scalar_out<S: Into<Scalar>>(
+    pub fn ne_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
@@ -25313,19 +25172,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_ne_tensor(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn ne_tensor(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_ne_tensor(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_ne_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn ne_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_ne_tensor_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_ne_tensor_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn ne_tensor_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_ne_tensor_out(
             c_tensors.as_mut_ptr(),
@@ -25336,43 +25195,43 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_neg(&self) -> Result<Tensor, TchError> {
+    pub fn neg(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_neg(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_neg_(&mut self) -> Result<Tensor, TchError> {
+    pub fn neg_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_neg_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_neg_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn neg_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_neg_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_negative(&self) -> Result<Tensor, TchError> {
+    pub fn negative(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_negative(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_negative_(&mut self) -> Result<Tensor, TchError> {
+    pub fn negative_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_negative_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_negative_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn negative_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_negative_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_nested_to_padded_tensor(
+    pub fn nested_to_padded_tensor(
         &self,
         padding: f64,
         output_size: impl IntListOption,
@@ -25388,7 +25247,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_new_empty(
+    pub fn new_empty(
         &self,
         size: impl IntList,
         options: (Kind, Device),
@@ -25405,7 +25264,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_new_empty_out(&self, out: &Tensor, size: impl IntList) -> Result<Tensor, TchError> {
+    pub fn new_empty_out(&self, out: &Tensor, size: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_new_empty_out(
             c_tensors.as_mut_ptr(),
@@ -25417,7 +25276,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_new_empty_strided(
+    pub fn new_empty_strided(
         &self,
         size: impl IntList,
         stride: impl IntList,
@@ -25437,7 +25296,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_new_empty_strided_out(
+    pub fn new_empty_strided_out(
         &self,
         out: &Tensor,
         size: impl IntList,
@@ -25456,7 +25315,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_new_full<S: Into<Scalar>>(
+    pub fn new_full<S: Into<Scalar>>(
         &self,
         size: impl IntList,
         fill_value: S,
@@ -25475,7 +25334,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_new_full_out<S: Into<Scalar>>(
+    pub fn new_full_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         size: impl IntList,
@@ -25493,7 +25352,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_new_ones(
+    pub fn new_ones(
         &self,
         size: impl IntList,
         options: (Kind, Device),
@@ -25510,7 +25369,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_new_ones_out(&self, out: &Tensor, size: impl IntList) -> Result<Tensor, TchError> {
+    pub fn new_ones_out(&self, out: &Tensor, size: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_new_ones_out(
             c_tensors.as_mut_ptr(),
@@ -25522,7 +25381,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_new_zeros(
+    pub fn new_zeros(
         &self,
         size: impl IntList,
         options: (Kind, Device),
@@ -25539,7 +25398,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_new_zeros_out(&self, out: &Tensor, size: impl IntList) -> Result<Tensor, TchError> {
+    pub fn new_zeros_out(&self, out: &Tensor, size: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_new_zeros_out(
             c_tensors.as_mut_ptr(),
@@ -25551,19 +25410,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_nextafter(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn nextafter(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_nextafter(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_nextafter_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn nextafter_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_nextafter_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_nextafter_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn nextafter_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_nextafter_out(
             c_tensors.as_mut_ptr(),
@@ -25574,7 +25433,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_nll_loss<T: Borrow<Tensor>>(
+    pub fn g_nll_loss<T: Borrow<Tensor>>(
         &self,
         target: &Tensor,
         weight: Option<T>,
@@ -25593,7 +25452,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_nll_loss2d<T: Borrow<Tensor>>(
+    pub fn nll_loss2d<T: Borrow<Tensor>>(
         &self,
         target: &Tensor,
         weight: Option<T>,
@@ -25612,7 +25471,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_nll_loss2d_backward<T: Borrow<Tensor>>(
+    pub fn nll_loss2d_backward<T: Borrow<Tensor>>(
         &self,
         grad_output: &Tensor,
         target: &Tensor,
@@ -25635,7 +25494,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_nll_loss2d_backward_grad_input<T: Borrow<Tensor>>(
+    pub fn nll_loss2d_backward_grad_input<T: Borrow<Tensor>>(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -25660,7 +25519,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_nll_loss2d_out<T: Borrow<Tensor>>(
+    pub fn nll_loss2d_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         target: &Tensor,
@@ -25681,7 +25540,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_nll_loss_backward<T: Borrow<Tensor>>(
+    pub fn nll_loss_backward<T: Borrow<Tensor>>(
         &self,
         grad_output: &Tensor,
         target: &Tensor,
@@ -25704,7 +25563,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_nll_loss_backward_grad_input<T: Borrow<Tensor>>(
+    pub fn nll_loss_backward_grad_input<T: Borrow<Tensor>>(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -25729,7 +25588,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_nll_loss_nd<T: Borrow<Tensor>>(
+    pub fn nll_loss_nd<T: Borrow<Tensor>>(
         &self,
         target: &Tensor,
         weight: Option<T>,
@@ -25748,7 +25607,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_nll_loss_out<T: Borrow<Tensor>>(
+    pub fn nll_loss_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         target: &Tensor,
@@ -25769,13 +25628,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_nonzero(&self) -> Result<Tensor, TchError> {
+    pub fn nonzero(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_nonzero(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_nonzero_numpy(&self) -> Result<Vec<Tensor>, TchError> {
+    pub fn nonzero_numpy(&self) -> Result<Vec<Tensor>, TchError> {
         let c_tensors = unsafe_torch_err!(atg_nonzero_numpy(self.c_tensor));
         let mut r__ = vec![];
         let mut i = 0;
@@ -25791,19 +25650,19 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_nonzero_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn nonzero_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_nonzero_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_norm(&self) -> Result<Tensor, TchError> {
+    pub fn norm(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_norm(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_norm_dtype_out<S: Into<Scalar>>(
+    pub fn norm_dtype_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         p: S,
@@ -25825,13 +25684,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_norm_except_dim(v: &Tensor, pow: i64, dim: i64) -> Result<Tensor, TchError> {
+    pub fn norm_except_dim(v: &Tensor, pow: i64, dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_norm_except_dim(c_tensors.as_mut_ptr(), v.c_tensor, pow, dim));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_norm_out<S: Into<Scalar>>(
+    pub fn norm_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         p: S,
@@ -25851,13 +25710,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_norm_scalar_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn norm_scalar_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_norm_scalar_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_norm_scalaropt_dim<S: Into<Scalar>>(
+    pub fn norm_scalaropt_dim<S: Into<Scalar>>(
         &self,
         p: S,
         dim: impl IntList,
@@ -25875,7 +25734,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_norm_scalaropt_dim_dtype<S: Into<Scalar>>(
+    pub fn norm_scalaropt_dim_dtype<S: Into<Scalar>>(
         &self,
         p: S,
         dim: impl IntList,
@@ -25895,7 +25754,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_norm_scalaropt_dtype<S: Into<Scalar>>(
+    pub fn norm_scalaropt_dtype<S: Into<Scalar>>(
         &self,
         p: S,
         dtype: Kind,
@@ -25910,7 +25769,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_norm_scalaropt_dtype_out<S: Into<Scalar>>(
+    pub fn norm_scalaropt_dtype_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         p: S,
@@ -25927,19 +25786,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_normal_(&mut self, mean: f64, std: f64) -> Result<Tensor, TchError> {
+    pub fn normal_(&mut self, mean: f64, std: f64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_normal_(c_tensors.as_mut_ptr(), self.c_tensor, mean, std));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_normal_functional(&self, mean: f64, std: f64) -> Result<Tensor, TchError> {
+    pub fn normal_functional(&self, mean: f64, std: f64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_normal_functional(c_tensors.as_mut_ptr(), self.c_tensor, mean, std));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_not_equal<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
+    pub fn not_equal<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_not_equal(
             c_tensors.as_mut_ptr(),
@@ -25949,7 +25808,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_not_equal_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn not_equal_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_not_equal_(
             c_tensors.as_mut_ptr(),
@@ -25959,7 +25818,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_not_equal_scalar_out<S: Into<Scalar>>(
+    pub fn not_equal_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
@@ -25974,7 +25833,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_not_equal_tensor(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn not_equal_tensor(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_not_equal_tensor(
             c_tensors.as_mut_ptr(),
@@ -25984,7 +25843,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_not_equal_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn not_equal_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_not_equal_tensor_(
             c_tensors.as_mut_ptr(),
@@ -25994,7 +25853,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_not_equal_tensor_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn not_equal_tensor_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_not_equal_tensor_out(
             c_tensors.as_mut_ptr(),
@@ -26005,7 +25864,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_nuclear_norm(&self, keepdim: bool) -> Result<Tensor, TchError> {
+    pub fn nuclear_norm(&self, keepdim: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_nuclear_norm(
             c_tensors.as_mut_ptr(),
@@ -26015,7 +25874,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_nuclear_norm_dim(&self, dim: impl IntList, keepdim: bool) -> Result<Tensor, TchError> {
+    pub fn nuclear_norm_dim(&self, dim: impl IntList, keepdim: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_nuclear_norm_dim(
             c_tensors.as_mut_ptr(),
@@ -26027,7 +25886,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_nuclear_norm_dim_out(
+    pub fn nuclear_norm_dim_out(
         &self,
         out: &Tensor,
         dim: impl IntList,
@@ -26045,7 +25904,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_nuclear_norm_out(&self, out: &Tensor, keepdim: bool) -> Result<Tensor, TchError> {
+    pub fn nuclear_norm_out(&self, out: &Tensor, keepdim: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_nuclear_norm_out(
             c_tensors.as_mut_ptr(),
@@ -26056,19 +25915,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_numpy_t(&self) -> Result<Tensor, TchError> {
+    pub fn numpy_t(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_numpy_t(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_one_hot(&self, num_classes: i64) -> Result<Tensor, TchError> {
+    pub fn one_hot(&self, num_classes: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_one_hot(c_tensors.as_mut_ptr(), self.c_tensor, num_classes));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_ones(size: impl IntList, options: (Kind, Device)) -> Result<Tensor, TchError> {
+    pub fn ones(size: impl IntList, options: (Kind, Device)) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_ones(
             c_tensors.as_mut_ptr(),
@@ -26080,19 +25939,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_ones_like(&self) -> Result<Tensor, TchError> {
+    pub fn ones_like(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_ones_like(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_ones_like_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn ones_like_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_ones_like_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_ones_out(out: &Tensor, size: impl IntList) -> Result<Tensor, TchError> {
+    pub fn ones_out(out: &Tensor, size: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_ones_out(
             c_tensors.as_mut_ptr(),
@@ -26103,13 +25962,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_orgqr(&self, input2: &Tensor) -> Result<Tensor, TchError> {
+    pub fn orgqr(&self, input2: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_orgqr(c_tensors.as_mut_ptr(), self.c_tensor, input2.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_orgqr_out(&self, out: &Tensor, input2: &Tensor) -> Result<Tensor, TchError> {
+    pub fn orgqr_out(&self, out: &Tensor, input2: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_orgqr_out(
             c_tensors.as_mut_ptr(),
@@ -26120,7 +25979,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_ormqr(
+    pub fn ormqr(
         &self,
         input2: &Tensor,
         input3: &Tensor,
@@ -26139,7 +25998,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_ormqr_out(
+    pub fn ormqr_out(
         &self,
         out: &Tensor,
         input2: &Tensor,
@@ -26160,13 +26019,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_outer(&self, vec2: &Tensor) -> Result<Tensor, TchError> {
+    pub fn outer(&self, vec2: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_outer(c_tensors.as_mut_ptr(), self.c_tensor, vec2.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_outer_out(&self, out: &Tensor, vec2: &Tensor) -> Result<Tensor, TchError> {
+    pub fn outer_out(&self, out: &Tensor, vec2: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_outer_out(
             c_tensors.as_mut_ptr(),
@@ -26177,13 +26036,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_output_nr(&self) -> Result<i64, TchError> {
+    pub fn output_nr(&self) -> Result<i64, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg_output_nr(self.c_tensor));
         Ok(return_)
     }
 
-    pub fn f_pad(
+    pub fn pad(
         &self,
         pad: impl IntList,
         mode: &str,
@@ -26204,7 +26063,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_pad_sequence<T: Borrow<Tensor>>(
+    pub fn pad_sequence<T: Borrow<Tensor>>(
         sequences: &[T],
         batch_first: bool,
         padding_value: f64,
@@ -26220,7 +26079,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_pairwise_distance(
+    pub fn pairwise_distance(
         x1: &Tensor,
         x2: &Tensor,
         p: f64,
@@ -26239,13 +26098,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_pdist(&self, p: f64) -> Result<Tensor, TchError> {
+    pub fn pdist(&self, p: f64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_pdist(c_tensors.as_mut_ptr(), self.c_tensor, p));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_permute(&self, dims: impl IntList) -> Result<Tensor, TchError> {
+    pub fn permute(&self, dims: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_permute(
             c_tensors.as_mut_ptr(),
@@ -26256,7 +26115,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_permute_copy(&self, dims: impl IntList) -> Result<Tensor, TchError> {
+    pub fn permute_copy(&self, dims: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_permute_copy(
             c_tensors.as_mut_ptr(),
@@ -26267,7 +26126,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_permute_copy_out(&self, out: &Tensor, dims: impl IntList) -> Result<Tensor, TchError> {
+    pub fn permute_copy_out(&self, out: &Tensor, dims: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_permute_copy_out(
             c_tensors.as_mut_ptr(),
@@ -26279,29 +26138,25 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_pin_memory(&self, device: Device) -> Result<Tensor, TchError> {
+    pub fn pin_memory(&self, device: Device) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_pin_memory(c_tensors.as_mut_ptr(), self.c_tensor, device.c_int()));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_pinverse(&self, rcond: f64) -> Result<Tensor, TchError> {
+    pub fn pinverse(&self, rcond: f64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_pinverse(c_tensors.as_mut_ptr(), self.c_tensor, rcond));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_pixel_shuffle(&self, upscale_factor: i64) -> Result<Tensor, TchError> {
+    pub fn pixel_shuffle(&self, upscale_factor: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_pixel_shuffle(c_tensors.as_mut_ptr(), self.c_tensor, upscale_factor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_pixel_shuffle_out(
-        &self,
-        out: &Tensor,
-        upscale_factor: i64,
-    ) -> Result<Tensor, TchError> {
+    pub fn pixel_shuffle_out(&self, out: &Tensor, upscale_factor: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_pixel_shuffle_out(
             c_tensors.as_mut_ptr(),
@@ -26312,7 +26167,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_pixel_unshuffle(&self, downscale_factor: i64) -> Result<Tensor, TchError> {
+    pub fn pixel_unshuffle(&self, downscale_factor: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_pixel_unshuffle(
             c_tensors.as_mut_ptr(),
@@ -26322,7 +26177,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_pixel_unshuffle_out(
+    pub fn pixel_unshuffle_out(
         &self,
         out: &Tensor,
         downscale_factor: i64,
@@ -26337,13 +26192,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_poisson(&self) -> Result<Tensor, TchError> {
+    pub fn poisson(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_poisson(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_poisson_nll_loss(
+    pub fn poisson_nll_loss(
         &self,
         target: &Tensor,
         log_input: bool,
@@ -26364,19 +26219,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_poisson_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn poisson_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_poisson_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_polar(abs: &Tensor, angle: &Tensor) -> Result<Tensor, TchError> {
+    pub fn polar(abs: &Tensor, angle: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_polar(c_tensors.as_mut_ptr(), abs.c_tensor, angle.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_polar_out(out: &Tensor, abs: &Tensor, angle: &Tensor) -> Result<Tensor, TchError> {
+    pub fn polar_out(out: &Tensor, abs: &Tensor, angle: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_polar_out(
             c_tensors.as_mut_ptr(),
@@ -26387,19 +26242,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_polygamma(&self, n: i64) -> Result<Tensor, TchError> {
+    pub fn polygamma(&self, n: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_polygamma(c_tensors.as_mut_ptr(), n, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_polygamma_(&mut self, n: i64) -> Result<Tensor, TchError> {
+    pub fn polygamma_(&mut self, n: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_polygamma_(c_tensors.as_mut_ptr(), self.c_tensor, n));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_polygamma_out(&self, out: &Tensor, n: i64) -> Result<Tensor, TchError> {
+    pub fn polygamma_out(&self, out: &Tensor, n: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_polygamma_out(
             c_tensors.as_mut_ptr(),
@@ -26410,19 +26265,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_positive(&self) -> Result<Tensor, TchError> {
+    pub fn positive(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_positive(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_pow(&self, exponent: &Tensor) -> Result<Tensor, TchError> {
+    pub fn pow(&self, exponent: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_pow(c_tensors.as_mut_ptr(), self.c_tensor, exponent.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_pow_<S: Into<Scalar>>(&mut self, exponent: S) -> Result<Tensor, TchError> {
+    pub fn pow_<S: Into<Scalar>>(&mut self, exponent: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_pow_(
             c_tensors.as_mut_ptr(),
@@ -26432,7 +26287,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_pow_scalar<S: Into<Scalar>>(
+    pub fn pow_scalar<S: Into<Scalar>>(
         self_scalar: S,
         exponent: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -26445,7 +26300,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_pow_scalar_out<S: Into<Scalar>>(
+    pub fn pow_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         self_scalar: S,
         exponent: &Tensor,
@@ -26460,7 +26315,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_pow_tensor_(&mut self, exponent: &Tensor) -> Result<Tensor, TchError> {
+    pub fn pow_tensor_(&mut self, exponent: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_pow_tensor_(
             c_tensors.as_mut_ptr(),
@@ -26470,7 +26325,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_pow_tensor_scalar<S: Into<Scalar>>(&self, exponent: S) -> Result<Tensor, TchError> {
+    pub fn pow_tensor_scalar<S: Into<Scalar>>(&self, exponent: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_pow_tensor_scalar(
             c_tensors.as_mut_ptr(),
@@ -26480,7 +26335,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_pow_tensor_scalar_out<S: Into<Scalar>>(
+    pub fn pow_tensor_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         exponent: S,
@@ -26495,7 +26350,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_pow_tensor_tensor_out(
+    pub fn pow_tensor_tensor_out(
         &self,
         out: &Tensor,
         exponent: &Tensor,
@@ -26510,13 +26365,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_prelu(&self, weight: &Tensor) -> Result<Tensor, TchError> {
+    pub fn prelu(&self, weight: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_prelu(c_tensors.as_mut_ptr(), self.c_tensor, weight.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_prod(&self, dtype: impl Into<Option<Kind>>) -> Result<Tensor, TchError> {
+    pub fn prod(&self, dtype: impl Into<Option<Kind>>) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_prod(
             c_tensors.as_mut_ptr(),
@@ -26526,7 +26381,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_prod_dim_int(
+    pub fn prod_dim_int(
         &self,
         dim: i64,
         keepdim: bool,
@@ -26543,7 +26398,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_prod_int_out(
+    pub fn prod_int_out(
         &self,
         out: &Tensor,
         dim: i64,
@@ -26562,7 +26417,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_prod_out(
+    pub fn prod_out(
         &self,
         out: &Tensor,
         dtype: impl Into<Option<Kind>>,
@@ -26577,7 +26432,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_put(
+    pub fn put(
         &self,
         index: &Tensor,
         source: &Tensor,
@@ -26594,7 +26449,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_put_(
+    pub fn put_(
         &mut self,
         index: &Tensor,
         source: &Tensor,
@@ -26611,7 +26466,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_put_out(
+    pub fn put_out(
         &self,
         out: &Tensor,
         index: &Tensor,
@@ -26630,19 +26485,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_q_per_channel_axis(&self) -> Result<i64, TchError> {
+    pub fn q_per_channel_axis(&self) -> Result<i64, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg_q_per_channel_axis(self.c_tensor));
         Ok(return_)
     }
 
-    pub fn f_q_per_channel_scales(&self) -> Result<Tensor, TchError> {
+    pub fn q_per_channel_scales(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_q_per_channel_scales(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_q_per_channel_scales_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn q_per_channel_scales_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_q_per_channel_scales_out(
             c_tensors.as_mut_ptr(),
@@ -26652,13 +26507,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_q_per_channel_zero_points(&self) -> Result<Tensor, TchError> {
+    pub fn q_per_channel_zero_points(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_q_per_channel_zero_points(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_q_per_channel_zero_points_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn q_per_channel_zero_points_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_q_per_channel_zero_points_out(
             c_tensors.as_mut_ptr(),
@@ -26668,25 +26523,25 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_q_scale(&self) -> Result<f64, TchError> {
+    pub fn q_scale(&self) -> Result<f64, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg_q_scale(self.c_tensor));
         Ok(return_)
     }
 
-    pub fn f_q_zero_point(&self) -> Result<i64, TchError> {
+    pub fn q_zero_point(&self) -> Result<i64, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg_q_zero_point(self.c_tensor));
         Ok(return_)
     }
 
-    pub fn f_qr(&self, some: bool) -> Result<(Tensor, Tensor), TchError> {
+    pub fn qr(&self, some: bool) -> Result<(Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 2];
         unsafe_torch_err!(atg_qr(c_tensors.as_mut_ptr(), self.c_tensor, if some { 1 } else { 0 }));
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_qr_q(&self, q: &Tensor, r: &Tensor, some: bool) -> Result<(Tensor, Tensor), TchError> {
+    pub fn qr_q(&self, q: &Tensor, r: &Tensor, some: bool) -> Result<(Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 2];
         unsafe_torch_err!(atg_qr_q(
             c_tensors.as_mut_ptr(),
@@ -26698,7 +26553,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_quantile(
+    pub fn quantile(
         &self,
         q: &Tensor,
         dim: impl Into<Option<i64>>,
@@ -26720,7 +26575,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_quantile_out(
+    pub fn quantile_out(
         &self,
         out: &Tensor,
         q: &Tensor,
@@ -26744,7 +26599,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_quantile_scalar(
+    pub fn quantile_scalar(
         &self,
         q: f64,
         dim: impl Into<Option<i64>>,
@@ -26766,7 +26621,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_quantile_scalar_out(
+    pub fn quantile_scalar_out(
         &self,
         out: &Tensor,
         q: f64,
@@ -26790,7 +26645,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_quantize_per_channel(
+    pub fn quantize_per_channel(
         &self,
         scales: &Tensor,
         zero_points: &Tensor,
@@ -26809,7 +26664,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_quantize_per_channel_out(
+    pub fn quantize_per_channel_out(
         &self,
         out: &Tensor,
         scales: &Tensor,
@@ -26830,7 +26685,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_quantize_per_tensor(
+    pub fn quantize_per_tensor(
         &self,
         scale: f64,
         zero_point: i64,
@@ -26847,7 +26702,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_quantize_per_tensor_dynamic(
+    pub fn quantize_per_tensor_dynamic(
         &self,
         dtype: Kind,
         reduce_range: bool,
@@ -26862,7 +26717,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_quantize_per_tensor_dynamic_out(
+    pub fn quantize_per_tensor_dynamic_out(
         &self,
         out: &Tensor,
         dtype: Kind,
@@ -26879,7 +26734,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_quantize_per_tensor_out(
+    pub fn quantize_per_tensor_out(
         &self,
         out: &Tensor,
         scale: f64,
@@ -26898,7 +26753,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_quantize_per_tensor_tensor_qparams(
+    pub fn quantize_per_tensor_tensor_qparams(
         &self,
         scale: &Tensor,
         zero_point: &Tensor,
@@ -26915,7 +26770,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_quantize_per_tensor_tensor_qparams_out(
+    pub fn quantize_per_tensor_tensor_qparams_out(
         &self,
         out: &Tensor,
         scale: &Tensor,
@@ -26934,7 +26789,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_quantize_per_tensor_tensors<T: Borrow<Tensor>>(
+    pub fn quantize_per_tensor_tensors<T: Borrow<Tensor>>(
         tensors: &[T],
         scales: &Tensor,
         zero_points: &Tensor,
@@ -26961,7 +26816,7 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_quantize_per_tensor_tensors_out<T: Borrow<Tensor>>(
+    pub fn quantize_per_tensor_tensors_out<T: Borrow<Tensor>>(
         out: &[T],
         tensors: &[T],
         scales: &Tensor,
@@ -26980,7 +26835,7 @@ impl Tensor {
         Ok(())
     }
 
-    pub fn f_quantized_batch_norm<T: Borrow<Tensor>>(
+    pub fn quantized_batch_norm<T: Borrow<Tensor>>(
         &self,
         weight: Option<T>,
         bias: Option<T>,
@@ -27005,7 +26860,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_quantized_batch_norm_out<T: Borrow<Tensor>>(
+    pub fn quantized_batch_norm_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: Option<T>,
@@ -27032,7 +26887,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_quantized_gru_cell<S: Into<Scalar>>(
+    pub fn quantized_gru_cell<S: Into<Scalar>>(
         &self,
         hx: &Tensor,
         w_ih: &Tensor,
@@ -27069,7 +26924,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_quantized_lstm_cell<T: Borrow<Tensor>, S: Into<Scalar>>(
+    pub fn quantized_lstm_cell<T: Borrow<Tensor>, S: Into<Scalar>>(
         &self,
         hx: &[T],
         w_ih: &Tensor,
@@ -27107,7 +26962,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_quantized_max_pool1d(
+    pub fn quantized_max_pool1d(
         &self,
         kernel_size: impl IntList,
         stride: impl IntList,
@@ -27132,7 +26987,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_quantized_max_pool1d_out(
+    pub fn quantized_max_pool1d_out(
         &self,
         out: &Tensor,
         kernel_size: impl IntList,
@@ -27159,7 +27014,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_quantized_max_pool2d(
+    pub fn quantized_max_pool2d(
         &self,
         kernel_size: impl IntList,
         stride: impl IntList,
@@ -27184,7 +27039,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_quantized_max_pool2d_out(
+    pub fn quantized_max_pool2d_out(
         &self,
         out: &Tensor,
         kernel_size: impl IntList,
@@ -27211,7 +27066,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_quantized_rnn_relu_cell<S: Into<Scalar>>(
+    pub fn quantized_rnn_relu_cell<S: Into<Scalar>>(
         &self,
         hx: &Tensor,
         w_ih: &Tensor,
@@ -27248,7 +27103,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_quantized_rnn_tanh_cell<S: Into<Scalar>>(
+    pub fn quantized_rnn_tanh_cell<S: Into<Scalar>>(
         &self,
         hx: &Tensor,
         w_ih: &Tensor,
@@ -27285,25 +27140,25 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_rad2deg(&self) -> Result<Tensor, TchError> {
+    pub fn rad2deg(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_rad2deg(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_rad2deg_(&mut self) -> Result<Tensor, TchError> {
+    pub fn rad2deg_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_rad2deg_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_rad2deg_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn rad2deg_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_rad2deg_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_rand(size: impl IntList, options: (Kind, Device)) -> Result<Tensor, TchError> {
+    pub fn rand(size: impl IntList, options: (Kind, Device)) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_rand(
             c_tensors.as_mut_ptr(),
@@ -27315,19 +27170,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_rand_like(&self) -> Result<Tensor, TchError> {
+    pub fn rand_like(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_rand_like(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_rand_like_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn rand_like_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_rand_like_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_rand_out(out: &Tensor, size: impl IntList) -> Result<Tensor, TchError> {
+    pub fn rand_out(out: &Tensor, size: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_rand_out(
             c_tensors.as_mut_ptr(),
@@ -27338,7 +27193,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_randint(
+    pub fn randint(
         high: i64,
         size: impl IntList,
         options: (Kind, Device),
@@ -27355,13 +27210,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_randint_like(&self, high: i64) -> Result<Tensor, TchError> {
+    pub fn randint_like(&self, high: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_randint_like(c_tensors.as_mut_ptr(), self.c_tensor, high));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_randint_like_low_dtype(&self, low: i64, high: i64) -> Result<Tensor, TchError> {
+    pub fn randint_like_low_dtype(&self, low: i64, high: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_randint_like_low_dtype(
             c_tensors.as_mut_ptr(),
@@ -27372,7 +27227,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_randint_like_low_dtype_out(
+    pub fn randint_like_low_dtype_out(
         &self,
         out: &Tensor,
         low: i64,
@@ -27389,7 +27244,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_randint_like_out(&self, out: &Tensor, high: i64) -> Result<Tensor, TchError> {
+    pub fn randint_like_out(&self, out: &Tensor, high: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_randint_like_out(
             c_tensors.as_mut_ptr(),
@@ -27400,7 +27255,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_randint_low(
+    pub fn randint_low(
         low: i64,
         high: i64,
         size: impl IntList,
@@ -27419,7 +27274,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_randint_low_out(
+    pub fn randint_low_out(
         out: &Tensor,
         low: i64,
         high: i64,
@@ -27437,7 +27292,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_randint_out(out: &Tensor, high: i64, size: impl IntList) -> Result<Tensor, TchError> {
+    pub fn randint_out(out: &Tensor, high: i64, size: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_randint_out(
             c_tensors.as_mut_ptr(),
@@ -27449,7 +27304,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_randn(size: impl IntList, options: (Kind, Device)) -> Result<Tensor, TchError> {
+    pub fn randn(size: impl IntList, options: (Kind, Device)) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_randn(
             c_tensors.as_mut_ptr(),
@@ -27461,19 +27316,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_randn_like(&self) -> Result<Tensor, TchError> {
+    pub fn randn_like(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_randn_like(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_randn_like_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn randn_like_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_randn_like_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_randn_out(out: &Tensor, size: impl IntList) -> Result<Tensor, TchError> {
+    pub fn randn_out(out: &Tensor, size: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_randn_out(
             c_tensors.as_mut_ptr(),
@@ -27484,19 +27339,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_random(&self) -> Result<Tensor, TchError> {
+    pub fn random(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_random(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_random_(&mut self) -> Result<Tensor, TchError> {
+    pub fn random_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_random_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_random_from(&self, from: i64, to: impl Into<Option<i64>>) -> Result<Tensor, TchError> {
+    pub fn random_from(&self, from: i64, to: impl Into<Option<i64>>) -> Result<Tensor, TchError> {
         let to = to.into();
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_random_from(
@@ -27509,7 +27364,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_random_from_(
+    pub fn random_from_(
         &mut self,
         from: i64,
         to: impl Into<Option<i64>>,
@@ -27526,7 +27381,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_random_from_out(
+    pub fn random_from_out(
         &self,
         out: &Tensor,
         from: i64,
@@ -27545,25 +27400,25 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_random_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn random_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_random_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_random_to(&self, to: i64) -> Result<Tensor, TchError> {
+    pub fn random_to(&self, to: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_random_to(c_tensors.as_mut_ptr(), self.c_tensor, to));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_random_to_(&mut self, to: i64) -> Result<Tensor, TchError> {
+    pub fn random_to_(&mut self, to: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_random_to_(c_tensors.as_mut_ptr(), self.c_tensor, to));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_random_to_out(&self, out: &Tensor, to: i64) -> Result<Tensor, TchError> {
+    pub fn random_to_out(&self, out: &Tensor, to: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_random_to_out(
             c_tensors.as_mut_ptr(),
@@ -27574,7 +27429,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_randperm(n: i64, options: (Kind, Device)) -> Result<Tensor, TchError> {
+    pub fn randperm(n: i64, options: (Kind, Device)) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_randperm(
             c_tensors.as_mut_ptr(),
@@ -27585,13 +27440,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_randperm_out(out: &Tensor, n: i64) -> Result<Tensor, TchError> {
+    pub fn randperm_out(out: &Tensor, n: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_randperm_out(c_tensors.as_mut_ptr(), out.c_tensor, n));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_range<S: Into<Scalar>>(
+    pub fn range<S: Into<Scalar>>(
         start: S,
         end: S,
         options: (Kind, Device),
@@ -27607,11 +27462,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_range_out<S: Into<Scalar>>(
-        out: &Tensor,
-        start: S,
-        end: S,
-    ) -> Result<Tensor, TchError> {
+    pub fn range_out<S: Into<Scalar>>(out: &Tensor, start: S, end: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_range_out(
             c_tensors.as_mut_ptr(),
@@ -27622,11 +27473,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_range_out_<S: Into<Scalar>>(
-        out: &Tensor,
-        start: S,
-        end: S,
-    ) -> Result<Tensor, TchError> {
+    pub fn range_out_<S: Into<Scalar>>(out: &Tensor, start: S, end: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_range_out_(
             c_tensors.as_mut_ptr(),
@@ -27637,7 +27484,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_range_step<S: Into<Scalar>>(
+    pub fn range_step<S: Into<Scalar>>(
         start: S,
         end: S,
         options: (Kind, Device),
@@ -27653,37 +27500,37 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_ravel(&self) -> Result<Tensor, TchError> {
+    pub fn ravel(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_ravel(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_real(&self) -> Result<Tensor, TchError> {
+    pub fn real(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_real(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_reciprocal(&self) -> Result<Tensor, TchError> {
+    pub fn reciprocal(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_reciprocal(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_reciprocal_(&mut self) -> Result<Tensor, TchError> {
+    pub fn reciprocal_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_reciprocal_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_reciprocal_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn reciprocal_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_reciprocal_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_reflection_pad1d(&self, padding: impl IntList) -> Result<Tensor, TchError> {
+    pub fn reflection_pad1d(&self, padding: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_reflection_pad1d(
             c_tensors.as_mut_ptr(),
@@ -27694,7 +27541,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_reflection_pad1d_backward(
+    pub fn reflection_pad1d_backward(
         &self,
         grad_output: &Tensor,
         padding: impl IntList,
@@ -27710,7 +27557,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_reflection_pad1d_backward_grad_input(
+    pub fn reflection_pad1d_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -27728,7 +27575,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_reflection_pad1d_out(
+    pub fn reflection_pad1d_out(
         &self,
         out: &Tensor,
         padding: impl IntList,
@@ -27744,7 +27591,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_reflection_pad2d(&self, padding: impl IntList) -> Result<Tensor, TchError> {
+    pub fn reflection_pad2d(&self, padding: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_reflection_pad2d(
             c_tensors.as_mut_ptr(),
@@ -27755,7 +27602,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_reflection_pad2d_backward(
+    pub fn reflection_pad2d_backward(
         &self,
         grad_output: &Tensor,
         padding: impl IntList,
@@ -27771,7 +27618,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_reflection_pad2d_backward_grad_input(
+    pub fn reflection_pad2d_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -27789,7 +27636,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_reflection_pad2d_out(
+    pub fn reflection_pad2d_out(
         &self,
         out: &Tensor,
         padding: impl IntList,
@@ -27805,7 +27652,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_reflection_pad3d(&self, padding: impl IntList) -> Result<Tensor, TchError> {
+    pub fn reflection_pad3d(&self, padding: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_reflection_pad3d(
             c_tensors.as_mut_ptr(),
@@ -27816,7 +27663,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_reflection_pad3d_backward(
+    pub fn reflection_pad3d_backward(
         &self,
         grad_output: &Tensor,
         padding: impl IntList,
@@ -27832,7 +27679,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_reflection_pad3d_backward_grad_input(
+    pub fn reflection_pad3d_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -27850,7 +27697,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_reflection_pad3d_out(
+    pub fn reflection_pad3d_out(
         &self,
         out: &Tensor,
         padding: impl IntList,
@@ -27866,37 +27713,37 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_relu(&self) -> Result<Tensor, TchError> {
+    pub fn relu(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_relu(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_relu6(&self) -> Result<Tensor, TchError> {
+    pub fn relu6(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_relu6(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_relu6_(&mut self) -> Result<Tensor, TchError> {
+    pub fn relu6_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_relu6_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_relu_(&mut self) -> Result<Tensor, TchError> {
+    pub fn relu_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_relu_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_relu_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn relu_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_relu_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_remainder<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
+    pub fn remainder<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_remainder(
             c_tensors.as_mut_ptr(),
@@ -27906,7 +27753,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_remainder_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn remainder_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_remainder_(
             c_tensors.as_mut_ptr(),
@@ -27916,7 +27763,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_remainder_scalar_out<S: Into<Scalar>>(
+    pub fn remainder_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
@@ -27931,7 +27778,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_remainder_scalar_tensor<S: Into<Scalar>>(
+    pub fn remainder_scalar_tensor<S: Into<Scalar>>(
         self_scalar: S,
         other: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -27944,7 +27791,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_remainder_scalar_tensor_out<S: Into<Scalar>>(
+    pub fn remainder_scalar_tensor_out<S: Into<Scalar>>(
         out: &Tensor,
         self_scalar: S,
         other: &Tensor,
@@ -27959,7 +27806,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_remainder_tensor(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn remainder_tensor(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_remainder_tensor(
             c_tensors.as_mut_ptr(),
@@ -27969,7 +27816,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_remainder_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn remainder_tensor_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_remainder_tensor_(
             c_tensors.as_mut_ptr(),
@@ -27979,7 +27826,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_remainder_tensor_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn remainder_tensor_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_remainder_tensor_out(
             c_tensors.as_mut_ptr(),
@@ -27990,12 +27837,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_renorm<S: Into<Scalar>>(
-        &self,
-        p: S,
-        dim: i64,
-        maxnorm: S,
-    ) -> Result<Tensor, TchError> {
+    pub fn renorm<S: Into<Scalar>>(&self, p: S, dim: i64, maxnorm: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_renorm(
             c_tensors.as_mut_ptr(),
@@ -28007,7 +27849,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_renorm_<S: Into<Scalar>>(
+    pub fn renorm_<S: Into<Scalar>>(
         &mut self,
         p: S,
         dim: i64,
@@ -28024,7 +27866,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_renorm_out<S: Into<Scalar>>(
+    pub fn renorm_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         p: S,
@@ -28043,7 +27885,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_repeat(&self, repeats: impl IntList) -> Result<Tensor, TchError> {
+    pub fn repeat(&self, repeats: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_repeat(
             c_tensors.as_mut_ptr(),
@@ -28054,7 +27896,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_repeat_interleave(
+    pub fn repeat_interleave(
         repeats: &Tensor,
         output_size: impl Into<Option<i64>>,
     ) -> Result<Tensor, TchError> {
@@ -28069,7 +27911,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_repeat_interleave_self_int(
+    pub fn repeat_interleave_self_int(
         &self,
         repeats: i64,
         dim: impl Into<Option<i64>>,
@@ -28090,7 +27932,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_repeat_interleave_self_tensor(
+    pub fn repeat_interleave_self_tensor(
         &self,
         repeats: &Tensor,
         dim: impl Into<Option<i64>>,
@@ -28111,7 +27953,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_repeat_interleave_tensor_out(
+    pub fn repeat_interleave_tensor_out(
         out: &Tensor,
         repeats: &Tensor,
         output_size: impl Into<Option<i64>>,
@@ -28128,7 +27970,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_repeat_out(&self, out: &Tensor, repeats: impl IntList) -> Result<Tensor, TchError> {
+    pub fn repeat_out(&self, out: &Tensor, repeats: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_repeat_out(
             c_tensors.as_mut_ptr(),
@@ -28140,7 +27982,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_replication_pad1d(&self, padding: impl IntList) -> Result<Tensor, TchError> {
+    pub fn replication_pad1d(&self, padding: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_replication_pad1d(
             c_tensors.as_mut_ptr(),
@@ -28151,7 +27993,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_replication_pad1d_backward(
+    pub fn replication_pad1d_backward(
         &self,
         grad_output: &Tensor,
         padding: impl IntList,
@@ -28167,7 +28009,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_replication_pad1d_backward_grad_input(
+    pub fn replication_pad1d_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -28185,7 +28027,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_replication_pad1d_out(
+    pub fn replication_pad1d_out(
         &self,
         out: &Tensor,
         padding: impl IntList,
@@ -28201,7 +28043,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_replication_pad2d(&self, padding: impl IntList) -> Result<Tensor, TchError> {
+    pub fn replication_pad2d(&self, padding: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_replication_pad2d(
             c_tensors.as_mut_ptr(),
@@ -28212,7 +28054,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_replication_pad2d_backward(
+    pub fn replication_pad2d_backward(
         &self,
         grad_output: &Tensor,
         padding: impl IntList,
@@ -28228,7 +28070,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_replication_pad2d_backward_grad_input(
+    pub fn replication_pad2d_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -28246,7 +28088,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_replication_pad2d_out(
+    pub fn replication_pad2d_out(
         &self,
         out: &Tensor,
         padding: impl IntList,
@@ -28262,7 +28104,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_replication_pad3d(&self, padding: impl IntList) -> Result<Tensor, TchError> {
+    pub fn replication_pad3d(&self, padding: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_replication_pad3d(
             c_tensors.as_mut_ptr(),
@@ -28273,7 +28115,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_replication_pad3d_backward(
+    pub fn replication_pad3d_backward(
         &self,
         grad_output: &Tensor,
         padding: impl IntList,
@@ -28289,7 +28131,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_replication_pad3d_backward_grad_input(
+    pub fn replication_pad3d_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -28307,7 +28149,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_replication_pad3d_out(
+    pub fn replication_pad3d_out(
         &self,
         out: &Tensor,
         padding: impl IntList,
@@ -28323,7 +28165,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_requires_grad_(&mut self, requires_grad: bool) -> Result<Tensor, TchError> {
+    pub fn requires_grad_(&mut self, requires_grad: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_requires_grad_(
             c_tensors.as_mut_ptr(),
@@ -28333,7 +28175,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_reshape(&self, shape: impl IntList) -> Result<Tensor, TchError> {
+    pub fn reshape(&self, shape: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_reshape(
             c_tensors.as_mut_ptr(),
@@ -28344,13 +28186,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_reshape_as(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn reshape_as(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_reshape_as(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_resize(&self, size: impl IntList) -> Result<Tensor, TchError> {
+    pub fn resize(&self, size: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_resize(
             c_tensors.as_mut_ptr(),
@@ -28361,7 +28203,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_resize_(&mut self, size: impl IntList) -> Result<Tensor, TchError> {
+    pub fn resize_(&mut self, size: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_resize_(
             c_tensors.as_mut_ptr(),
@@ -28372,7 +28214,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_resize_as(&self, the_template: &Tensor) -> Result<Tensor, TchError> {
+    pub fn resize_as(&self, the_template: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_resize_as(
             c_tensors.as_mut_ptr(),
@@ -28382,7 +28224,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_resize_as_(&mut self, the_template: &Tensor) -> Result<Tensor, TchError> {
+    pub fn resize_as_(&mut self, the_template: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_resize_as_(
             c_tensors.as_mut_ptr(),
@@ -28392,7 +28234,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_resize_as_out(&self, out: &Tensor, the_template: &Tensor) -> Result<Tensor, TchError> {
+    pub fn resize_as_out(&self, out: &Tensor, the_template: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_resize_as_out(
             c_tensors.as_mut_ptr(),
@@ -28403,7 +28245,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_resize_as_sparse(&self, the_template: &Tensor) -> Result<Tensor, TchError> {
+    pub fn resize_as_sparse(&self, the_template: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_resize_as_sparse(
             c_tensors.as_mut_ptr(),
@@ -28413,7 +28255,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_resize_as_sparse_(&mut self, the_template: &Tensor) -> Result<Tensor, TchError> {
+    pub fn resize_as_sparse_(&mut self, the_template: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_resize_as_sparse_(
             c_tensors.as_mut_ptr(),
@@ -28423,7 +28265,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_resize_as_sparse_out(
+    pub fn resize_as_sparse_out(
         &self,
         out: &Tensor,
         the_template: &Tensor,
@@ -28438,7 +28280,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_resize_out(&self, out: &Tensor, size: impl IntList) -> Result<Tensor, TchError> {
+    pub fn resize_out(&self, out: &Tensor, size: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_resize_out(
             c_tensors.as_mut_ptr(),
@@ -28450,25 +28292,25 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_resolve_conj(&self) -> Result<Tensor, TchError> {
+    pub fn resolve_conj(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_resolve_conj(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_resolve_neg(&self) -> Result<Tensor, TchError> {
+    pub fn resolve_neg(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_resolve_neg(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_retains_grad(&self) -> Result<bool, TchError> {
+    pub fn retains_grad(&self) -> Result<bool, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg_retains_grad(self.c_tensor));
         Ok(return_ != 0)
     }
 
-    pub fn f_rnn_relu<T: Borrow<Tensor>>(
+    pub fn rnn_relu<T: Borrow<Tensor>>(
         &self,
         hx: &Tensor,
         params: &[T],
@@ -28496,7 +28338,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_rnn_relu_cell<T: Borrow<Tensor>>(
+    pub fn rnn_relu_cell<T: Borrow<Tensor>>(
         &self,
         hx: &Tensor,
         w_ih: &Tensor,
@@ -28517,7 +28359,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_rnn_relu_data<T: Borrow<Tensor>>(
+    pub fn rnn_relu_data<T: Borrow<Tensor>>(
         data: &Tensor,
         batch_sizes: &Tensor,
         hx: &Tensor,
@@ -28545,7 +28387,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_rnn_tanh<T: Borrow<Tensor>>(
+    pub fn rnn_tanh<T: Borrow<Tensor>>(
         &self,
         hx: &Tensor,
         params: &[T],
@@ -28573,7 +28415,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_rnn_tanh_cell<T: Borrow<Tensor>>(
+    pub fn rnn_tanh_cell<T: Borrow<Tensor>>(
         &self,
         hx: &Tensor,
         w_ih: &Tensor,
@@ -28594,7 +28436,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_rnn_tanh_data<T: Borrow<Tensor>>(
+    pub fn rnn_tanh_data<T: Borrow<Tensor>>(
         data: &Tensor,
         batch_sizes: &Tensor,
         hx: &Tensor,
@@ -28622,7 +28464,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_roll(&self, shifts: impl IntList, dims: impl IntList) -> Result<Tensor, TchError> {
+    pub fn roll(&self, shifts: impl IntList, dims: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_roll(
             c_tensors.as_mut_ptr(),
@@ -28635,7 +28477,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_roll_out(
+    pub fn roll_out(
         &self,
         out: &Tensor,
         shifts: impl IntList,
@@ -28654,7 +28496,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_rot90(&self, k: i64, dims: impl IntList) -> Result<Tensor, TchError> {
+    pub fn rot90(&self, k: i64, dims: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_rot90(
             c_tensors.as_mut_ptr(),
@@ -28666,12 +28508,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_rot90_out(
-        &self,
-        out: &Tensor,
-        k: i64,
-        dims: impl IntList,
-    ) -> Result<Tensor, TchError> {
+    pub fn rot90_out(&self, out: &Tensor, k: i64, dims: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_rot90_out(
             c_tensors.as_mut_ptr(),
@@ -28684,31 +28521,31 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_round(&self) -> Result<Tensor, TchError> {
+    pub fn round(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_round(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_round_(&mut self) -> Result<Tensor, TchError> {
+    pub fn round_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_round_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_round_decimals(&self, decimals: i64) -> Result<Tensor, TchError> {
+    pub fn round_decimals(&self, decimals: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_round_decimals(c_tensors.as_mut_ptr(), self.c_tensor, decimals));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_round_decimals_(&mut self, decimals: i64) -> Result<Tensor, TchError> {
+    pub fn round_decimals_(&mut self, decimals: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_round_decimals_(c_tensors.as_mut_ptr(), self.c_tensor, decimals));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_round_decimals_out(&self, out: &Tensor, decimals: i64) -> Result<Tensor, TchError> {
+    pub fn round_decimals_out(&self, out: &Tensor, decimals: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_round_decimals_out(
             c_tensors.as_mut_ptr(),
@@ -28719,25 +28556,25 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_round_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn round_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_round_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_row_indices(&self) -> Result<Tensor, TchError> {
+    pub fn row_indices(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_row_indices(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_row_indices_copy(&self) -> Result<Tensor, TchError> {
+    pub fn row_indices_copy(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_row_indices_copy(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_row_indices_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn row_indices_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_row_indices_copy_out(
             c_tensors.as_mut_ptr(),
@@ -28747,7 +28584,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_row_stack<T: Borrow<Tensor>>(tensors: &[T]) -> Result<Tensor, TchError> {
+    pub fn row_stack<T: Borrow<Tensor>>(tensors: &[T]) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_row_stack(
             c_tensors.as_mut_ptr(),
@@ -28757,7 +28594,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_row_stack_out<T: Borrow<Tensor>>(
+    pub fn row_stack_out<T: Borrow<Tensor>>(
         out: &Tensor,
         tensors: &[T],
     ) -> Result<Tensor, TchError> {
@@ -28771,7 +28608,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_rrelu(&self, training: bool) -> Result<Tensor, TchError> {
+    pub fn rrelu(&self, training: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_rrelu(
             c_tensors.as_mut_ptr(),
@@ -28781,7 +28618,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_rrelu_(&mut self, training: bool) -> Result<Tensor, TchError> {
+    pub fn rrelu_(&mut self, training: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_rrelu_(
             c_tensors.as_mut_ptr(),
@@ -28791,7 +28628,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_rrelu_with_noise(&self, noise: &Tensor, training: bool) -> Result<Tensor, TchError> {
+    pub fn rrelu_with_noise(&self, noise: &Tensor, training: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_rrelu_with_noise(
             c_tensors.as_mut_ptr(),
@@ -28802,7 +28639,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_rrelu_with_noise_(
+    pub fn rrelu_with_noise_(
         &mut self,
         noise: &Tensor,
         training: bool,
@@ -28817,7 +28654,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_rrelu_with_noise_backward<S: Into<Scalar>>(
+    pub fn rrelu_with_noise_backward<S: Into<Scalar>>(
         &self,
         grad_output: &Tensor,
         noise: &Tensor,
@@ -28840,7 +28677,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_rrelu_with_noise_backward_out<S: Into<Scalar>>(
+    pub fn rrelu_with_noise_backward_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         grad_output: &Tensor,
@@ -28865,7 +28702,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_rrelu_with_noise_out(
+    pub fn rrelu_with_noise_out(
         &self,
         out: &Tensor,
         noise: &Tensor,
@@ -28882,31 +28719,31 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_rsqrt(&self) -> Result<Tensor, TchError> {
+    pub fn rsqrt(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_rsqrt(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_rsqrt_(&mut self) -> Result<Tensor, TchError> {
+    pub fn rsqrt_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_rsqrt_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_rsqrt_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn rsqrt_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_rsqrt_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_rsub(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn rsub(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_rsub(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_rsub_scalar<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
+    pub fn rsub_scalar<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_rsub_scalar(
             c_tensors.as_mut_ptr(),
@@ -28916,7 +28753,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_rsub_scalar_out<S: Into<Scalar>>(
+    pub fn rsub_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
@@ -28931,7 +28768,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_rsub_tensor_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn rsub_tensor_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_rsub_tensor_out(
             c_tensors.as_mut_ptr(),
@@ -28942,7 +28779,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_scalar_tensor<S: Into<Scalar>>(
+    pub fn scalar_tensor<S: Into<Scalar>>(
         s: S,
         options: (Kind, Device),
     ) -> Result<Tensor, TchError> {
@@ -28956,7 +28793,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_scalar_tensor_out<S: Into<Scalar>>(out: &Tensor, s: S) -> Result<Tensor, TchError> {
+    pub fn scalar_tensor_out<S: Into<Scalar>>(out: &Tensor, s: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_scalar_tensor_out(
             c_tensors.as_mut_ptr(),
@@ -28966,7 +28803,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_scaled_dot_product_attention<T: Borrow<Tensor>>(
+    pub fn scaled_dot_product_attention<T: Borrow<Tensor>>(
         query: &Tensor,
         key: &Tensor,
         value: &Tensor,
@@ -28987,7 +28824,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_scatter(&self, dim: i64, index: &Tensor, src: &Tensor) -> Result<Tensor, TchError> {
+    pub fn scatter(&self, dim: i64, index: &Tensor, src: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_scatter(
             c_tensors.as_mut_ptr(),
@@ -28999,12 +28836,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_scatter_(
-        &mut self,
-        dim: i64,
-        index: &Tensor,
-        src: &Tensor,
-    ) -> Result<Tensor, TchError> {
+    pub fn scatter_(&mut self, dim: i64, index: &Tensor, src: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_scatter_(
             c_tensors.as_mut_ptr(),
@@ -29016,12 +28848,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_scatter_add(
-        &self,
-        dim: i64,
-        index: &Tensor,
-        src: &Tensor,
-    ) -> Result<Tensor, TchError> {
+    pub fn scatter_add(&self, dim: i64, index: &Tensor, src: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_scatter_add(
             c_tensors.as_mut_ptr(),
@@ -29033,7 +28860,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_scatter_add_(
+    pub fn scatter_add_(
         &mut self,
         dim: i64,
         index: &Tensor,
@@ -29050,7 +28877,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_scatter_add_out(
+    pub fn scatter_add_out(
         &self,
         out: &Tensor,
         dim: i64,
@@ -29069,7 +28896,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_scatter_reduce(
+    pub fn scatter_reduce(
         &self,
         dim: i64,
         index: &Tensor,
@@ -29089,7 +28916,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_scatter_reduce_(
+    pub fn scatter_reduce_(
         &mut self,
         dim: i64,
         index: &Tensor,
@@ -29109,7 +28936,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_scatter_reduce_out(
+    pub fn scatter_reduce_out(
         &self,
         out: &Tensor,
         dim: i64,
@@ -29131,7 +28958,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_scatter_src_out(
+    pub fn scatter_src_out(
         &self,
         out: &Tensor,
         dim: i64,
@@ -29150,7 +28977,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_scatter_value<S: Into<Scalar>>(
+    pub fn scatter_value<S: Into<Scalar>>(
         &self,
         dim: i64,
         index: &Tensor,
@@ -29167,7 +28994,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_scatter_value_<S: Into<Scalar>>(
+    pub fn scatter_value_<S: Into<Scalar>>(
         &mut self,
         dim: i64,
         index: &Tensor,
@@ -29184,7 +29011,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_scatter_value_out<S: Into<Scalar>>(
+    pub fn scatter_value_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         dim: i64,
@@ -29203,7 +29030,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_scatter_value_reduce<S: Into<Scalar>>(
+    pub fn scatter_value_reduce<S: Into<Scalar>>(
         &self,
         dim: i64,
         index: &Tensor,
@@ -29223,7 +29050,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_scatter_value_reduce_<S: Into<Scalar>>(
+    pub fn scatter_value_reduce_<S: Into<Scalar>>(
         &mut self,
         dim: i64,
         index: &Tensor,
@@ -29243,7 +29070,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_scatter_value_reduce_out<S: Into<Scalar>>(
+    pub fn scatter_value_reduce_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         dim: i64,
@@ -29265,7 +29092,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_searchsorted<T: Borrow<Tensor>>(
+    pub fn searchsorted<T: Borrow<Tensor>>(
         &self,
         sorted_sequence: &Tensor,
         out_int32: bool,
@@ -29287,7 +29114,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_searchsorted_scalar<T: Borrow<Tensor>, S: Into<Scalar>>(
+    pub fn searchsorted_scalar<T: Borrow<Tensor>, S: Into<Scalar>>(
         sorted_sequence: &Tensor,
         self_scalar: S,
         out_int32: bool,
@@ -29309,7 +29136,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_searchsorted_scalar_out<T: Borrow<Tensor>, S: Into<Scalar>>(
+    pub fn searchsorted_scalar_out<T: Borrow<Tensor>, S: Into<Scalar>>(
         out: &Tensor,
         sorted_sequence: &Tensor,
         self_scalar: S,
@@ -29333,7 +29160,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_searchsorted_tensor_out<T: Borrow<Tensor>>(
+    pub fn searchsorted_tensor_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         sorted_sequence: &Tensor,
@@ -29357,7 +29184,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_segment_reduce<T: Borrow<Tensor>, S: Into<Scalar>>(
+    pub fn segment_reduce<T: Borrow<Tensor>, S: Into<Scalar>>(
         data: &Tensor,
         reduce: &str,
         lengths: Option<T>,
@@ -29383,7 +29210,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_segment_reduce_out<T: Borrow<Tensor>, S: Into<Scalar>>(
+    pub fn segment_reduce_out<T: Borrow<Tensor>, S: Into<Scalar>>(
         out: &Tensor,
         data: &Tensor,
         reduce: &str,
@@ -29411,13 +29238,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_select(&self, dim: i64, index: i64) -> Result<Tensor, TchError> {
+    pub fn select(&self, dim: i64, index: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_select(c_tensors.as_mut_ptr(), self.c_tensor, dim, index));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_select_backward(
+    pub fn select_backward(
         grad_output: &Tensor,
         input_sizes: impl IntList,
         dim: i64,
@@ -29435,7 +29262,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_select_backward_out(
+    pub fn select_backward_out(
         out: &Tensor,
         grad_output: &Tensor,
         input_sizes: impl IntList,
@@ -29455,13 +29282,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_select_copy(&self, dim: i64, index: i64) -> Result<Tensor, TchError> {
+    pub fn select_copy(&self, dim: i64, index: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_select_copy(c_tensors.as_mut_ptr(), self.c_tensor, dim, index));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_select_copy_int_out(
+    pub fn select_copy_int_out(
         &self,
         out: &Tensor,
         dim: i64,
@@ -29478,7 +29305,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_select_scatter(&self, src: &Tensor, dim: i64, index: i64) -> Result<Tensor, TchError> {
+    pub fn select_scatter(&self, src: &Tensor, dim: i64, index: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_select_scatter(
             c_tensors.as_mut_ptr(),
@@ -29490,7 +29317,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_select_scatter_out(
+    pub fn select_scatter_out(
         &self,
         out: &Tensor,
         src: &Tensor,
@@ -29509,42 +29336,42 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_selu(&self) -> Result<Tensor, TchError> {
+    pub fn selu(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_selu(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_selu_(&mut self) -> Result<Tensor, TchError> {
+    pub fn selu_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_selu_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_set(&self) -> Result<Tensor, TchError> {
+    pub fn set(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_set(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_set_(&mut self) -> Result<Tensor, TchError> {
+    pub fn set_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_set_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_set_data(&mut self, new_data: &Tensor) -> Result<(), TchError> {
+    pub fn set_data(&mut self, new_data: &Tensor) -> Result<(), TchError> {
         unsafe_torch_err!(atg_set_data(self.c_tensor, new_data.c_tensor));
         Ok(())
     }
 
-    pub fn f_set_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn set_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_set_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_set_requires_grad(&self, r: bool) -> Result<Tensor, TchError> {
+    pub fn set_requires_grad(&self, r: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_set_requires_grad(
             c_tensors.as_mut_ptr(),
@@ -29554,7 +29381,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_set_source_tensor(&self, source: &Tensor) -> Result<Tensor, TchError> {
+    pub fn set_source_tensor(&self, source: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_set_source_tensor(
             c_tensors.as_mut_ptr(),
@@ -29564,7 +29391,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_set_source_tensor_(&mut self, source: &Tensor) -> Result<Tensor, TchError> {
+    pub fn set_source_tensor_(&mut self, source: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_set_source_tensor_(
             c_tensors.as_mut_ptr(),
@@ -29574,11 +29401,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_set_source_tensor_out(
-        &self,
-        out: &Tensor,
-        source: &Tensor,
-    ) -> Result<Tensor, TchError> {
+    pub fn set_source_tensor_out(&self, out: &Tensor, source: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_set_source_tensor_out(
             c_tensors.as_mut_ptr(),
@@ -29589,7 +29412,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_set_source_tensor_storage_offset_(
+    pub fn set_source_tensor_storage_offset_(
         &mut self,
         source: &Tensor,
         storage_offset: i64,
@@ -29610,37 +29433,37 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sgn(&self) -> Result<Tensor, TchError> {
+    pub fn sgn(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sgn(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sgn_(&mut self) -> Result<Tensor, TchError> {
+    pub fn sgn_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sgn_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sgn_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn sgn_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sgn_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sigmoid(&self) -> Result<Tensor, TchError> {
+    pub fn sigmoid(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sigmoid(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sigmoid_(&mut self) -> Result<Tensor, TchError> {
+    pub fn sigmoid_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sigmoid_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sigmoid_backward(grad_output: &Tensor, output: &Tensor) -> Result<Tensor, TchError> {
+    pub fn sigmoid_backward(grad_output: &Tensor, output: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sigmoid_backward(
             c_tensors.as_mut_ptr(),
@@ -29650,7 +29473,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sigmoid_backward_grad_input(
+    pub fn sigmoid_backward_grad_input(
         grad_input: &Tensor,
         grad_output: &Tensor,
         output: &Tensor,
@@ -29665,55 +29488,55 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sigmoid_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn sigmoid_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sigmoid_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sign(&self) -> Result<Tensor, TchError> {
+    pub fn sign(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sign(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sign_(&mut self) -> Result<Tensor, TchError> {
+    pub fn sign_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sign_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sign_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn sign_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sign_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_signbit(&self) -> Result<Tensor, TchError> {
+    pub fn signbit(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_signbit(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_signbit_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn signbit_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_signbit_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_silu(&self) -> Result<Tensor, TchError> {
+    pub fn silu(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_silu(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_silu_(&mut self) -> Result<Tensor, TchError> {
+    pub fn silu_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_silu_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_silu_backward(&self, grad_output: &Tensor) -> Result<Tensor, TchError> {
+    pub fn silu_backward(&self, grad_output: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_silu_backward(
             c_tensors.as_mut_ptr(),
@@ -29723,7 +29546,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_silu_backward_grad_input(
+    pub fn silu_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -29738,67 +29561,67 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_silu_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn silu_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_silu_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sin(&self) -> Result<Tensor, TchError> {
+    pub fn sin(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sin(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sin_(&mut self) -> Result<Tensor, TchError> {
+    pub fn sin_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sin_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sin_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn sin_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sin_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sinc(&self) -> Result<Tensor, TchError> {
+    pub fn sinc(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sinc(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sinc_(&mut self) -> Result<Tensor, TchError> {
+    pub fn sinc_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sinc_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sinc_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn sinc_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sinc_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sinh(&self) -> Result<Tensor, TchError> {
+    pub fn sinh(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sinh(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sinh_(&mut self) -> Result<Tensor, TchError> {
+    pub fn sinh_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sinh_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sinh_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn sinh_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sinh_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_slice(
+    pub fn slice(
         &self,
         dim: i64,
         start: impl Into<Option<i64>>,
@@ -29821,7 +29644,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_slice_backward(
+    pub fn slice_backward(
         grad_output: &Tensor,
         input_sizes: impl IntList,
         dim: i64,
@@ -29843,7 +29666,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_slice_backward_out(
+    pub fn slice_backward_out(
         out: &Tensor,
         grad_output: &Tensor,
         input_sizes: impl IntList,
@@ -29867,7 +29690,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_slice_copy(
+    pub fn slice_copy(
         &self,
         dim: i64,
         start: impl Into<Option<i64>>,
@@ -29890,7 +29713,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_slice_copy_tensor_out(
+    pub fn slice_copy_tensor_out(
         &self,
         out: &Tensor,
         dim: i64,
@@ -29915,7 +29738,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_slice_scatter(
+    pub fn slice_scatter(
         &self,
         src: &Tensor,
         dim: i64,
@@ -29940,7 +29763,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_slice_scatter_out(
+    pub fn slice_scatter_out(
         &self,
         out: &Tensor,
         src: &Tensor,
@@ -29967,13 +29790,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_slogdet(&self) -> Result<(Tensor, Tensor), TchError> {
+    pub fn slogdet(&self) -> Result<(Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 2];
         unsafe_torch_err!(atg_slogdet(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_slogdet_out(
+    pub fn slogdet_out(
         &self,
         sign: &Tensor,
         logabsdet: &Tensor,
@@ -29988,7 +29811,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_slow_conv3d<T: Borrow<Tensor>>(
+    pub fn slow_conv3d<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         kernel_size: impl IntList,
@@ -30012,7 +29835,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_slow_conv3d_out<T: Borrow<Tensor>>(
+    pub fn slow_conv3d_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -30038,7 +29861,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_slow_conv_dilated2d<T: Borrow<Tensor>>(
+    pub fn slow_conv_dilated2d<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         kernel_size: impl IntList,
@@ -30065,7 +29888,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_slow_conv_dilated2d_out<T: Borrow<Tensor>>(
+    pub fn slow_conv_dilated2d_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -30094,7 +29917,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_slow_conv_dilated3d<T: Borrow<Tensor>>(
+    pub fn slow_conv_dilated3d<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         kernel_size: impl IntList,
@@ -30121,7 +29944,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_slow_conv_dilated3d_out<T: Borrow<Tensor>>(
+    pub fn slow_conv_dilated3d_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -30150,7 +29973,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_slow_conv_transpose2d<T: Borrow<Tensor>>(
+    pub fn slow_conv_transpose2d<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         kernel_size: impl IntList,
@@ -30180,7 +30003,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_slow_conv_transpose2d_out<T: Borrow<Tensor>>(
+    pub fn slow_conv_transpose2d_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -30212,7 +30035,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_slow_conv_transpose3d<T: Borrow<Tensor>>(
+    pub fn slow_conv_transpose3d<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         kernel_size: impl IntList,
@@ -30242,7 +30065,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_slow_conv_transpose3d_out<T: Borrow<Tensor>>(
+    pub fn slow_conv_transpose3d_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -30274,13 +30097,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_smm(&self, mat2: &Tensor) -> Result<Tensor, TchError> {
+    pub fn smm(&self, mat2: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_smm(c_tensors.as_mut_ptr(), self.c_tensor, mat2.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_smooth_l1_loss(
+    pub fn smooth_l1_loss(
         &self,
         target: &Tensor,
         reduction: crate::Reduction,
@@ -30297,7 +30120,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_smooth_l1_loss_backward(
+    pub fn smooth_l1_loss_backward(
         &self,
         grad_output: &Tensor,
         target: &Tensor,
@@ -30316,7 +30139,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_smooth_l1_loss_backward_grad_input(
+    pub fn smooth_l1_loss_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -30337,7 +30160,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_smooth_l1_loss_out(
+    pub fn smooth_l1_loss_out(
         &self,
         out: &Tensor,
         target: &Tensor,
@@ -30356,7 +30179,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_soft_margin_loss(
+    pub fn soft_margin_loss(
         &self,
         target: &Tensor,
         reduction: crate::Reduction,
@@ -30371,7 +30194,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_soft_margin_loss_backward(
+    pub fn soft_margin_loss_backward(
         &self,
         grad_output: &Tensor,
         target: &Tensor,
@@ -30388,7 +30211,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_soft_margin_loss_backward_grad_input(
+    pub fn soft_margin_loss_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -30407,7 +30230,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_soft_margin_loss_out(
+    pub fn soft_margin_loss_out(
         &self,
         out: &Tensor,
         target: &Tensor,
@@ -30424,7 +30247,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_softmax(&self, dim: i64, dtype: impl Into<Option<Kind>>) -> Result<Tensor, TchError> {
+    pub fn softmax(&self, dim: i64, dtype: impl Into<Option<Kind>>) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_softmax(
             c_tensors.as_mut_ptr(),
@@ -30435,7 +30258,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_softmax_int_out(
+    pub fn softmax_int_out(
         &self,
         out: &Tensor,
         dim: i64,
@@ -30452,13 +30275,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_softplus(&self) -> Result<Tensor, TchError> {
+    pub fn softplus(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_softplus(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_softplus_backward<S: Into<Scalar>>(
+    pub fn softplus_backward<S: Into<Scalar>>(
         &self,
         grad_output: &Tensor,
         beta: S,
@@ -30475,7 +30298,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_softplus_backward_grad_input<S: Into<Scalar>>(
+    pub fn softplus_backward_grad_input<S: Into<Scalar>>(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -30494,19 +30317,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_softplus_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn softplus_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_softplus_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_softshrink(&self) -> Result<Tensor, TchError> {
+    pub fn softshrink(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_softshrink(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_softshrink_backward<S: Into<Scalar>>(
+    pub fn softshrink_backward<S: Into<Scalar>>(
         &self,
         grad_output: &Tensor,
         lambd: S,
@@ -30521,7 +30344,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_softshrink_backward_grad_input<S: Into<Scalar>>(
+    pub fn softshrink_backward_grad_input<S: Into<Scalar>>(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -30538,13 +30361,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_softshrink_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn softshrink_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_softshrink_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sort(&self, dim: i64, descending: bool) -> Result<(Tensor, Tensor), TchError> {
+    pub fn sort(&self, dim: i64, descending: bool) -> Result<(Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 2];
         unsafe_torch_err!(atg_sort(
             c_tensors.as_mut_ptr(),
@@ -30555,7 +30378,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_sort_stable(
+    pub fn sort_stable(
         &self,
         stable: bool,
         dim: i64,
@@ -30572,7 +30395,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_sort_values(
+    pub fn sort_values(
         &self,
         values: &Tensor,
         indices: &Tensor,
@@ -30591,7 +30414,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_sort_values_stable(
+    pub fn sort_values_stable(
         &self,
         values: &Tensor,
         indices: &Tensor,
@@ -30612,7 +30435,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_sparse_bsc_tensor(
+    pub fn sparse_bsc_tensor(
         ccol_indices: &Tensor,
         row_indices: &Tensor,
         values: &Tensor,
@@ -30630,7 +30453,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sparse_bsc_tensor_ccol_row_value_size(
+    pub fn sparse_bsc_tensor_ccol_row_value_size(
         ccol_indices: &Tensor,
         row_indices: &Tensor,
         values: &Tensor,
@@ -30651,7 +30474,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sparse_bsr_tensor(
+    pub fn sparse_bsr_tensor(
         crow_indices: &Tensor,
         col_indices: &Tensor,
         values: &Tensor,
@@ -30669,7 +30492,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sparse_bsr_tensor_crow_col_value_size(
+    pub fn sparse_bsr_tensor_crow_col_value_size(
         crow_indices: &Tensor,
         col_indices: &Tensor,
         values: &Tensor,
@@ -30690,7 +30513,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sparse_compressed_tensor(
+    pub fn sparse_compressed_tensor(
         compressed_indices: &Tensor,
         plain_indices: &Tensor,
         values: &Tensor,
@@ -30708,7 +30531,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sparse_compressed_tensor_comp_plain_value_size(
+    pub fn sparse_compressed_tensor_comp_plain_value_size(
         compressed_indices: &Tensor,
         plain_indices: &Tensor,
         values: &Tensor,
@@ -30729,7 +30552,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sparse_coo_tensor(
+    pub fn sparse_coo_tensor(
         size: impl IntList,
         options: (Kind, Device),
     ) -> Result<Tensor, TchError> {
@@ -30744,7 +30567,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sparse_coo_tensor_indices(
+    pub fn sparse_coo_tensor_indices(
         indices: &Tensor,
         values: &Tensor,
         options: (Kind, Device),
@@ -30760,7 +30583,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sparse_coo_tensor_indices_size(
+    pub fn sparse_coo_tensor_indices_size(
         indices: &Tensor,
         values: &Tensor,
         size: impl IntList,
@@ -30779,7 +30602,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sparse_coo_tensor_size_out(
+    pub fn sparse_coo_tensor_size_out(
         out: &Tensor,
         size: impl IntList,
     ) -> Result<Tensor, TchError> {
@@ -30793,7 +30616,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sparse_csc_tensor(
+    pub fn sparse_csc_tensor(
         ccol_indices: &Tensor,
         row_indices: &Tensor,
         values: &Tensor,
@@ -30811,7 +30634,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sparse_csc_tensor_ccol_row_value_size(
+    pub fn sparse_csc_tensor_ccol_row_value_size(
         ccol_indices: &Tensor,
         row_indices: &Tensor,
         values: &Tensor,
@@ -30832,7 +30655,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sparse_csr_tensor(
+    pub fn sparse_csr_tensor(
         crow_indices: &Tensor,
         col_indices: &Tensor,
         values: &Tensor,
@@ -30850,7 +30673,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sparse_csr_tensor_crow_col_value_size(
+    pub fn sparse_csr_tensor_crow_col_value_size(
         crow_indices: &Tensor,
         col_indices: &Tensor,
         values: &Tensor,
@@ -30871,19 +30694,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sparse_dim(&self) -> Result<i64, TchError> {
+    pub fn sparse_dim(&self) -> Result<i64, TchError> {
         let return_;
         unsafe_torch_err!(return_ = atg_sparse_dim(self.c_tensor));
         Ok(return_)
     }
 
-    pub fn f_sparse_mask(&self, mask: &Tensor) -> Result<Tensor, TchError> {
+    pub fn sparse_mask(&self, mask: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sparse_mask(c_tensors.as_mut_ptr(), self.c_tensor, mask.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sparse_mask_out(&self, out: &Tensor, mask: &Tensor) -> Result<Tensor, TchError> {
+    pub fn sparse_mask_out(&self, out: &Tensor, mask: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sparse_mask_out(
             c_tensors.as_mut_ptr(),
@@ -30894,7 +30717,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sparse_resize(
+    pub fn sparse_resize(
         &self,
         size: impl IntList,
         sparse_dim: i64,
@@ -30912,7 +30735,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sparse_resize_(
+    pub fn sparse_resize_(
         &mut self,
         size: impl IntList,
         sparse_dim: i64,
@@ -30930,7 +30753,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sparse_resize_and_clear(
+    pub fn sparse_resize_and_clear(
         &self,
         size: impl IntList,
         sparse_dim: i64,
@@ -30948,7 +30771,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sparse_resize_and_clear_(
+    pub fn sparse_resize_and_clear_(
         &mut self,
         size: impl IntList,
         sparse_dim: i64,
@@ -30966,7 +30789,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sparse_resize_and_clear_out(
+    pub fn sparse_resize_and_clear_out(
         &self,
         out: &Tensor,
         size: impl IntList,
@@ -30986,7 +30809,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sparse_resize_out(
+    pub fn sparse_resize_out(
         &self,
         out: &Tensor,
         size: impl IntList,
@@ -31006,7 +30829,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sparse_sampled_addmm(&self, mat1: &Tensor, mat2: &Tensor) -> Result<Tensor, TchError> {
+    pub fn sparse_sampled_addmm(&self, mat1: &Tensor, mat2: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sparse_sampled_addmm(
             c_tensors.as_mut_ptr(),
@@ -31017,7 +30840,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sparse_sampled_addmm_out(
+    pub fn sparse_sampled_addmm_out(
         &self,
         out: &Tensor,
         mat1: &Tensor,
@@ -31034,13 +30857,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_airy_ai(x: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_airy_ai(x: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_airy_ai(c_tensors.as_mut_ptr(), x.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_airy_ai_out(out: &Tensor, x: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_airy_ai_out(out: &Tensor, x: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_airy_ai_out(
             c_tensors.as_mut_ptr(),
@@ -31050,13 +30873,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_bessel_j0(&self) -> Result<Tensor, TchError> {
+    pub fn special_bessel_j0(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_bessel_j0(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_bessel_j0_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_bessel_j0_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_bessel_j0_out(
             c_tensors.as_mut_ptr(),
@@ -31066,13 +30889,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_bessel_j1(&self) -> Result<Tensor, TchError> {
+    pub fn special_bessel_j1(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_bessel_j1(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_bessel_j1_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_bessel_j1_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_bessel_j1_out(
             c_tensors.as_mut_ptr(),
@@ -31082,13 +30905,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_bessel_y0(&self) -> Result<Tensor, TchError> {
+    pub fn special_bessel_y0(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_bessel_y0(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_bessel_y0_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_bessel_y0_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_bessel_y0_out(
             c_tensors.as_mut_ptr(),
@@ -31098,13 +30921,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_bessel_y1(&self) -> Result<Tensor, TchError> {
+    pub fn special_bessel_y1(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_bessel_y1(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_bessel_y1_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_bessel_y1_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_bessel_y1_out(
             c_tensors.as_mut_ptr(),
@@ -31114,7 +30937,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_chebyshev_polynomial_t(x: &Tensor, n: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_chebyshev_polynomial_t(x: &Tensor, n: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_chebyshev_polynomial_t(
             c_tensors.as_mut_ptr(),
@@ -31124,7 +30947,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_chebyshev_polynomial_t_n_scalar<S: Into<Scalar>>(
+    pub fn special_chebyshev_polynomial_t_n_scalar<S: Into<Scalar>>(
         x: &Tensor,
         n: S,
     ) -> Result<Tensor, TchError> {
@@ -31137,7 +30960,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_chebyshev_polynomial_t_n_scalar_out<S: Into<Scalar>>(
+    pub fn special_chebyshev_polynomial_t_n_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: &Tensor,
         n: S,
@@ -31152,7 +30975,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_chebyshev_polynomial_t_out(
+    pub fn special_chebyshev_polynomial_t_out(
         out: &Tensor,
         x: &Tensor,
         n: &Tensor,
@@ -31167,7 +30990,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_chebyshev_polynomial_t_x_scalar<S: Into<Scalar>>(
+    pub fn special_chebyshev_polynomial_t_x_scalar<S: Into<Scalar>>(
         x: S,
         n: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -31180,7 +31003,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_chebyshev_polynomial_t_x_scalar_out<S: Into<Scalar>>(
+    pub fn special_chebyshev_polynomial_t_x_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: S,
         n: &Tensor,
@@ -31195,7 +31018,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_chebyshev_polynomial_u(x: &Tensor, n: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_chebyshev_polynomial_u(x: &Tensor, n: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_chebyshev_polynomial_u(
             c_tensors.as_mut_ptr(),
@@ -31205,7 +31028,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_chebyshev_polynomial_u_n_scalar<S: Into<Scalar>>(
+    pub fn special_chebyshev_polynomial_u_n_scalar<S: Into<Scalar>>(
         x: &Tensor,
         n: S,
     ) -> Result<Tensor, TchError> {
@@ -31218,7 +31041,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_chebyshev_polynomial_u_n_scalar_out<S: Into<Scalar>>(
+    pub fn special_chebyshev_polynomial_u_n_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: &Tensor,
         n: S,
@@ -31233,7 +31056,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_chebyshev_polynomial_u_out(
+    pub fn special_chebyshev_polynomial_u_out(
         out: &Tensor,
         x: &Tensor,
         n: &Tensor,
@@ -31248,7 +31071,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_chebyshev_polynomial_u_x_scalar<S: Into<Scalar>>(
+    pub fn special_chebyshev_polynomial_u_x_scalar<S: Into<Scalar>>(
         x: S,
         n: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -31261,7 +31084,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_chebyshev_polynomial_u_x_scalar_out<S: Into<Scalar>>(
+    pub fn special_chebyshev_polynomial_u_x_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: S,
         n: &Tensor,
@@ -31276,7 +31099,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_chebyshev_polynomial_v(x: &Tensor, n: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_chebyshev_polynomial_v(x: &Tensor, n: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_chebyshev_polynomial_v(
             c_tensors.as_mut_ptr(),
@@ -31286,7 +31109,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_chebyshev_polynomial_v_n_scalar<S: Into<Scalar>>(
+    pub fn special_chebyshev_polynomial_v_n_scalar<S: Into<Scalar>>(
         x: &Tensor,
         n: S,
     ) -> Result<Tensor, TchError> {
@@ -31299,7 +31122,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_chebyshev_polynomial_v_n_scalar_out<S: Into<Scalar>>(
+    pub fn special_chebyshev_polynomial_v_n_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: &Tensor,
         n: S,
@@ -31314,7 +31137,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_chebyshev_polynomial_v_out(
+    pub fn special_chebyshev_polynomial_v_out(
         out: &Tensor,
         x: &Tensor,
         n: &Tensor,
@@ -31329,7 +31152,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_chebyshev_polynomial_v_x_scalar<S: Into<Scalar>>(
+    pub fn special_chebyshev_polynomial_v_x_scalar<S: Into<Scalar>>(
         x: S,
         n: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -31342,7 +31165,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_chebyshev_polynomial_v_x_scalar_out<S: Into<Scalar>>(
+    pub fn special_chebyshev_polynomial_v_x_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: S,
         n: &Tensor,
@@ -31357,7 +31180,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_chebyshev_polynomial_w(x: &Tensor, n: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_chebyshev_polynomial_w(x: &Tensor, n: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_chebyshev_polynomial_w(
             c_tensors.as_mut_ptr(),
@@ -31367,7 +31190,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_chebyshev_polynomial_w_n_scalar<S: Into<Scalar>>(
+    pub fn special_chebyshev_polynomial_w_n_scalar<S: Into<Scalar>>(
         x: &Tensor,
         n: S,
     ) -> Result<Tensor, TchError> {
@@ -31380,7 +31203,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_chebyshev_polynomial_w_n_scalar_out<S: Into<Scalar>>(
+    pub fn special_chebyshev_polynomial_w_n_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: &Tensor,
         n: S,
@@ -31395,7 +31218,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_chebyshev_polynomial_w_out(
+    pub fn special_chebyshev_polynomial_w_out(
         out: &Tensor,
         x: &Tensor,
         n: &Tensor,
@@ -31410,7 +31233,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_chebyshev_polynomial_w_x_scalar<S: Into<Scalar>>(
+    pub fn special_chebyshev_polynomial_w_x_scalar<S: Into<Scalar>>(
         x: S,
         n: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -31423,7 +31246,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_chebyshev_polynomial_w_x_scalar_out<S: Into<Scalar>>(
+    pub fn special_chebyshev_polynomial_w_x_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: S,
         n: &Tensor,
@@ -31438,13 +31261,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_digamma(&self) -> Result<Tensor, TchError> {
+    pub fn special_digamma(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_digamma(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_digamma_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_digamma_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_digamma_out(
             c_tensors.as_mut_ptr(),
@@ -31454,13 +31277,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_entr(&self) -> Result<Tensor, TchError> {
+    pub fn special_entr(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_entr(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_entr_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_entr_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_entr_out(
             c_tensors.as_mut_ptr(),
@@ -31470,25 +31293,25 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_erf(&self) -> Result<Tensor, TchError> {
+    pub fn special_erf(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_erf(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_erf_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_erf_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_erf_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_erfc(&self) -> Result<Tensor, TchError> {
+    pub fn special_erfc(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_erfc(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_erfc_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_erfc_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_erfc_out(
             c_tensors.as_mut_ptr(),
@@ -31498,13 +31321,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_erfcx(&self) -> Result<Tensor, TchError> {
+    pub fn special_erfcx(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_erfcx(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_erfcx_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_erfcx_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_erfcx_out(
             c_tensors.as_mut_ptr(),
@@ -31514,13 +31337,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_erfinv(&self) -> Result<Tensor, TchError> {
+    pub fn special_erfinv(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_erfinv(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_erfinv_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_erfinv_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_erfinv_out(
             c_tensors.as_mut_ptr(),
@@ -31530,13 +31353,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_exp2(&self) -> Result<Tensor, TchError> {
+    pub fn special_exp2(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_exp2(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_exp2_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_exp2_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_exp2_out(
             c_tensors.as_mut_ptr(),
@@ -31546,13 +31369,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_expit(&self) -> Result<Tensor, TchError> {
+    pub fn special_expit(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_expit(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_expit_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_expit_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_expit_out(
             c_tensors.as_mut_ptr(),
@@ -31562,13 +31385,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_expm1(&self) -> Result<Tensor, TchError> {
+    pub fn special_expm1(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_expm1(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_expm1_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_expm1_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_expm1_out(
             c_tensors.as_mut_ptr(),
@@ -31578,7 +31401,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_gammainc(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_gammainc(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_gammainc(
             c_tensors.as_mut_ptr(),
@@ -31588,7 +31411,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_gammainc_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_gammainc_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_gammainc_out(
             c_tensors.as_mut_ptr(),
@@ -31599,7 +31422,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_gammaincc(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_gammaincc(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_gammaincc(
             c_tensors.as_mut_ptr(),
@@ -31609,11 +31432,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_gammaincc_out(
-        &self,
-        out: &Tensor,
-        other: &Tensor,
-    ) -> Result<Tensor, TchError> {
+    pub fn special_gammaincc_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_gammaincc_out(
             c_tensors.as_mut_ptr(),
@@ -31624,13 +31443,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_gammaln(&self) -> Result<Tensor, TchError> {
+    pub fn special_gammaln(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_gammaln(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_gammaln_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_gammaln_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_gammaln_out(
             c_tensors.as_mut_ptr(),
@@ -31640,7 +31459,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_hermite_polynomial_h(x: &Tensor, n: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_hermite_polynomial_h(x: &Tensor, n: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_hermite_polynomial_h(
             c_tensors.as_mut_ptr(),
@@ -31650,7 +31469,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_hermite_polynomial_h_n_scalar<S: Into<Scalar>>(
+    pub fn special_hermite_polynomial_h_n_scalar<S: Into<Scalar>>(
         x: &Tensor,
         n: S,
     ) -> Result<Tensor, TchError> {
@@ -31663,7 +31482,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_hermite_polynomial_h_n_scalar_out<S: Into<Scalar>>(
+    pub fn special_hermite_polynomial_h_n_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: &Tensor,
         n: S,
@@ -31678,7 +31497,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_hermite_polynomial_h_out(
+    pub fn special_hermite_polynomial_h_out(
         out: &Tensor,
         x: &Tensor,
         n: &Tensor,
@@ -31693,7 +31512,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_hermite_polynomial_h_x_scalar<S: Into<Scalar>>(
+    pub fn special_hermite_polynomial_h_x_scalar<S: Into<Scalar>>(
         x: S,
         n: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -31706,7 +31525,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_hermite_polynomial_h_x_scalar_out<S: Into<Scalar>>(
+    pub fn special_hermite_polynomial_h_x_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: S,
         n: &Tensor,
@@ -31721,7 +31540,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_hermite_polynomial_he(x: &Tensor, n: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_hermite_polynomial_he(x: &Tensor, n: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_hermite_polynomial_he(
             c_tensors.as_mut_ptr(),
@@ -31731,7 +31550,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_hermite_polynomial_he_n_scalar<S: Into<Scalar>>(
+    pub fn special_hermite_polynomial_he_n_scalar<S: Into<Scalar>>(
         x: &Tensor,
         n: S,
     ) -> Result<Tensor, TchError> {
@@ -31744,7 +31563,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_hermite_polynomial_he_n_scalar_out<S: Into<Scalar>>(
+    pub fn special_hermite_polynomial_he_n_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: &Tensor,
         n: S,
@@ -31759,7 +31578,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_hermite_polynomial_he_out(
+    pub fn special_hermite_polynomial_he_out(
         out: &Tensor,
         x: &Tensor,
         n: &Tensor,
@@ -31774,7 +31593,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_hermite_polynomial_he_x_scalar<S: Into<Scalar>>(
+    pub fn special_hermite_polynomial_he_x_scalar<S: Into<Scalar>>(
         x: S,
         n: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -31787,7 +31606,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_hermite_polynomial_he_x_scalar_out<S: Into<Scalar>>(
+    pub fn special_hermite_polynomial_he_x_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: S,
         n: &Tensor,
@@ -31802,55 +31621,55 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_i0(&self) -> Result<Tensor, TchError> {
+    pub fn special_i0(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_i0(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_i0_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_i0_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_i0_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_i0e(&self) -> Result<Tensor, TchError> {
+    pub fn special_i0e(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_i0e(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_i0e_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_i0e_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_i0e_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_i1(&self) -> Result<Tensor, TchError> {
+    pub fn special_i1(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_i1(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_i1_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_i1_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_i1_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_i1e(&self) -> Result<Tensor, TchError> {
+    pub fn special_i1e(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_i1e(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_i1e_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_i1e_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_i1e_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_laguerre_polynomial_l(x: &Tensor, n: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_laguerre_polynomial_l(x: &Tensor, n: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_laguerre_polynomial_l(
             c_tensors.as_mut_ptr(),
@@ -31860,7 +31679,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_laguerre_polynomial_l_n_scalar<S: Into<Scalar>>(
+    pub fn special_laguerre_polynomial_l_n_scalar<S: Into<Scalar>>(
         x: &Tensor,
         n: S,
     ) -> Result<Tensor, TchError> {
@@ -31873,7 +31692,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_laguerre_polynomial_l_n_scalar_out<S: Into<Scalar>>(
+    pub fn special_laguerre_polynomial_l_n_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: &Tensor,
         n: S,
@@ -31888,7 +31707,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_laguerre_polynomial_l_out(
+    pub fn special_laguerre_polynomial_l_out(
         out: &Tensor,
         x: &Tensor,
         n: &Tensor,
@@ -31903,7 +31722,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_laguerre_polynomial_l_x_scalar<S: Into<Scalar>>(
+    pub fn special_laguerre_polynomial_l_x_scalar<S: Into<Scalar>>(
         x: S,
         n: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -31916,7 +31735,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_laguerre_polynomial_l_x_scalar_out<S: Into<Scalar>>(
+    pub fn special_laguerre_polynomial_l_x_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: S,
         n: &Tensor,
@@ -31931,7 +31750,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_legendre_polynomial_p(x: &Tensor, n: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_legendre_polynomial_p(x: &Tensor, n: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_legendre_polynomial_p(
             c_tensors.as_mut_ptr(),
@@ -31941,7 +31760,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_legendre_polynomial_p_n_scalar<S: Into<Scalar>>(
+    pub fn special_legendre_polynomial_p_n_scalar<S: Into<Scalar>>(
         x: &Tensor,
         n: S,
     ) -> Result<Tensor, TchError> {
@@ -31954,7 +31773,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_legendre_polynomial_p_n_scalar_out<S: Into<Scalar>>(
+    pub fn special_legendre_polynomial_p_n_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: &Tensor,
         n: S,
@@ -31969,7 +31788,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_legendre_polynomial_p_out(
+    pub fn special_legendre_polynomial_p_out(
         out: &Tensor,
         x: &Tensor,
         n: &Tensor,
@@ -31984,7 +31803,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_legendre_polynomial_p_x_scalar<S: Into<Scalar>>(
+    pub fn special_legendre_polynomial_p_x_scalar<S: Into<Scalar>>(
         x: S,
         n: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -31997,7 +31816,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_legendre_polynomial_p_x_scalar_out<S: Into<Scalar>>(
+    pub fn special_legendre_polynomial_p_x_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: S,
         n: &Tensor,
@@ -32012,13 +31831,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_log1p(&self) -> Result<Tensor, TchError> {
+    pub fn special_log1p(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_log1p(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_log1p_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_log1p_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_log1p_out(
             c_tensors.as_mut_ptr(),
@@ -32028,13 +31847,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_log_ndtr(&self) -> Result<Tensor, TchError> {
+    pub fn special_log_ndtr(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_log_ndtr(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_log_ndtr_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_log_ndtr_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_log_ndtr_out(
             c_tensors.as_mut_ptr(),
@@ -32044,7 +31863,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_log_softmax(
+    pub fn special_log_softmax(
         &self,
         dim: i64,
         dtype: impl Into<Option<Kind>>,
@@ -32059,7 +31878,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_logit(&self, eps: impl Into<Option<f64>>) -> Result<Tensor, TchError> {
+    pub fn special_logit(&self, eps: impl Into<Option<f64>>) -> Result<Tensor, TchError> {
         let eps = eps.into();
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_logit(
@@ -32071,7 +31890,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_logit_out(
+    pub fn special_logit_out(
         &self,
         out: &Tensor,
         eps: impl Into<Option<f64>>,
@@ -32088,11 +31907,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_logsumexp(
-        &self,
-        dim: impl IntList,
-        keepdim: bool,
-    ) -> Result<Tensor, TchError> {
+    pub fn special_logsumexp(&self, dim: impl IntList, keepdim: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_logsumexp(
             c_tensors.as_mut_ptr(),
@@ -32104,7 +31919,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_logsumexp_out(
+    pub fn special_logsumexp_out(
         &self,
         out: &Tensor,
         dim: impl IntList,
@@ -32122,13 +31937,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_modified_bessel_i0(&self) -> Result<Tensor, TchError> {
+    pub fn special_modified_bessel_i0(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_modified_bessel_i0(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_modified_bessel_i0_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_modified_bessel_i0_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_modified_bessel_i0_out(
             c_tensors.as_mut_ptr(),
@@ -32138,13 +31953,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_modified_bessel_i1(&self) -> Result<Tensor, TchError> {
+    pub fn special_modified_bessel_i1(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_modified_bessel_i1(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_modified_bessel_i1_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_modified_bessel_i1_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_modified_bessel_i1_out(
             c_tensors.as_mut_ptr(),
@@ -32154,13 +31969,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_modified_bessel_k0(&self) -> Result<Tensor, TchError> {
+    pub fn special_modified_bessel_k0(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_modified_bessel_k0(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_modified_bessel_k0_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_modified_bessel_k0_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_modified_bessel_k0_out(
             c_tensors.as_mut_ptr(),
@@ -32170,13 +31985,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_modified_bessel_k1(&self) -> Result<Tensor, TchError> {
+    pub fn special_modified_bessel_k1(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_modified_bessel_k1(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_modified_bessel_k1_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_modified_bessel_k1_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_modified_bessel_k1_out(
             c_tensors.as_mut_ptr(),
@@ -32186,13 +32001,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_multigammaln(&self, p: i64) -> Result<Tensor, TchError> {
+    pub fn special_multigammaln(&self, p: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_multigammaln(c_tensors.as_mut_ptr(), self.c_tensor, p));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_multigammaln_out(&self, out: &Tensor, p: i64) -> Result<Tensor, TchError> {
+    pub fn special_multigammaln_out(&self, out: &Tensor, p: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_multigammaln_out(
             c_tensors.as_mut_ptr(),
@@ -32203,13 +32018,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_ndtr(&self) -> Result<Tensor, TchError> {
+    pub fn special_ndtr(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_ndtr(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_ndtr_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_ndtr_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_ndtr_out(
             c_tensors.as_mut_ptr(),
@@ -32219,13 +32034,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_ndtri(&self) -> Result<Tensor, TchError> {
+    pub fn special_ndtri(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_ndtri(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_ndtri_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_ndtri_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_ndtri_out(
             c_tensors.as_mut_ptr(),
@@ -32235,13 +32050,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_polygamma(&self, n: i64) -> Result<Tensor, TchError> {
+    pub fn special_polygamma(&self, n: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_polygamma(c_tensors.as_mut_ptr(), n, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_polygamma_out(&self, out: &Tensor, n: i64) -> Result<Tensor, TchError> {
+    pub fn special_polygamma_out(&self, out: &Tensor, n: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_polygamma_out(
             c_tensors.as_mut_ptr(),
@@ -32252,25 +32067,25 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_psi(&self) -> Result<Tensor, TchError> {
+    pub fn special_psi(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_psi(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_psi_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_psi_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_psi_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_round(&self, decimals: i64) -> Result<Tensor, TchError> {
+    pub fn special_round(&self, decimals: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_round(c_tensors.as_mut_ptr(), self.c_tensor, decimals));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_round_out(&self, out: &Tensor, decimals: i64) -> Result<Tensor, TchError> {
+    pub fn special_round_out(&self, out: &Tensor, decimals: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_round_out(
             c_tensors.as_mut_ptr(),
@@ -32281,7 +32096,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_scaled_modified_bessel_k0(x: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_scaled_modified_bessel_k0(x: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_scaled_modified_bessel_k0(
             c_tensors.as_mut_ptr(),
@@ -32290,7 +32105,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_scaled_modified_bessel_k0_out(
+    pub fn special_scaled_modified_bessel_k0_out(
         out: &Tensor,
         x: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -32303,7 +32118,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_scaled_modified_bessel_k1(x: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_scaled_modified_bessel_k1(x: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_scaled_modified_bessel_k1(
             c_tensors.as_mut_ptr(),
@@ -32312,7 +32127,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_scaled_modified_bessel_k1_out(
+    pub fn special_scaled_modified_bessel_k1_out(
         out: &Tensor,
         x: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -32325,7 +32140,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_shifted_chebyshev_polynomial_t(
+    pub fn special_shifted_chebyshev_polynomial_t(
         x: &Tensor,
         n: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -32338,7 +32153,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_shifted_chebyshev_polynomial_t_n_scalar<S: Into<Scalar>>(
+    pub fn special_shifted_chebyshev_polynomial_t_n_scalar<S: Into<Scalar>>(
         x: &Tensor,
         n: S,
     ) -> Result<Tensor, TchError> {
@@ -32351,7 +32166,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_shifted_chebyshev_polynomial_t_n_scalar_out<S: Into<Scalar>>(
+    pub fn special_shifted_chebyshev_polynomial_t_n_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: &Tensor,
         n: S,
@@ -32366,7 +32181,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_shifted_chebyshev_polynomial_t_out(
+    pub fn special_shifted_chebyshev_polynomial_t_out(
         out: &Tensor,
         x: &Tensor,
         n: &Tensor,
@@ -32381,7 +32196,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_shifted_chebyshev_polynomial_t_x_scalar<S: Into<Scalar>>(
+    pub fn special_shifted_chebyshev_polynomial_t_x_scalar<S: Into<Scalar>>(
         x: S,
         n: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -32394,7 +32209,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_shifted_chebyshev_polynomial_t_x_scalar_out<S: Into<Scalar>>(
+    pub fn special_shifted_chebyshev_polynomial_t_x_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: S,
         n: &Tensor,
@@ -32409,7 +32224,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_shifted_chebyshev_polynomial_u(
+    pub fn special_shifted_chebyshev_polynomial_u(
         x: &Tensor,
         n: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -32422,7 +32237,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_shifted_chebyshev_polynomial_u_n_scalar<S: Into<Scalar>>(
+    pub fn special_shifted_chebyshev_polynomial_u_n_scalar<S: Into<Scalar>>(
         x: &Tensor,
         n: S,
     ) -> Result<Tensor, TchError> {
@@ -32435,7 +32250,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_shifted_chebyshev_polynomial_u_n_scalar_out<S: Into<Scalar>>(
+    pub fn special_shifted_chebyshev_polynomial_u_n_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: &Tensor,
         n: S,
@@ -32450,7 +32265,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_shifted_chebyshev_polynomial_u_out(
+    pub fn special_shifted_chebyshev_polynomial_u_out(
         out: &Tensor,
         x: &Tensor,
         n: &Tensor,
@@ -32465,7 +32280,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_shifted_chebyshev_polynomial_u_x_scalar<S: Into<Scalar>>(
+    pub fn special_shifted_chebyshev_polynomial_u_x_scalar<S: Into<Scalar>>(
         x: S,
         n: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -32478,7 +32293,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_shifted_chebyshev_polynomial_u_x_scalar_out<S: Into<Scalar>>(
+    pub fn special_shifted_chebyshev_polynomial_u_x_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: S,
         n: &Tensor,
@@ -32493,7 +32308,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_shifted_chebyshev_polynomial_v(
+    pub fn special_shifted_chebyshev_polynomial_v(
         x: &Tensor,
         n: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -32506,7 +32321,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_shifted_chebyshev_polynomial_v_n_scalar<S: Into<Scalar>>(
+    pub fn special_shifted_chebyshev_polynomial_v_n_scalar<S: Into<Scalar>>(
         x: &Tensor,
         n: S,
     ) -> Result<Tensor, TchError> {
@@ -32519,7 +32334,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_shifted_chebyshev_polynomial_v_n_scalar_out<S: Into<Scalar>>(
+    pub fn special_shifted_chebyshev_polynomial_v_n_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: &Tensor,
         n: S,
@@ -32534,7 +32349,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_shifted_chebyshev_polynomial_v_out(
+    pub fn special_shifted_chebyshev_polynomial_v_out(
         out: &Tensor,
         x: &Tensor,
         n: &Tensor,
@@ -32549,7 +32364,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_shifted_chebyshev_polynomial_v_x_scalar<S: Into<Scalar>>(
+    pub fn special_shifted_chebyshev_polynomial_v_x_scalar<S: Into<Scalar>>(
         x: S,
         n: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -32562,7 +32377,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_shifted_chebyshev_polynomial_v_x_scalar_out<S: Into<Scalar>>(
+    pub fn special_shifted_chebyshev_polynomial_v_x_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: S,
         n: &Tensor,
@@ -32577,7 +32392,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_shifted_chebyshev_polynomial_w(
+    pub fn special_shifted_chebyshev_polynomial_w(
         x: &Tensor,
         n: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -32590,7 +32405,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_shifted_chebyshev_polynomial_w_n_scalar<S: Into<Scalar>>(
+    pub fn special_shifted_chebyshev_polynomial_w_n_scalar<S: Into<Scalar>>(
         x: &Tensor,
         n: S,
     ) -> Result<Tensor, TchError> {
@@ -32603,7 +32418,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_shifted_chebyshev_polynomial_w_n_scalar_out<S: Into<Scalar>>(
+    pub fn special_shifted_chebyshev_polynomial_w_n_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: &Tensor,
         n: S,
@@ -32618,7 +32433,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_shifted_chebyshev_polynomial_w_out(
+    pub fn special_shifted_chebyshev_polynomial_w_out(
         out: &Tensor,
         x: &Tensor,
         n: &Tensor,
@@ -32633,7 +32448,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_shifted_chebyshev_polynomial_w_x_scalar<S: Into<Scalar>>(
+    pub fn special_shifted_chebyshev_polynomial_w_x_scalar<S: Into<Scalar>>(
         x: S,
         n: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -32646,7 +32461,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_shifted_chebyshev_polynomial_w_x_scalar_out<S: Into<Scalar>>(
+    pub fn special_shifted_chebyshev_polynomial_w_x_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: S,
         n: &Tensor,
@@ -32661,13 +32476,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_sinc(&self) -> Result<Tensor, TchError> {
+    pub fn special_sinc(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_sinc(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_sinc_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_sinc_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_sinc_out(
             c_tensors.as_mut_ptr(),
@@ -32677,7 +32492,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_softmax(
+    pub fn special_softmax(
         &self,
         dim: i64,
         dtype: impl Into<Option<Kind>>,
@@ -32692,13 +32507,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_spherical_bessel_j0(x: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_spherical_bessel_j0(x: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_spherical_bessel_j0(c_tensors.as_mut_ptr(), x.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_spherical_bessel_j0_out(out: &Tensor, x: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_spherical_bessel_j0_out(out: &Tensor, x: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_spherical_bessel_j0_out(
             c_tensors.as_mut_ptr(),
@@ -32708,7 +32523,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_xlog1py(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_xlog1py(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_xlog1py(
             c_tensors.as_mut_ptr(),
@@ -32718,7 +32533,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_xlog1py_other_scalar<S: Into<Scalar>>(
+    pub fn special_xlog1py_other_scalar<S: Into<Scalar>>(
         &self,
         other: S,
     ) -> Result<Tensor, TchError> {
@@ -32731,7 +32546,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_xlog1py_other_scalar_out<S: Into<Scalar>>(
+    pub fn special_xlog1py_other_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
@@ -32746,7 +32561,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_xlog1py_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_xlog1py_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_xlog1py_out(
             c_tensors.as_mut_ptr(),
@@ -32757,7 +32572,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_xlog1py_self_scalar<S: Into<Scalar>>(
+    pub fn special_xlog1py_self_scalar<S: Into<Scalar>>(
         self_scalar: S,
         other: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -32770,7 +32585,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_xlog1py_self_scalar_out<S: Into<Scalar>>(
+    pub fn special_xlog1py_self_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         self_scalar: S,
         other: &Tensor,
@@ -32785,13 +32600,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_xlogy(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_xlogy(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_xlogy(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_xlogy_other_scalar<S: Into<Scalar>>(
+    pub fn special_xlogy_other_scalar<S: Into<Scalar>>(
         &self,
         other: S,
     ) -> Result<Tensor, TchError> {
@@ -32804,7 +32619,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_xlogy_other_scalar_out<S: Into<Scalar>>(
+    pub fn special_xlogy_other_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
@@ -32819,7 +32634,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_xlogy_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_xlogy_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_xlogy_out(
             c_tensors.as_mut_ptr(),
@@ -32830,7 +32645,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_xlogy_self_scalar<S: Into<Scalar>>(
+    pub fn special_xlogy_self_scalar<S: Into<Scalar>>(
         self_scalar: S,
         other: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -32843,7 +32658,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_xlogy_self_scalar_out<S: Into<Scalar>>(
+    pub fn special_xlogy_self_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         self_scalar: S,
         other: &Tensor,
@@ -32858,16 +32673,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_zeta(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_zeta(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_zeta(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_zeta_other_scalar<S: Into<Scalar>>(
-        &self,
-        other: S,
-    ) -> Result<Tensor, TchError> {
+    pub fn special_zeta_other_scalar<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_zeta_other_scalar(
             c_tensors.as_mut_ptr(),
@@ -32877,7 +32689,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_zeta_other_scalar_out<S: Into<Scalar>>(
+    pub fn special_zeta_other_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
@@ -32892,7 +32704,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_zeta_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn special_zeta_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_special_zeta_out(
             c_tensors.as_mut_ptr(),
@@ -32903,7 +32715,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_zeta_self_scalar<S: Into<Scalar>>(
+    pub fn special_zeta_self_scalar<S: Into<Scalar>>(
         self_scalar: S,
         other: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -32916,7 +32728,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_special_zeta_self_scalar_out<S: Into<Scalar>>(
+    pub fn special_zeta_self_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         self_scalar: S,
         other: &Tensor,
@@ -32931,7 +32743,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_split(&self, split_size: i64, dim: i64) -> Result<Vec<Tensor>, TchError> {
+    pub fn split(&self, split_size: i64, dim: i64) -> Result<Vec<Tensor>, TchError> {
         let c_tensors = unsafe_torch_err!(atg_split(self.c_tensor, split_size, dim));
         let mut r__ = vec![];
         let mut i = 0;
@@ -32947,7 +32759,7 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_split_copy(&self, split_size: i64, dim: i64) -> Result<Vec<Tensor>, TchError> {
+    pub fn split_copy(&self, split_size: i64, dim: i64) -> Result<Vec<Tensor>, TchError> {
         let c_tensors = unsafe_torch_err!(atg_split_copy(self.c_tensor, split_size, dim));
         let mut r__ = vec![];
         let mut i = 0;
@@ -32963,7 +32775,7 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_split_copy_tensor_out<T: Borrow<Tensor>>(
+    pub fn split_copy_tensor_out<T: Borrow<Tensor>>(
         &self,
         out: &[T],
         split_size: i64,
@@ -32979,11 +32791,7 @@ impl Tensor {
         Ok(())
     }
 
-    pub fn f_split_sizes(
-        &self,
-        split_size: impl IntList,
-        dim: i64,
-    ) -> Result<Vec<Tensor>, TchError> {
+    pub fn split_sizes(&self, split_size: impl IntList, dim: i64) -> Result<Vec<Tensor>, TchError> {
         let c_tensors = unsafe_torch_err!(atg_split_sizes(
             self.c_tensor,
             split_size.as_ptr(),
@@ -33004,7 +32812,7 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_split_with_sizes(
+    pub fn split_with_sizes(
         &self,
         split_sizes: impl IntList,
         dim: i64,
@@ -33029,7 +32837,7 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_split_with_sizes_copy(
+    pub fn split_with_sizes_copy(
         &self,
         split_sizes: impl IntList,
         dim: i64,
@@ -33054,7 +32862,7 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_split_with_sizes_copy_out<T: Borrow<Tensor>>(
+    pub fn split_with_sizes_copy_out<T: Borrow<Tensor>>(
         &self,
         out: &[T],
         split_sizes: impl IntList,
@@ -33071,67 +32879,67 @@ impl Tensor {
         Ok(())
     }
 
-    pub fn f_sqrt(&self) -> Result<Tensor, TchError> {
+    pub fn sqrt(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sqrt(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sqrt_(&mut self) -> Result<Tensor, TchError> {
+    pub fn sqrt_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sqrt_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sqrt_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn sqrt_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sqrt_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_square(&self) -> Result<Tensor, TchError> {
+    pub fn square(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_square(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_square_(&mut self) -> Result<Tensor, TchError> {
+    pub fn square_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_square_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_square_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn square_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_square_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_squeeze(&self) -> Result<Tensor, TchError> {
+    pub fn squeeze(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_squeeze(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_squeeze_(&mut self) -> Result<Tensor, TchError> {
+    pub fn squeeze_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_squeeze_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_squeeze_copy(&self) -> Result<Tensor, TchError> {
+    pub fn squeeze_copy(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_squeeze_copy(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_squeeze_copy_dim(&self, dim: i64) -> Result<Tensor, TchError> {
+    pub fn squeeze_copy_dim(&self, dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_squeeze_copy_dim(c_tensors.as_mut_ptr(), self.c_tensor, dim));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_squeeze_copy_dim_out(&self, out: &Tensor, dim: i64) -> Result<Tensor, TchError> {
+    pub fn squeeze_copy_dim_out(&self, out: &Tensor, dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_squeeze_copy_dim_out(
             c_tensors.as_mut_ptr(),
@@ -33142,7 +32950,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_squeeze_copy_dims(&self, dim: impl IntList) -> Result<Tensor, TchError> {
+    pub fn squeeze_copy_dims(&self, dim: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_squeeze_copy_dims(
             c_tensors.as_mut_ptr(),
@@ -33153,7 +32961,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_squeeze_copy_dims_out(
+    pub fn squeeze_copy_dims_out(
         &self,
         out: &Tensor,
         dim: impl IntList,
@@ -33169,7 +32977,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_squeeze_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn squeeze_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_squeeze_copy_out(
             c_tensors.as_mut_ptr(),
@@ -33179,19 +32987,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_squeeze_dim(&self, dim: i64) -> Result<Tensor, TchError> {
+    pub fn squeeze_dim(&self, dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_squeeze_dim(c_tensors.as_mut_ptr(), self.c_tensor, dim));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_squeeze_dim_(&mut self, dim: i64) -> Result<Tensor, TchError> {
+    pub fn squeeze_dim_(&mut self, dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_squeeze_dim_(c_tensors.as_mut_ptr(), self.c_tensor, dim));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_squeeze_dims(&self, dim: impl IntList) -> Result<Tensor, TchError> {
+    pub fn squeeze_dims(&self, dim: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_squeeze_dims(
             c_tensors.as_mut_ptr(),
@@ -33202,7 +33010,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_squeeze_dims_(&mut self, dim: impl IntList) -> Result<Tensor, TchError> {
+    pub fn squeeze_dims_(&mut self, dim: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_squeeze_dims_(
             c_tensors.as_mut_ptr(),
@@ -33213,7 +33021,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sspaddmm(&self, mat1: &Tensor, mat2: &Tensor) -> Result<Tensor, TchError> {
+    pub fn sspaddmm(&self, mat1: &Tensor, mat2: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sspaddmm(
             c_tensors.as_mut_ptr(),
@@ -33224,7 +33032,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sspaddmm_out(
+    pub fn sspaddmm_out(
         &self,
         out: &Tensor,
         mat1: &Tensor,
@@ -33241,7 +33049,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_stack<T: Borrow<Tensor>>(tensors: &[T], dim: i64) -> Result<Tensor, TchError> {
+    pub fn stack<T: Borrow<Tensor>>(tensors: &[T], dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_stack(
             c_tensors.as_mut_ptr(),
@@ -33252,7 +33060,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_stack_out<T: Borrow<Tensor>>(
+    pub fn stack_out<T: Borrow<Tensor>>(
         out: &Tensor,
         tensors: &[T],
         dim: i64,
@@ -33268,7 +33076,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_std(&self, unbiased: bool) -> Result<Tensor, TchError> {
+    pub fn std(&self, unbiased: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_std(
             c_tensors.as_mut_ptr(),
@@ -33278,7 +33086,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_std_correction(
+    pub fn std_correction(
         &self,
         dim: impl IntListOption,
         correction: impl Into<Option<i64>>,
@@ -33298,7 +33106,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_std_correction_out(
+    pub fn std_correction_out(
         &self,
         out: &Tensor,
         dim: impl IntListOption,
@@ -33320,7 +33128,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_std_dim(
+    pub fn std_dim(
         &self,
         dim: impl IntListOption,
         unbiased: bool,
@@ -33338,7 +33146,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_std_mean(&self, unbiased: bool) -> Result<(Tensor, Tensor), TchError> {
+    pub fn std_mean(&self, unbiased: bool) -> Result<(Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 2];
         unsafe_torch_err!(atg_std_mean(
             c_tensors.as_mut_ptr(),
@@ -33348,7 +33156,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_std_mean_correction(
+    pub fn std_mean_correction(
         &self,
         dim: impl IntListOption,
         correction: impl Into<Option<i64>>,
@@ -33368,7 +33176,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_std_mean_correction_out(
+    pub fn std_mean_correction_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -33392,7 +33200,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_std_mean_dim(
+    pub fn std_mean_dim(
         &self,
         dim: impl IntListOption,
         unbiased: bool,
@@ -33410,7 +33218,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_std_out(
+    pub fn std_out(
         &self,
         out: &Tensor,
         dim: impl IntListOption,
@@ -33430,7 +33238,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_stft<T: Borrow<Tensor>>(
+    pub fn stft<T: Borrow<Tensor>>(
         &self,
         n_fft: i64,
         hop_length: impl Into<Option<i64>>,
@@ -33459,7 +33267,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_stft_center<T: Borrow<Tensor>>(
+    pub fn stft_center<T: Borrow<Tensor>>(
         &self,
         n_fft: i64,
         hop_length: impl Into<Option<i64>>,
@@ -33493,19 +33301,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sub(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn g_sub(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sub(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sub_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn g_sub_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sub_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sub_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn sub_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sub_out(
             c_tensors.as_mut_ptr(),
@@ -33516,7 +33324,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sub_scalar<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
+    pub fn g_sub_scalar<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sub_scalar(
             c_tensors.as_mut_ptr(),
@@ -33526,7 +33334,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sub_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn g_sub_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sub_scalar_(
             c_tensors.as_mut_ptr(),
@@ -33536,7 +33344,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sub_scalar_out<S: Into<Scalar>>(
+    pub fn sub_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
@@ -33551,19 +33359,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_subtract(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn subtract(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_subtract(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_subtract_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn subtract_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_subtract_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_subtract_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn subtract_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_subtract_out(
             c_tensors.as_mut_ptr(),
@@ -33574,7 +33382,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_subtract_scalar<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
+    pub fn subtract_scalar<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_subtract_scalar(
             c_tensors.as_mut_ptr(),
@@ -33584,7 +33392,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_subtract_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn subtract_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_subtract_scalar_(
             c_tensors.as_mut_ptr(),
@@ -33594,7 +33402,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sum(&self, dtype: impl Into<Option<Kind>>) -> Result<Tensor, TchError> {
+    pub fn sum(&self, dtype: impl Into<Option<Kind>>) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sum(
             c_tensors.as_mut_ptr(),
@@ -33604,7 +33412,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sum_dim_intlist(
+    pub fn sum_dim_intlist(
         &self,
         dim: impl IntListOption,
         keepdim: bool,
@@ -33622,7 +33430,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sum_intlist_out(
+    pub fn sum_intlist_out(
         &self,
         out: &Tensor,
         dim: impl IntListOption,
@@ -33642,7 +33450,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sum_out(
+    pub fn sum_out(
         &self,
         out: &Tensor,
         dtype: impl Into<Option<Kind>>,
@@ -33657,7 +33465,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_sum_to_size(&self, size: impl IntList) -> Result<Tensor, TchError> {
+    pub fn sum_to_size(&self, size: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_sum_to_size(
             c_tensors.as_mut_ptr(),
@@ -33668,11 +33476,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_svd(
-        &self,
-        some: bool,
-        compute_uv: bool,
-    ) -> Result<(Tensor, Tensor, Tensor), TchError> {
+    pub fn svd(&self, some: bool, compute_uv: bool) -> Result<(Tensor, Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 3];
         unsafe_torch_err!(atg_svd(
             c_tensors.as_mut_ptr(),
@@ -33687,7 +33491,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_svd_u(
+    pub fn svd_u(
         &self,
         u: &Tensor,
         s: &Tensor,
@@ -33712,61 +33516,61 @@ impl Tensor {
         ))
     }
 
-    pub fn f_swapaxes(&self, axis0: i64, axis1: i64) -> Result<Tensor, TchError> {
+    pub fn swapaxes(&self, axis0: i64, axis1: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_swapaxes(c_tensors.as_mut_ptr(), self.c_tensor, axis0, axis1));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_swapaxes_(&mut self, axis0: i64, axis1: i64) -> Result<Tensor, TchError> {
+    pub fn swapaxes_(&mut self, axis0: i64, axis1: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_swapaxes_(c_tensors.as_mut_ptr(), self.c_tensor, axis0, axis1));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_swapdims(&self, dim0: i64, dim1: i64) -> Result<Tensor, TchError> {
+    pub fn swapdims(&self, dim0: i64, dim1: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_swapdims(c_tensors.as_mut_ptr(), self.c_tensor, dim0, dim1));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_swapdims_(&mut self, dim0: i64, dim1: i64) -> Result<Tensor, TchError> {
+    pub fn swapdims_(&mut self, dim0: i64, dim1: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_swapdims_(c_tensors.as_mut_ptr(), self.c_tensor, dim0, dim1));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_tr(&self) -> Result<Tensor, TchError> {
+    pub fn tr(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_t(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_t_(&mut self) -> Result<Tensor, TchError> {
+    pub fn t_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_t_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_t_copy(&self) -> Result<Tensor, TchError> {
+    pub fn t_copy(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_t_copy(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_t_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn t_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_t_copy_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_take(&self, index: &Tensor) -> Result<Tensor, TchError> {
+    pub fn take(&self, index: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_take(c_tensors.as_mut_ptr(), self.c_tensor, index.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_take_along_dim(
+    pub fn take_along_dim(
         &self,
         indices: &Tensor,
         dim: impl Into<Option<i64>>,
@@ -33783,7 +33587,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_take_along_dim_out(
+    pub fn take_along_dim_out(
         &self,
         out: &Tensor,
         indices: &Tensor,
@@ -33802,7 +33606,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_take_out(&self, out: &Tensor, index: &Tensor) -> Result<Tensor, TchError> {
+    pub fn take_out(&self, out: &Tensor, index: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_take_out(
             c_tensors.as_mut_ptr(),
@@ -33813,37 +33617,37 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_tan(&self) -> Result<Tensor, TchError> {
+    pub fn tan(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_tan(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_tan_(&mut self) -> Result<Tensor, TchError> {
+    pub fn tan_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_tan_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_tan_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn tan_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_tan_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_tanh(&self) -> Result<Tensor, TchError> {
+    pub fn tanh(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_tanh(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_tanh_(&mut self) -> Result<Tensor, TchError> {
+    pub fn tanh_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_tanh_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_tanh_backward(grad_output: &Tensor, output: &Tensor) -> Result<Tensor, TchError> {
+    pub fn tanh_backward(grad_output: &Tensor, output: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_tanh_backward(
             c_tensors.as_mut_ptr(),
@@ -33853,7 +33657,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_tanh_backward_grad_input(
+    pub fn tanh_backward_grad_input(
         grad_input: &Tensor,
         grad_output: &Tensor,
         output: &Tensor,
@@ -33868,13 +33672,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_tanh_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn tanh_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_tanh_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_tensor_split(&self, sections: i64, dim: i64) -> Result<Vec<Tensor>, TchError> {
+    pub fn tensor_split(&self, sections: i64, dim: i64) -> Result<Vec<Tensor>, TchError> {
         let c_tensors = unsafe_torch_err!(atg_tensor_split(self.c_tensor, sections, dim));
         let mut r__ = vec![];
         let mut i = 0;
@@ -33890,7 +33694,7 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_tensor_split_indices(
+    pub fn tensor_split_indices(
         &self,
         indices: impl IntList,
         dim: i64,
@@ -33915,7 +33719,7 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_tensor_split_tensor_indices_or_sections(
+    pub fn tensor_split_tensor_indices_or_sections(
         &self,
         tensor_indices_or_sections: &Tensor,
         dim: i64,
@@ -33939,7 +33743,7 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_tensordot(
+    pub fn tensordot(
         &self,
         other: &Tensor,
         dims_self: impl IntList,
@@ -33958,7 +33762,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_tensordot_out(
+    pub fn tensordot_out(
         &self,
         out: &Tensor,
         other: &Tensor,
@@ -33979,7 +33783,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_threshold<S: Into<Scalar>>(&self, threshold: S, value: S) -> Result<Tensor, TchError> {
+    pub fn threshold<S: Into<Scalar>>(&self, threshold: S, value: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_threshold(
             c_tensors.as_mut_ptr(),
@@ -33990,7 +33794,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_threshold_<S: Into<Scalar>>(
+    pub fn threshold_<S: Into<Scalar>>(
         &mut self,
         threshold: S,
         value: S,
@@ -34005,7 +33809,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_threshold_backward<S: Into<Scalar>>(
+    pub fn threshold_backward<S: Into<Scalar>>(
         &self,
         grad_output: &Tensor,
         threshold: S,
@@ -34020,7 +33824,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_threshold_backward_grad_input<S: Into<Scalar>>(
+    pub fn threshold_backward_grad_input<S: Into<Scalar>>(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -34037,7 +33841,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_threshold_out<S: Into<Scalar>>(
+    pub fn threshold_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         threshold: S,
@@ -34054,7 +33858,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_tile(&self, dims: impl IntList) -> Result<Tensor, TchError> {
+    pub fn tile(&self, dims: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_tile(
             c_tensors.as_mut_ptr(),
@@ -34065,13 +33869,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_to(&self, device: Device) -> Result<Tensor, TchError> {
+    pub fn to(&self, device: Device) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_to(c_tensors.as_mut_ptr(), self.c_tensor, device.c_int()));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_to_dense(&self, dtype: impl Into<Option<Kind>>) -> Result<Tensor, TchError> {
+    pub fn to_dense(&self, dtype: impl Into<Option<Kind>>) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_to_dense(
             c_tensors.as_mut_ptr(),
@@ -34081,7 +33885,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_to_dense_backward(&self, grad: &Tensor) -> Result<Tensor, TchError> {
+    pub fn to_dense_backward(&self, grad: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_to_dense_backward(
             c_tensors.as_mut_ptr(),
@@ -34091,7 +33895,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_to_device_(
+    pub fn to_device_(
         &self,
         device: Device,
         dtype: Kind,
@@ -34110,7 +33914,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_to_dtype(
+    pub fn to_dtype(
         &self,
         dtype: Kind,
         non_blocking: bool,
@@ -34127,7 +33931,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_to_dtype_layout(
+    pub fn to_dtype_layout(
         &self,
         options: (Kind, Device),
         non_blocking: bool,
@@ -34145,7 +33949,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_to_mkldnn(&self, dtype: impl Into<Option<Kind>>) -> Result<Tensor, TchError> {
+    pub fn g_to_mkldnn(&self, dtype: impl Into<Option<Kind>>) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_to_mkldnn(
             c_tensors.as_mut_ptr(),
@@ -34155,7 +33959,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_to_mkldnn_backward(&self, grad: &Tensor) -> Result<Tensor, TchError> {
+    pub fn to_mkldnn_backward(&self, grad: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_to_mkldnn_backward(
             c_tensors.as_mut_ptr(),
@@ -34165,7 +33969,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_to_mkldnn_out(
+    pub fn to_mkldnn_out(
         &self,
         out: &Tensor,
         dtype: impl Into<Option<Kind>>,
@@ -34180,7 +33984,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_to_other(
+    pub fn to_other(
         &self,
         other: &Tensor,
         non_blocking: bool,
@@ -34197,7 +34001,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_to_padded_tensor(
+    pub fn to_padded_tensor(
         &self,
         padding: f64,
         output_size: impl IntListOption,
@@ -34213,7 +34017,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_to_padded_tensor_out(
+    pub fn to_padded_tensor_out(
         &self,
         out: &Tensor,
         padding: f64,
@@ -34231,7 +34035,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_to_sparse(
+    pub fn to_sparse(
         &self,
         layout: Option<Layout>,
         blocksize: impl IntListOption,
@@ -34251,7 +34055,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_to_sparse_bsc(
+    pub fn to_sparse_bsc(
         &self,
         blocksize: impl IntList,
         dense_dim: impl Into<Option<i64>>,
@@ -34269,7 +34073,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_to_sparse_bsc_out(
+    pub fn to_sparse_bsc_out(
         &self,
         out: &Tensor,
         blocksize: impl IntList,
@@ -34289,7 +34093,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_to_sparse_bsr(
+    pub fn to_sparse_bsr(
         &self,
         blocksize: impl IntList,
         dense_dim: impl Into<Option<i64>>,
@@ -34307,7 +34111,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_to_sparse_bsr_out(
+    pub fn to_sparse_bsr_out(
         &self,
         out: &Tensor,
         blocksize: impl IntList,
@@ -34327,7 +34131,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_to_sparse_csc(&self, dense_dim: impl Into<Option<i64>>) -> Result<Tensor, TchError> {
+    pub fn to_sparse_csc(&self, dense_dim: impl Into<Option<i64>>) -> Result<Tensor, TchError> {
         let dense_dim = dense_dim.into();
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_to_sparse_csc(
@@ -34339,7 +34143,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_to_sparse_csc_out(
+    pub fn to_sparse_csc_out(
         &self,
         out: &Tensor,
         dense_dim: impl Into<Option<i64>>,
@@ -34356,7 +34160,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_to_sparse_csr(&self, dense_dim: impl Into<Option<i64>>) -> Result<Tensor, TchError> {
+    pub fn to_sparse_csr(&self, dense_dim: impl Into<Option<i64>>) -> Result<Tensor, TchError> {
         let dense_dim = dense_dim.into();
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_to_sparse_csr(
@@ -34368,7 +34172,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_to_sparse_csr_out(
+    pub fn to_sparse_csr_out(
         &self,
         out: &Tensor,
         dense_dim: impl Into<Option<i64>>,
@@ -34385,7 +34189,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_to_sparse_out(
+    pub fn to_sparse_out(
         &self,
         out: &Tensor,
         layout: Option<Layout>,
@@ -34407,7 +34211,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_to_sparse_sparse_dim(&self, sparse_dim: i64) -> Result<Tensor, TchError> {
+    pub fn to_sparse_sparse_dim(&self, sparse_dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_to_sparse_sparse_dim(
             c_tensors.as_mut_ptr(),
@@ -34417,7 +34221,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_to_sparse_sparse_dim_out(
+    pub fn to_sparse_sparse_dim_out(
         &self,
         out: &Tensor,
         sparse_dim: i64,
@@ -34432,7 +34236,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_topk(
+    pub fn topk(
         &self,
         k: i64,
         dim: i64,
@@ -34451,7 +34255,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_topk_values(
+    pub fn topk_values(
         &self,
         values: &Tensor,
         indices: &Tensor,
@@ -34474,19 +34278,19 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_totype(&self, scalar_type: Kind) -> Result<Tensor, TchError> {
+    pub fn totype(&self, scalar_type: Kind) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_totype(c_tensors.as_mut_ptr(), self.c_tensor, scalar_type.c_int()));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_trace(&self) -> Result<Tensor, TchError> {
+    pub fn trace(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_trace(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_trace_backward(grad: &Tensor, sizes: impl IntList) -> Result<Tensor, TchError> {
+    pub fn trace_backward(grad: &Tensor, sizes: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_trace_backward(
             c_tensors.as_mut_ptr(),
@@ -34497,31 +34301,31 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_trace_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn trace_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_trace_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_transpose(&self, dim0: i64, dim1: i64) -> Result<Tensor, TchError> {
+    pub fn transpose(&self, dim0: i64, dim1: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_transpose(c_tensors.as_mut_ptr(), self.c_tensor, dim0, dim1));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_transpose_(&mut self, dim0: i64, dim1: i64) -> Result<Tensor, TchError> {
+    pub fn transpose_(&mut self, dim0: i64, dim1: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_transpose_(c_tensors.as_mut_ptr(), self.c_tensor, dim0, dim1));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_transpose_copy(&self, dim0: i64, dim1: i64) -> Result<Tensor, TchError> {
+    pub fn transpose_copy(&self, dim0: i64, dim1: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_transpose_copy(c_tensors.as_mut_ptr(), self.c_tensor, dim0, dim1));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_transpose_copy_int_out(
+    pub fn transpose_copy_int_out(
         &self,
         out: &Tensor,
         dim0: i64,
@@ -34538,31 +34342,31 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_trapezoid(y: &Tensor, dim: i64) -> Result<Tensor, TchError> {
+    pub fn trapezoid(y: &Tensor, dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_trapezoid(c_tensors.as_mut_ptr(), y.c_tensor, dim));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_trapezoid_x(y: &Tensor, x: &Tensor, dim: i64) -> Result<Tensor, TchError> {
+    pub fn trapezoid_x(y: &Tensor, x: &Tensor, dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_trapezoid_x(c_tensors.as_mut_ptr(), y.c_tensor, x.c_tensor, dim));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_trapz(y: &Tensor, x: &Tensor, dim: i64) -> Result<Tensor, TchError> {
+    pub fn trapz(y: &Tensor, x: &Tensor, dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_trapz(c_tensors.as_mut_ptr(), y.c_tensor, x.c_tensor, dim));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_trapz_dx(y: &Tensor, dx: f64, dim: i64) -> Result<Tensor, TchError> {
+    pub fn trapz_dx(y: &Tensor, dx: f64, dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_trapz_dx(c_tensors.as_mut_ptr(), y.c_tensor, dx, dim));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_triangular_solve(
+    pub fn triangular_solve(
         &self,
         a: &Tensor,
         upper: bool,
@@ -34581,7 +34385,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_triangular_solve_x(
+    pub fn triangular_solve_x(
         &self,
         x: &Tensor,
         m: &Tensor,
@@ -34604,19 +34408,19 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_tril(&self, diagonal: i64) -> Result<Tensor, TchError> {
+    pub fn tril(&self, diagonal: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_tril(c_tensors.as_mut_ptr(), self.c_tensor, diagonal));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_tril_(&mut self, diagonal: i64) -> Result<Tensor, TchError> {
+    pub fn tril_(&mut self, diagonal: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_tril_(c_tensors.as_mut_ptr(), self.c_tensor, diagonal));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_tril_indices(
+    pub fn tril_indices(
         row: i64,
         col: i64,
         offset: i64,
@@ -34634,7 +34438,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_tril_indices_out(
+    pub fn tril_indices_out(
         out: &Tensor,
         row: i64,
         col: i64,
@@ -34651,7 +34455,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_tril_out(&self, out: &Tensor, diagonal: i64) -> Result<Tensor, TchError> {
+    pub fn tril_out(&self, out: &Tensor, diagonal: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_tril_out(
             c_tensors.as_mut_ptr(),
@@ -34662,7 +34466,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_triplet_margin_loss(
+    pub fn triplet_margin_loss(
         anchor: &Tensor,
         positive: &Tensor,
         negative: &Tensor,
@@ -34687,19 +34491,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_triu(&self, diagonal: i64) -> Result<Tensor, TchError> {
+    pub fn triu(&self, diagonal: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_triu(c_tensors.as_mut_ptr(), self.c_tensor, diagonal));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_triu_(&mut self, diagonal: i64) -> Result<Tensor, TchError> {
+    pub fn triu_(&mut self, diagonal: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_triu_(c_tensors.as_mut_ptr(), self.c_tensor, diagonal));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_triu_indices(
+    pub fn triu_indices(
         row: i64,
         col: i64,
         offset: i64,
@@ -34717,7 +34521,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_triu_indices_out(
+    pub fn triu_indices_out(
         out: &Tensor,
         row: i64,
         col: i64,
@@ -34734,7 +34538,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_triu_out(&self, out: &Tensor, diagonal: i64) -> Result<Tensor, TchError> {
+    pub fn triu_out(&self, out: &Tensor, diagonal: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_triu_out(
             c_tensors.as_mut_ptr(),
@@ -34745,19 +34549,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_true_divide(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn true_divide(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_true_divide(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_true_divide_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn true_divide_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_true_divide_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_true_divide_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn true_divide_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_true_divide_out(
             c_tensors.as_mut_ptr(),
@@ -34768,7 +34572,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_true_divide_scalar<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
+    pub fn true_divide_scalar<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_true_divide_scalar(
             c_tensors.as_mut_ptr(),
@@ -34778,7 +34582,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_true_divide_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn true_divide_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_true_divide_scalar_(
             c_tensors.as_mut_ptr(),
@@ -34788,31 +34592,31 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_trunc(&self) -> Result<Tensor, TchError> {
+    pub fn trunc(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_trunc(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_trunc_(&mut self) -> Result<Tensor, TchError> {
+    pub fn trunc_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_trunc_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_trunc_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn trunc_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_trunc_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_type_as(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn type_as(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_type_as(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_unbind(&self, dim: i64) -> Result<Vec<Tensor>, TchError> {
+    pub fn unbind(&self, dim: i64) -> Result<Vec<Tensor>, TchError> {
         let c_tensors = unsafe_torch_err!(atg_unbind(self.c_tensor, dim));
         let mut r__ = vec![];
         let mut i = 0;
@@ -34828,7 +34632,7 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_unbind_copy(&self, dim: i64) -> Result<Vec<Tensor>, TchError> {
+    pub fn unbind_copy(&self, dim: i64) -> Result<Vec<Tensor>, TchError> {
         let c_tensors = unsafe_torch_err!(atg_unbind_copy(self.c_tensor, dim));
         let mut r__ = vec![];
         let mut i = 0;
@@ -34844,7 +34648,7 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_unbind_copy_int_out<T: Borrow<Tensor>>(
+    pub fn unbind_copy_int_out<T: Borrow<Tensor>>(
         &self,
         out: &[T],
         dim: i64,
@@ -34858,7 +34662,7 @@ impl Tensor {
         Ok(())
     }
 
-    pub fn f_unflatten(&self, dim: i64, sizes: impl IntList) -> Result<Tensor, TchError> {
+    pub fn unflatten(&self, dim: i64, sizes: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_unflatten(
             c_tensors.as_mut_ptr(),
@@ -34870,7 +34674,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_unflatten_dense_tensors<T: Borrow<Tensor>>(
+    pub fn unflatten_dense_tensors<T: Borrow<Tensor>>(
         flat: &Tensor,
         tensors: &[T],
     ) -> Result<Vec<Tensor>, TchError> {
@@ -34893,13 +34697,13 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_unfold(&self, dimension: i64, size: i64, step: i64) -> Result<Tensor, TchError> {
+    pub fn unfold(&self, dimension: i64, size: i64, step: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_unfold(c_tensors.as_mut_ptr(), self.c_tensor, dimension, size, step));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_unfold_backward(
+    pub fn unfold_backward(
         grad_in: &Tensor,
         input_sizes: impl IntList,
         dim: i64,
@@ -34919,7 +34723,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_unfold_backward_out(
+    pub fn unfold_backward_out(
         out: &Tensor,
         grad_in: &Tensor,
         input_sizes: impl IntList,
@@ -34941,7 +34745,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_unfold_copy(&self, dimension: i64, size: i64, step: i64) -> Result<Tensor, TchError> {
+    pub fn unfold_copy(&self, dimension: i64, size: i64, step: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_unfold_copy(
             c_tensors.as_mut_ptr(),
@@ -34953,7 +34757,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_unfold_copy_out(
+    pub fn unfold_copy_out(
         &self,
         out: &Tensor,
         dimension: i64,
@@ -34972,19 +34776,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_uniform(&self, from: f64, to: f64) -> Result<Tensor, TchError> {
+    pub fn uniform(&self, from: f64, to: f64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_uniform(c_tensors.as_mut_ptr(), self.c_tensor, from, to));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_uniform_(&mut self, from: f64, to: f64) -> Result<Tensor, TchError> {
+    pub fn uniform_(&mut self, from: f64, to: f64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_uniform_(c_tensors.as_mut_ptr(), self.c_tensor, from, to));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_uniform_out(&self, out: &Tensor, from: f64, to: f64) -> Result<Tensor, TchError> {
+    pub fn uniform_out(&self, out: &Tensor, from: f64, to: f64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_uniform_out(
             c_tensors.as_mut_ptr(),
@@ -34996,7 +34800,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_unique_consecutive(
+    pub fn unique_consecutive(
         &self,
         return_inverse: bool,
         return_counts: bool,
@@ -35019,7 +34823,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_unique_consecutive_out(
+    pub fn unique_consecutive_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -35048,7 +34852,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_unique_dim(
+    pub fn unique_dim(
         &self,
         dim: i64,
         sorted: bool,
@@ -35071,7 +34875,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_unique_dim_consecutive(
+    pub fn unique_dim_consecutive(
         &self,
         dim: i64,
         return_inverse: bool,
@@ -35092,7 +34896,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_unique_dim_consecutive_out(
+    pub fn unique_dim_consecutive_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -35119,7 +34923,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_unique_dim_out(
+    pub fn unique_dim_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -35148,7 +34952,7 @@ impl Tensor {
         ))
     }
 
-    pub fn f_unsafe_chunk(&self, chunks: i64, dim: i64) -> Result<Vec<Tensor>, TchError> {
+    pub fn unsafe_chunk(&self, chunks: i64, dim: i64) -> Result<Vec<Tensor>, TchError> {
         let c_tensors = unsafe_torch_err!(atg_unsafe_chunk(self.c_tensor, chunks, dim));
         let mut r__ = vec![];
         let mut i = 0;
@@ -35164,7 +34968,7 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_unsafe_split(&self, split_size: i64, dim: i64) -> Result<Vec<Tensor>, TchError> {
+    pub fn unsafe_split(&self, split_size: i64, dim: i64) -> Result<Vec<Tensor>, TchError> {
         let c_tensors = unsafe_torch_err!(atg_unsafe_split(self.c_tensor, split_size, dim));
         let mut r__ = vec![];
         let mut i = 0;
@@ -35180,7 +34984,7 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_unsafe_split_tensor_out<T: Borrow<Tensor>>(
+    pub fn unsafe_split_tensor_out<T: Borrow<Tensor>>(
         &self,
         out: &[T],
         split_size: i64,
@@ -35196,7 +35000,7 @@ impl Tensor {
         Ok(())
     }
 
-    pub fn f_unsafe_split_with_sizes(
+    pub fn unsafe_split_with_sizes(
         &self,
         split_sizes: impl IntList,
         dim: i64,
@@ -35221,7 +35025,7 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_unsafe_split_with_sizes_out<T: Borrow<Tensor>>(
+    pub fn unsafe_split_with_sizes_out<T: Borrow<Tensor>>(
         &self,
         out: &[T],
         split_sizes: impl IntList,
@@ -35238,25 +35042,25 @@ impl Tensor {
         Ok(())
     }
 
-    pub fn f_unsqueeze(&self, dim: i64) -> Result<Tensor, TchError> {
+    pub fn unsqueeze(&self, dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_unsqueeze(c_tensors.as_mut_ptr(), self.c_tensor, dim));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_unsqueeze_(&mut self, dim: i64) -> Result<Tensor, TchError> {
+    pub fn unsqueeze_(&mut self, dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_unsqueeze_(c_tensors.as_mut_ptr(), self.c_tensor, dim));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_unsqueeze_copy(&self, dim: i64) -> Result<Tensor, TchError> {
+    pub fn unsqueeze_copy(&self, dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_unsqueeze_copy(c_tensors.as_mut_ptr(), self.c_tensor, dim));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_unsqueeze_copy_out(&self, out: &Tensor, dim: i64) -> Result<Tensor, TchError> {
+    pub fn unsqueeze_copy_out(&self, out: &Tensor, dim: i64) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_unsqueeze_copy_out(
             c_tensors.as_mut_ptr(),
@@ -35267,7 +35071,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_bicubic2d(
+    pub fn upsample_bicubic2d(
         &self,
         output_size: impl IntList,
         align_corners: bool,
@@ -35291,7 +35095,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_bicubic2d_backward(
+    pub fn upsample_bicubic2d_backward(
         grad_output: &Tensor,
         output_size: impl IntList,
         input_size: impl IntList,
@@ -35318,7 +35122,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_bicubic2d_backward_grad_input(
+    pub fn upsample_bicubic2d_backward_grad_input(
         grad_input: &Tensor,
         grad_output: &Tensor,
         output_size: impl IntList,
@@ -35347,7 +35151,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_bicubic2d_out(
+    pub fn upsample_bicubic2d_out(
         &self,
         out: &Tensor,
         output_size: impl IntList,
@@ -35373,7 +35177,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_bicubic2d_vec(
+    pub fn upsample_bicubic2d_vec(
         &self,
         output_size: impl IntListOption,
         align_corners: bool,
@@ -35392,7 +35196,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_bilinear2d(
+    pub fn upsample_bilinear2d(
         &self,
         output_size: impl IntList,
         align_corners: bool,
@@ -35416,7 +35220,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_bilinear2d_backward(
+    pub fn upsample_bilinear2d_backward(
         grad_output: &Tensor,
         output_size: impl IntList,
         input_size: impl IntList,
@@ -35443,7 +35247,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_bilinear2d_backward_grad_input(
+    pub fn upsample_bilinear2d_backward_grad_input(
         grad_input: &Tensor,
         grad_output: &Tensor,
         output_size: impl IntList,
@@ -35472,7 +35276,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_bilinear2d_out(
+    pub fn upsample_bilinear2d_out(
         &self,
         out: &Tensor,
         output_size: impl IntList,
@@ -35498,7 +35302,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_bilinear2d_vec(
+    pub fn upsample_bilinear2d_vec(
         &self,
         output_size: impl IntListOption,
         align_corners: bool,
@@ -35517,7 +35321,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_linear1d(
+    pub fn upsample_linear1d(
         &self,
         output_size: impl IntList,
         align_corners: bool,
@@ -35537,7 +35341,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_linear1d_backward(
+    pub fn upsample_linear1d_backward(
         grad_output: &Tensor,
         output_size: impl IntList,
         input_size: impl IntList,
@@ -35560,7 +35364,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_linear1d_backward_grad_input(
+    pub fn upsample_linear1d_backward_grad_input(
         grad_input: &Tensor,
         grad_output: &Tensor,
         output_size: impl IntList,
@@ -35585,7 +35389,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_linear1d_out(
+    pub fn upsample_linear1d_out(
         &self,
         out: &Tensor,
         output_size: impl IntList,
@@ -35607,7 +35411,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_linear1d_vec(
+    pub fn upsample_linear1d_vec(
         &self,
         output_size: impl IntListOption,
         align_corners: bool,
@@ -35626,7 +35430,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_nearest1d(
+    pub fn upsample_nearest1d(
         &self,
         output_size: impl IntList,
         scales: impl Into<Option<f64>>,
@@ -35644,7 +35448,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_nearest1d_backward(
+    pub fn upsample_nearest1d_backward(
         grad_output: &Tensor,
         output_size: impl IntList,
         input_size: impl IntList,
@@ -35665,7 +35469,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_nearest1d_backward_grad_input(
+    pub fn upsample_nearest1d_backward_grad_input(
         grad_input: &Tensor,
         grad_output: &Tensor,
         output_size: impl IntList,
@@ -35688,7 +35492,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_nearest1d_out(
+    pub fn upsample_nearest1d_out(
         &self,
         out: &Tensor,
         output_size: impl IntList,
@@ -35708,7 +35512,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_nearest1d_vec(
+    pub fn upsample_nearest1d_vec(
         &self,
         output_size: impl IntListOption,
         scale_factors: impl DoubleList,
@@ -35725,7 +35529,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_nearest2d(
+    pub fn upsample_nearest2d(
         &self,
         output_size: impl IntList,
         scales_h: impl Into<Option<f64>>,
@@ -35747,7 +35551,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_nearest2d_backward(
+    pub fn upsample_nearest2d_backward(
         grad_output: &Tensor,
         output_size: impl IntList,
         input_size: impl IntList,
@@ -35772,7 +35576,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_nearest2d_backward_grad_input(
+    pub fn upsample_nearest2d_backward_grad_input(
         grad_input: &Tensor,
         grad_output: &Tensor,
         output_size: impl IntList,
@@ -35799,7 +35603,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_nearest2d_out(
+    pub fn upsample_nearest2d_out(
         &self,
         out: &Tensor,
         output_size: impl IntList,
@@ -35823,7 +35627,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_nearest2d_vec(
+    pub fn upsample_nearest2d_vec(
         &self,
         output_size: impl IntListOption,
         scale_factors: impl DoubleList,
@@ -35840,7 +35644,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_nearest3d(
+    pub fn upsample_nearest3d(
         &self,
         output_size: impl IntList,
         scales_d: impl Into<Option<f64>>,
@@ -35866,7 +35670,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_nearest3d_backward(
+    pub fn upsample_nearest3d_backward(
         grad_output: &Tensor,
         output_size: impl IntList,
         input_size: impl IntList,
@@ -35895,7 +35699,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_nearest3d_backward_grad_input(
+    pub fn upsample_nearest3d_backward_grad_input(
         grad_input: &Tensor,
         grad_output: &Tensor,
         output_size: impl IntList,
@@ -35926,7 +35730,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_nearest3d_out(
+    pub fn upsample_nearest3d_out(
         &self,
         out: &Tensor,
         output_size: impl IntList,
@@ -35954,7 +35758,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_nearest3d_vec(
+    pub fn upsample_nearest3d_vec(
         &self,
         output_size: impl IntListOption,
         scale_factors: impl DoubleList,
@@ -35971,7 +35775,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_trilinear3d(
+    pub fn upsample_trilinear3d(
         &self,
         output_size: impl IntList,
         align_corners: bool,
@@ -35999,7 +35803,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_trilinear3d_backward(
+    pub fn upsample_trilinear3d_backward(
         grad_output: &Tensor,
         output_size: impl IntList,
         input_size: impl IntList,
@@ -36030,7 +35834,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_trilinear3d_backward_grad_input(
+    pub fn upsample_trilinear3d_backward_grad_input(
         grad_input: &Tensor,
         grad_output: &Tensor,
         output_size: impl IntList,
@@ -36063,7 +35867,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_trilinear3d_out(
+    pub fn upsample_trilinear3d_out(
         &self,
         out: &Tensor,
         output_size: impl IntList,
@@ -36093,7 +35897,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_upsample_trilinear3d_vec(
+    pub fn upsample_trilinear3d_vec(
         &self,
         output_size: impl IntListOption,
         align_corners: bool,
@@ -36112,7 +35916,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_value_selecting_reduction_backward(
+    pub fn value_selecting_reduction_backward(
         grad: &Tensor,
         dim: i64,
         indices: &Tensor,
@@ -36132,25 +35936,25 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_values(&self) -> Result<Tensor, TchError> {
+    pub fn values(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_values(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_values_copy(&self) -> Result<Tensor, TchError> {
+    pub fn values_copy(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_values_copy(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_values_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn values_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_values_copy_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_vander(
+    pub fn vander(
         x: &Tensor,
         n: impl Into<Option<i64>>,
         increasing: bool,
@@ -36167,7 +35971,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_var(&self, unbiased: bool) -> Result<Tensor, TchError> {
+    pub fn var(&self, unbiased: bool) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_var(
             c_tensors.as_mut_ptr(),
@@ -36177,7 +35981,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_var_correction(
+    pub fn var_correction(
         &self,
         dim: impl IntListOption,
         correction: impl Into<Option<i64>>,
@@ -36197,7 +36001,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_var_correction_out(
+    pub fn var_correction_out(
         &self,
         out: &Tensor,
         dim: impl IntListOption,
@@ -36219,7 +36023,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_var_dim(
+    pub fn var_dim(
         &self,
         dim: impl IntListOption,
         unbiased: bool,
@@ -36237,7 +36041,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_var_mean(&self, unbiased: bool) -> Result<(Tensor, Tensor), TchError> {
+    pub fn var_mean(&self, unbiased: bool) -> Result<(Tensor, Tensor), TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 2];
         unsafe_torch_err!(atg_var_mean(
             c_tensors.as_mut_ptr(),
@@ -36247,7 +36051,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_var_mean_correction(
+    pub fn var_mean_correction(
         &self,
         dim: impl IntListOption,
         correction: impl Into<Option<i64>>,
@@ -36267,7 +36071,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_var_mean_correction_out(
+    pub fn var_mean_correction_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -36291,7 +36095,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_var_mean_dim(
+    pub fn var_mean_dim(
         &self,
         dim: impl IntListOption,
         unbiased: bool,
@@ -36309,7 +36113,7 @@ impl Tensor {
         Ok((Tensor { c_tensor: c_tensors[0] }, Tensor { c_tensor: c_tensors[1] }))
     }
 
-    pub fn f_var_out(
+    pub fn var_out(
         &self,
         out: &Tensor,
         dim: impl IntListOption,
@@ -36329,13 +36133,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_vdot(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn vdot(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_vdot(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_vdot_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn vdot_out(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_vdot_out(
             c_tensors.as_mut_ptr(),
@@ -36346,7 +36150,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_view_(&self, size: impl IntList) -> Result<Tensor, TchError> {
+    pub fn view_(&self, size: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_view(
             c_tensors.as_mut_ptr(),
@@ -36357,25 +36161,25 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_view_as(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn view_as(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_view_as(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_view_as_complex(&self) -> Result<Tensor, TchError> {
+    pub fn view_as_complex(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_view_as_complex(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_view_as_complex_copy(&self) -> Result<Tensor, TchError> {
+    pub fn view_as_complex_copy(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_view_as_complex_copy(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_view_as_complex_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn view_as_complex_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_view_as_complex_copy_out(
             c_tensors.as_mut_ptr(),
@@ -36385,19 +36189,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_view_as_real(&self) -> Result<Tensor, TchError> {
+    pub fn view_as_real(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_view_as_real(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_view_as_real_copy(&self) -> Result<Tensor, TchError> {
+    pub fn view_as_real_copy(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_view_as_real_copy(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_view_as_real_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn view_as_real_copy_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_view_as_real_copy_out(
             c_tensors.as_mut_ptr(),
@@ -36407,7 +36211,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_view_copy(&self, size: impl IntList) -> Result<Tensor, TchError> {
+    pub fn view_copy(&self, size: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_view_copy(
             c_tensors.as_mut_ptr(),
@@ -36418,7 +36222,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_view_copy_dtype(&self, dtype: Kind) -> Result<Tensor, TchError> {
+    pub fn view_copy_dtype(&self, dtype: Kind) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_view_copy_dtype(
             c_tensors.as_mut_ptr(),
@@ -36428,7 +36232,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_view_copy_dtype_out(&self, out: &Tensor, dtype: Kind) -> Result<Tensor, TchError> {
+    pub fn view_copy_dtype_out(&self, out: &Tensor, dtype: Kind) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_view_copy_dtype_out(
             c_tensors.as_mut_ptr(),
@@ -36439,7 +36243,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_view_copy_out(&self, out: &Tensor, size: impl IntList) -> Result<Tensor, TchError> {
+    pub fn view_copy_out(&self, out: &Tensor, size: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_view_copy_out(
             c_tensors.as_mut_ptr(),
@@ -36451,13 +36255,13 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_view_dtype(&self, dtype: Kind) -> Result<Tensor, TchError> {
+    pub fn view_dtype(&self, dtype: Kind) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_view_dtype(c_tensors.as_mut_ptr(), self.c_tensor, dtype.c_int()));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_vsplit(&self, sections: i64) -> Result<Vec<Tensor>, TchError> {
+    pub fn vsplit(&self, sections: i64) -> Result<Vec<Tensor>, TchError> {
         let c_tensors = unsafe_torch_err!(atg_vsplit(self.c_tensor, sections));
         let mut r__ = vec![];
         let mut i = 0;
@@ -36473,7 +36277,7 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_vsplit_array(&self, indices: impl IntList) -> Result<Vec<Tensor>, TchError> {
+    pub fn vsplit_array(&self, indices: impl IntList) -> Result<Vec<Tensor>, TchError> {
         let c_tensors =
             unsafe_torch_err!(atg_vsplit_array(self.c_tensor, indices.as_ptr(), indices.len_i32()));
         let mut r__ = vec![];
@@ -36490,7 +36294,7 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_vstack<T: Borrow<Tensor>>(tensors: &[T]) -> Result<Tensor, TchError> {
+    pub fn vstack<T: Borrow<Tensor>>(tensors: &[T]) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_vstack(
             c_tensors.as_mut_ptr(),
@@ -36500,10 +36304,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_vstack_out<T: Borrow<Tensor>>(
-        out: &Tensor,
-        tensors: &[T],
-    ) -> Result<Tensor, TchError> {
+    pub fn vstack_out<T: Borrow<Tensor>>(out: &Tensor, tensors: &[T]) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_vstack_out(
             c_tensors.as_mut_ptr(),
@@ -36514,7 +36315,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_where_(condition: &Tensor) -> Result<Vec<Tensor>, TchError> {
+    pub fn where_(condition: &Tensor) -> Result<Vec<Tensor>, TchError> {
         let c_tensors = unsafe_torch_err!(atg_where(condition.c_tensor));
         let mut r__ = vec![];
         let mut i = 0;
@@ -36530,7 +36331,7 @@ impl Tensor {
         Ok(r__)
     }
 
-    pub fn f_where_scalar<S: Into<Scalar>>(
+    pub fn where_scalar<S: Into<Scalar>>(
         condition: &Tensor,
         self_scalar: S,
         other: S,
@@ -36545,7 +36346,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_where_scalarother<S: Into<Scalar>>(
+    pub fn where_scalarother<S: Into<Scalar>>(
         &self,
         condition: &Tensor,
         other: S,
@@ -36560,7 +36361,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_where_scalarself<S: Into<Scalar>>(
+    pub fn where_scalarself<S: Into<Scalar>>(
         condition: &Tensor,
         self_scalar: S,
         other: &Tensor,
@@ -36575,7 +36376,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_where_self(&self, condition: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn where_self(&self, condition: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_where_self(
             c_tensors.as_mut_ptr(),
@@ -36586,7 +36387,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_where_self_out(
+    pub fn where_self_out(
         &self,
         out: &Tensor,
         condition: &Tensor,
@@ -36603,19 +36404,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_xlogy(&self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn xlogy(&self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_xlogy(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_xlogy_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn xlogy_(&mut self, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_xlogy_(c_tensors.as_mut_ptr(), self.c_tensor, other.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_xlogy_outscalar_other<S: Into<Scalar>>(
+    pub fn xlogy_outscalar_other<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
@@ -36630,7 +36431,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_xlogy_outscalar_self<S: Into<Scalar>>(
+    pub fn xlogy_outscalar_self<S: Into<Scalar>>(
         out: &Tensor,
         self_scalar: S,
         other: &Tensor,
@@ -36645,7 +36446,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_xlogy_outtensor(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
+    pub fn xlogy_outtensor(&self, out: &Tensor, other: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_xlogy_outtensor(
             c_tensors.as_mut_ptr(),
@@ -36656,7 +36457,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_xlogy_scalar_other<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
+    pub fn xlogy_scalar_other<S: Into<Scalar>>(&self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_xlogy_scalar_other(
             c_tensors.as_mut_ptr(),
@@ -36666,7 +36467,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_xlogy_scalar_other_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
+    pub fn xlogy_scalar_other_<S: Into<Scalar>>(&mut self, other: S) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_xlogy_scalar_other_(
             c_tensors.as_mut_ptr(),
@@ -36676,7 +36477,7 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_xlogy_scalar_self<S: Into<Scalar>>(
+    pub fn xlogy_scalar_self<S: Into<Scalar>>(
         self_scalar: S,
         other: &Tensor,
     ) -> Result<Tensor, TchError> {
@@ -36689,25 +36490,25 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_zero(&self) -> Result<Tensor, TchError> {
+    pub fn zero(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_zero(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_zero_(&mut self) -> Result<Tensor, TchError> {
+    pub fn zero_(&mut self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_zero_(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_zero_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn zero_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_zero_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_zeros(size: impl IntList, options: (Kind, Device)) -> Result<Tensor, TchError> {
+    pub fn zeros(size: impl IntList, options: (Kind, Device)) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_zeros(
             c_tensors.as_mut_ptr(),
@@ -36719,19 +36520,19 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_zeros_like(&self) -> Result<Tensor, TchError> {
+    pub fn zeros_like(&self) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_zeros_like(c_tensors.as_mut_ptr(), self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_zeros_like_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
+    pub fn zeros_like_out(&self, out: &Tensor) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_zeros_like_out(c_tensors.as_mut_ptr(), out.c_tensor, self.c_tensor));
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
-    pub fn f_zeros_out(out: &Tensor, size: impl IntList) -> Result<Tensor, TchError> {
+    pub fn zeros_out(out: &Tensor, size: impl IntList) -> Result<Tensor, TchError> {
         let mut c_tensors = [std::ptr::null_mut(); 1];
         unsafe_torch_err!(atg_zeros_out(
             c_tensors.as_mut_ptr(),

--- a/src/wrappers/tensor_generated.rs
+++ b/src/wrappers/tensor_generated.rs
@@ -6,220 +6,224 @@ use std::convert::Into;
 use torch_sys::*;
 
 impl Tensor {
-    pub fn internal_and_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_internal_and_(other).unwrap()
+    pub fn f_internal_and_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.internal_and_(other).unwrap()
     }
 
-    pub fn internal_and_tensor_(&mut self, other: &Tensor) -> Tensor {
-        self.f_internal_and_tensor_(other).unwrap()
+    pub fn f_internal_and_tensor_(&mut self, other: &Tensor) -> Tensor {
+        self.internal_and_tensor_(other).unwrap()
     }
 
-    pub fn internal_iand_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_internal_iand_(other).unwrap()
+    pub fn f_internal_iand_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.internal_iand_(other).unwrap()
     }
 
-    pub fn internal_iand_tensor_(&mut self, other: &Tensor) -> Tensor {
-        self.f_internal_iand_tensor_(other).unwrap()
+    pub fn f_internal_iand_tensor_(&mut self, other: &Tensor) -> Tensor {
+        self.internal_iand_tensor_(other).unwrap()
     }
 
-    pub fn internal_ilshift_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_internal_ilshift_(other).unwrap()
+    pub fn f_internal_ilshift_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.internal_ilshift_(other).unwrap()
     }
 
-    pub fn internal_ilshift_tensor_(&mut self, other: &Tensor) -> Tensor {
-        self.f_internal_ilshift_tensor_(other).unwrap()
+    pub fn f_internal_ilshift_tensor_(&mut self, other: &Tensor) -> Tensor {
+        self.internal_ilshift_tensor_(other).unwrap()
     }
 
-    pub fn internal_ior_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_internal_ior_(other).unwrap()
+    pub fn f_internal_ior_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.internal_ior_(other).unwrap()
     }
 
-    pub fn internal_ior_tensor_(&mut self, other: &Tensor) -> Tensor {
-        self.f_internal_ior_tensor_(other).unwrap()
+    pub fn f_internal_ior_tensor_(&mut self, other: &Tensor) -> Tensor {
+        self.internal_ior_tensor_(other).unwrap()
     }
 
-    pub fn internal_irshift_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_internal_irshift_(other).unwrap()
+    pub fn f_internal_irshift_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.internal_irshift_(other).unwrap()
     }
 
-    pub fn internal_irshift_tensor_(&mut self, other: &Tensor) -> Tensor {
-        self.f_internal_irshift_tensor_(other).unwrap()
+    pub fn f_internal_irshift_tensor_(&mut self, other: &Tensor) -> Tensor {
+        self.internal_irshift_tensor_(other).unwrap()
     }
 
-    pub fn internal_ixor_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_internal_ixor_(other).unwrap()
+    pub fn f_internal_ixor_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.internal_ixor_(other).unwrap()
     }
 
-    pub fn internal_ixor_tensor_(&mut self, other: &Tensor) -> Tensor {
-        self.f_internal_ixor_tensor_(other).unwrap()
+    pub fn f_internal_ixor_tensor_(&mut self, other: &Tensor) -> Tensor {
+        self.internal_ixor_tensor_(other).unwrap()
     }
 
-    pub fn internal_lshift_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_internal_lshift_(other).unwrap()
+    pub fn f_internal_lshift_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.internal_lshift_(other).unwrap()
     }
 
-    pub fn internal_lshift_scalar_out_<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
-        self.f_internal_lshift_scalar_out_(out, other).unwrap()
+    pub fn f_internal_lshift_scalar_out_<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
+        self.internal_lshift_scalar_out_(out, other).unwrap()
     }
 
-    pub fn internal_lshift_tensor_(&mut self, other: &Tensor) -> Tensor {
-        self.f_internal_lshift_tensor_(other).unwrap()
+    pub fn f_internal_lshift_tensor_(&mut self, other: &Tensor) -> Tensor {
+        self.internal_lshift_tensor_(other).unwrap()
     }
 
-    pub fn internal_lshift_tensor_out_(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_internal_lshift_tensor_out_(out, other).unwrap()
+    pub fn f_internal_lshift_tensor_out_(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.internal_lshift_tensor_out_(out, other).unwrap()
     }
 
-    pub fn internal_or_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_internal_or_(other).unwrap()
+    pub fn f_internal_or_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.internal_or_(other).unwrap()
     }
 
-    pub fn internal_or_tensor_(&mut self, other: &Tensor) -> Tensor {
-        self.f_internal_or_tensor_(other).unwrap()
+    pub fn f_internal_or_tensor_(&mut self, other: &Tensor) -> Tensor {
+        self.internal_or_tensor_(other).unwrap()
     }
 
-    pub fn internal_rshift_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_internal_rshift_(other).unwrap()
+    pub fn f_internal_rshift_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.internal_rshift_(other).unwrap()
     }
 
-    pub fn internal_rshift_scalar_out_<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
-        self.f_internal_rshift_scalar_out_(out, other).unwrap()
+    pub fn f_internal_rshift_scalar_out_<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
+        self.internal_rshift_scalar_out_(out, other).unwrap()
     }
 
-    pub fn internal_rshift_tensor_(&mut self, other: &Tensor) -> Tensor {
-        self.f_internal_rshift_tensor_(other).unwrap()
+    pub fn f_internal_rshift_tensor_(&mut self, other: &Tensor) -> Tensor {
+        self.internal_rshift_tensor_(other).unwrap()
     }
 
-    pub fn internal_rshift_tensor_out_(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_internal_rshift_tensor_out_(out, other).unwrap()
+    pub fn f_internal_rshift_tensor_out_(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.internal_rshift_tensor_out_(out, other).unwrap()
     }
 
-    pub fn internal_xor_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_internal_xor_(other).unwrap()
+    pub fn f_internal_xor_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.internal_xor_(other).unwrap()
     }
 
-    pub fn internal_xor_tensor_(&mut self, other: &Tensor) -> Tensor {
-        self.f_internal_xor_tensor_(other).unwrap()
+    pub fn f_internal_xor_tensor_(&mut self, other: &Tensor) -> Tensor {
+        self.internal_xor_tensor_(other).unwrap()
     }
 
-    pub fn internal_adaptive_avg_pool2d(&self, output_size: impl IntList) -> Tensor {
-        self.f_internal_adaptive_avg_pool2d(output_size).unwrap()
+    pub fn f_internal_adaptive_avg_pool2d(&self, output_size: impl IntList) -> Tensor {
+        self.internal_adaptive_avg_pool2d(output_size).unwrap()
     }
 
-    pub fn internal_adaptive_avg_pool2d_backward(&self, grad_output: &Tensor) -> Tensor {
-        self.f_internal_adaptive_avg_pool2d_backward(grad_output).unwrap()
+    pub fn f_internal_adaptive_avg_pool2d_backward(&self, grad_output: &Tensor) -> Tensor {
+        self.internal_adaptive_avg_pool2d_backward(grad_output).unwrap()
     }
 
-    pub fn internal_adaptive_avg_pool2d_backward_out(
+    pub fn f_internal_adaptive_avg_pool2d_backward_out(
         &self,
         out: &Tensor,
         grad_output: &Tensor,
     ) -> Tensor {
-        self.f_internal_adaptive_avg_pool2d_backward_out(out, grad_output).unwrap()
+        self.internal_adaptive_avg_pool2d_backward_out(out, grad_output).unwrap()
     }
 
-    pub fn internal_adaptive_avg_pool2d_out(
+    pub fn f_internal_adaptive_avg_pool2d_out(
         &self,
         out: &Tensor,
         output_size: impl IntList,
     ) -> Tensor {
-        self.f_internal_adaptive_avg_pool2d_out(out, output_size).unwrap()
+        self.internal_adaptive_avg_pool2d_out(out, output_size).unwrap()
     }
 
-    pub fn internal_adaptive_avg_pool3d(&self, output_size: impl IntList) -> Tensor {
-        self.f_internal_adaptive_avg_pool3d(output_size).unwrap()
+    pub fn f_internal_adaptive_avg_pool3d(&self, output_size: impl IntList) -> Tensor {
+        self.internal_adaptive_avg_pool3d(output_size).unwrap()
     }
 
-    pub fn internal_adaptive_avg_pool3d_backward(&self, grad_output: &Tensor) -> Tensor {
-        self.f_internal_adaptive_avg_pool3d_backward(grad_output).unwrap()
+    pub fn f_internal_adaptive_avg_pool3d_backward(&self, grad_output: &Tensor) -> Tensor {
+        self.internal_adaptive_avg_pool3d_backward(grad_output).unwrap()
     }
 
-    pub fn internal_adaptive_avg_pool3d_backward_out(
+    pub fn f_internal_adaptive_avg_pool3d_backward_out(
         &self,
         out: &Tensor,
         grad_output: &Tensor,
     ) -> Tensor {
-        self.f_internal_adaptive_avg_pool3d_backward_out(out, grad_output).unwrap()
+        self.internal_adaptive_avg_pool3d_backward_out(out, grad_output).unwrap()
     }
 
-    pub fn internal_adaptive_avg_pool3d_out(
+    pub fn f_internal_adaptive_avg_pool3d_out(
         &self,
         out: &Tensor,
         output_size: impl IntList,
     ) -> Tensor {
-        self.f_internal_adaptive_avg_pool3d_out(out, output_size).unwrap()
+        self.internal_adaptive_avg_pool3d_out(out, output_size).unwrap()
     }
 
-    pub fn internal_add_batch_dim(&self, batch_dim: i64, level: i64) -> Tensor {
-        self.f_internal_add_batch_dim(batch_dim, level).unwrap()
+    pub fn f_internal_add_batch_dim(&self, batch_dim: i64, level: i64) -> Tensor {
+        self.internal_add_batch_dim(batch_dim, level).unwrap()
     }
 
-    pub fn internal_add_relu(&self, other: &Tensor) -> Tensor {
-        self.f_internal_add_relu(other).unwrap()
+    pub fn f_internal_add_relu(&self, other: &Tensor) -> Tensor {
+        self.internal_add_relu(other).unwrap()
     }
 
-    pub fn internal_add_relu_(&mut self, other: &Tensor) -> Tensor {
-        self.f_internal_add_relu_(other).unwrap()
+    pub fn f_internal_add_relu_(&mut self, other: &Tensor) -> Tensor {
+        self.internal_add_relu_(other).unwrap()
     }
 
-    pub fn internal_add_relu_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_internal_add_relu_out(out, other).unwrap()
+    pub fn f_internal_add_relu_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.internal_add_relu_out(out, other).unwrap()
     }
 
-    pub fn internal_add_relu_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_internal_add_relu_scalar(other).unwrap()
+    pub fn f_internal_add_relu_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.internal_add_relu_scalar(other).unwrap()
     }
 
-    pub fn internal_add_relu_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_internal_add_relu_scalar_(other).unwrap()
+    pub fn f_internal_add_relu_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.internal_add_relu_scalar_(other).unwrap()
     }
 
-    pub fn internal_add_relu_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
-        self.f_internal_add_relu_scalar_out(out, other).unwrap()
+    pub fn f_internal_add_relu_scalar_out<S: Into<Scalar>>(
+        &self,
+        out: &Tensor,
+        other: S,
+    ) -> Tensor {
+        self.internal_add_relu_scalar_out(out, other).unwrap()
     }
 
-    pub fn internal_addmm_activation(
+    pub fn f_internal_addmm_activation(
         &self,
         mat1: &Tensor,
         mat2: &Tensor,
         use_gelu: bool,
     ) -> Tensor {
-        self.f_internal_addmm_activation(mat1, mat2, use_gelu).unwrap()
+        self.internal_addmm_activation(mat1, mat2, use_gelu).unwrap()
     }
 
-    pub fn internal_addmm_activation_out(
+    pub fn f_internal_addmm_activation_out(
         &self,
         out: &Tensor,
         mat1: &Tensor,
         mat2: &Tensor,
         use_gelu: bool,
     ) -> Tensor {
-        self.f_internal_addmm_activation_out(out, mat1, mat2, use_gelu).unwrap()
+        self.internal_addmm_activation_out(out, mat1, mat2, use_gelu).unwrap()
     }
 
-    pub fn internal_aminmax(&self) -> (Tensor, Tensor) {
-        self.f_internal_aminmax().unwrap()
+    pub fn f_internal_aminmax(&self) -> (Tensor, Tensor) {
+        self.internal_aminmax().unwrap()
     }
 
-    pub fn internal_aminmax_dim(&self, dim: i64, keepdim: bool) -> (Tensor, Tensor) {
-        self.f_internal_aminmax_dim(dim, keepdim).unwrap()
+    pub fn f_internal_aminmax_dim(&self, dim: i64, keepdim: bool) -> (Tensor, Tensor) {
+        self.internal_aminmax_dim(dim, keepdim).unwrap()
     }
 
-    pub fn internal_aminmax_dim_out(
+    pub fn f_internal_aminmax_dim_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
         dim: i64,
         keepdim: bool,
     ) -> (Tensor, Tensor) {
-        self.f_internal_aminmax_dim_out(out0, out1, dim, keepdim).unwrap()
+        self.internal_aminmax_dim_out(out0, out1, dim, keepdim).unwrap()
     }
 
-    pub fn internal_aminmax_out(&self, out0: &Tensor, out1: &Tensor) -> (Tensor, Tensor) {
-        self.f_internal_aminmax_out(out0, out1).unwrap()
+    pub fn f_internal_aminmax_out(&self, out0: &Tensor, out1: &Tensor) -> (Tensor, Tensor) {
+        self.internal_aminmax_out(out0, out1).unwrap()
     }
 
-    pub fn internal_amp_update_scale(
+    pub fn f_internal_amp_update_scale(
         &self,
         growth_tracker: &Tensor,
         found_inf: &Tensor,
@@ -227,7 +231,7 @@ impl Tensor {
         scale_backoff_factor: f64,
         growth_interval: i64,
     ) -> (Tensor, Tensor) {
-        self.f_internal_amp_update_scale(
+        self.internal_amp_update_scale(
             growth_tracker,
             found_inf,
             scale_growth_factor,
@@ -237,7 +241,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_amp_update_scale_(
+    pub fn f_internal_amp_update_scale_(
         &mut self,
         growth_tracker: &Tensor,
         found_inf: &Tensor,
@@ -245,7 +249,7 @@ impl Tensor {
         scale_backoff_factor: f64,
         growth_interval: i64,
     ) -> Tensor {
-        self.f_internal_amp_update_scale_(
+        self.internal_amp_update_scale_(
             growth_tracker,
             found_inf,
             scale_growth_factor,
@@ -255,7 +259,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_amp_update_scale_out(
+    pub fn f_internal_amp_update_scale_out(
         &self,
         out: &Tensor,
         growth_tracker: &Tensor,
@@ -264,7 +268,7 @@ impl Tensor {
         scale_backoff_factor: f64,
         growth_interval: i64,
     ) -> Tensor {
-        self.f_internal_amp_update_scale_out(
+        self.internal_amp_update_scale_out(
             out,
             growth_tracker,
             found_inf,
@@ -275,31 +279,31 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_assert_tensor_metadata(
+    pub fn f_internal_assert_tensor_metadata(
         a: &Tensor,
         size: impl IntListOption,
         stride: impl IntListOption,
         dtype: impl Into<Option<Kind>>,
     ) {
-        Tensor::f_internal_assert_tensor_metadata(a, size, stride, dtype).unwrap()
+        Tensor::internal_assert_tensor_metadata(a, size, stride, dtype).unwrap()
     }
 
-    pub fn internal_autocast_to_full_precision(
+    pub fn f_internal_autocast_to_full_precision(
         &self,
         cuda_enabled: bool,
         cpu_enabled: bool,
     ) -> Tensor {
-        self.f_internal_autocast_to_full_precision(cuda_enabled, cpu_enabled).unwrap()
+        self.internal_autocast_to_full_precision(cuda_enabled, cpu_enabled).unwrap()
     }
 
-    pub fn internal_autocast_to_reduced_precision(
+    pub fn f_internal_autocast_to_reduced_precision(
         &self,
         cuda_enabled: bool,
         cpu_enabled: bool,
         cuda_dtype: Kind,
         cpu_dtype: Kind,
     ) -> Tensor {
-        self.f_internal_autocast_to_reduced_precision(
+        self.internal_autocast_to_reduced_precision(
             cuda_enabled,
             cpu_enabled,
             cuda_dtype,
@@ -308,49 +312,49 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_cast_byte(&self, non_blocking: bool) -> Tensor {
-        self.f_internal_cast_byte(non_blocking).unwrap()
+    pub fn f_internal_cast_byte(&self, non_blocking: bool) -> Tensor {
+        self.internal_cast_byte(non_blocking).unwrap()
     }
 
-    pub fn internal_cast_char(&self, non_blocking: bool) -> Tensor {
-        self.f_internal_cast_char(non_blocking).unwrap()
+    pub fn f_internal_cast_char(&self, non_blocking: bool) -> Tensor {
+        self.internal_cast_char(non_blocking).unwrap()
     }
 
-    pub fn internal_cast_double(&self, non_blocking: bool) -> Tensor {
-        self.f_internal_cast_double(non_blocking).unwrap()
+    pub fn f_internal_cast_double(&self, non_blocking: bool) -> Tensor {
+        self.internal_cast_double(non_blocking).unwrap()
     }
 
-    pub fn internal_cast_float(&self, non_blocking: bool) -> Tensor {
-        self.f_internal_cast_float(non_blocking).unwrap()
+    pub fn f_internal_cast_float(&self, non_blocking: bool) -> Tensor {
+        self.internal_cast_float(non_blocking).unwrap()
     }
 
-    pub fn internal_cast_half(&self, non_blocking: bool) -> Tensor {
-        self.f_internal_cast_half(non_blocking).unwrap()
+    pub fn f_internal_cast_half(&self, non_blocking: bool) -> Tensor {
+        self.internal_cast_half(non_blocking).unwrap()
     }
 
-    pub fn internal_cast_int(&self, non_blocking: bool) -> Tensor {
-        self.f_internal_cast_int(non_blocking).unwrap()
+    pub fn f_internal_cast_int(&self, non_blocking: bool) -> Tensor {
+        self.internal_cast_int(non_blocking).unwrap()
     }
 
-    pub fn internal_cast_long(&self, non_blocking: bool) -> Tensor {
-        self.f_internal_cast_long(non_blocking).unwrap()
+    pub fn f_internal_cast_long(&self, non_blocking: bool) -> Tensor {
+        self.internal_cast_long(non_blocking).unwrap()
     }
 
-    pub fn internal_cast_short(&self, non_blocking: bool) -> Tensor {
-        self.f_internal_cast_short(non_blocking).unwrap()
+    pub fn f_internal_cast_short(&self, non_blocking: bool) -> Tensor {
+        self.internal_cast_short(non_blocking).unwrap()
     }
 
-    pub fn internal_cdist_backward(
+    pub fn f_internal_cdist_backward(
         grad: &Tensor,
         x1: &Tensor,
         x2: &Tensor,
         p: f64,
         cdist: &Tensor,
     ) -> Tensor {
-        Tensor::f_internal_cdist_backward(grad, x1, x2, p, cdist).unwrap()
+        Tensor::internal_cdist_backward(grad, x1, x2, p, cdist).unwrap()
     }
 
-    pub fn internal_cdist_backward_out(
+    pub fn f_internal_cdist_backward_out(
         out: &Tensor,
         grad: &Tensor,
         x1: &Tensor,
@@ -358,85 +362,85 @@ impl Tensor {
         p: f64,
         cdist: &Tensor,
     ) -> Tensor {
-        Tensor::f_internal_cdist_backward_out(out, grad, x1, x2, p, cdist).unwrap()
+        Tensor::internal_cdist_backward_out(out, grad, x1, x2, p, cdist).unwrap()
     }
 
-    pub fn internal_cholesky_solve_helper(&self, a: &Tensor, upper: bool) -> Tensor {
-        self.f_internal_cholesky_solve_helper(a, upper).unwrap()
+    pub fn f_internal_cholesky_solve_helper(&self, a: &Tensor, upper: bool) -> Tensor {
+        self.internal_cholesky_solve_helper(a, upper).unwrap()
     }
 
-    pub fn internal_cholesky_solve_helper_out(
+    pub fn f_internal_cholesky_solve_helper_out(
         &self,
         out: &Tensor,
         a: &Tensor,
         upper: bool,
     ) -> Tensor {
-        self.f_internal_cholesky_solve_helper_out(out, a, upper).unwrap()
+        self.internal_cholesky_solve_helper_out(out, a, upper).unwrap()
     }
 
-    pub fn internal_chunk_grad_outputs_efficient_attention(
+    pub fn f_internal_chunk_grad_outputs_efficient_attention(
         query: &Tensor,
         key: &Tensor,
         value: &Tensor,
         is_causal: bool,
     ) -> bool {
-        Tensor::f_internal_chunk_grad_outputs_efficient_attention(query, key, value, is_causal)
+        Tensor::internal_chunk_grad_outputs_efficient_attention(query, key, value, is_causal)
             .unwrap()
     }
 
-    pub fn internal_coalesce(&self) -> Tensor {
-        self.f_internal_coalesce().unwrap()
+    pub fn f_internal_coalesce(&self) -> Tensor {
+        self.internal_coalesce().unwrap()
     }
 
-    pub fn internal_coalesce_out(&self, out: &Tensor) -> Tensor {
-        self.f_internal_coalesce_out(out).unwrap()
+    pub fn f_internal_coalesce_out(&self, out: &Tensor) -> Tensor {
+        self.internal_coalesce_out(out).unwrap()
     }
 
-    pub fn internal_coalesced(&self, coalesced: bool) -> Tensor {
-        self.f_internal_coalesced(coalesced).unwrap()
+    pub fn f_internal_coalesced(&self, coalesced: bool) -> Tensor {
+        self.internal_coalesced(coalesced).unwrap()
     }
 
-    pub fn internal_coalesced_(&mut self, coalesced: bool) -> Tensor {
-        self.f_internal_coalesced_(coalesced).unwrap()
+    pub fn f_internal_coalesced_(&mut self, coalesced: bool) -> Tensor {
+        self.internal_coalesced_(coalesced).unwrap()
     }
 
-    pub fn internal_coalesced_out(&self, out: &Tensor, coalesced: bool) -> Tensor {
-        self.f_internal_coalesced_out(out, coalesced).unwrap()
+    pub fn f_internal_coalesced_out(&self, out: &Tensor, coalesced: bool) -> Tensor {
+        self.internal_coalesced_out(out, coalesced).unwrap()
     }
 
-    pub fn internal_compute_linear_combination(&self, coefficients: &Tensor) -> Tensor {
-        self.f_internal_compute_linear_combination(coefficients).unwrap()
+    pub fn f_internal_compute_linear_combination(&self, coefficients: &Tensor) -> Tensor {
+        self.internal_compute_linear_combination(coefficients).unwrap()
     }
 
-    pub fn internal_compute_linear_combination_out(
+    pub fn f_internal_compute_linear_combination_out(
         &self,
         out: &Tensor,
         coefficients: &Tensor,
     ) -> Tensor {
-        self.f_internal_compute_linear_combination_out(out, coefficients).unwrap()
+        self.internal_compute_linear_combination_out(out, coefficients).unwrap()
     }
 
-    pub fn internal_conj(&self) -> Tensor {
-        self.f_internal_conj().unwrap()
+    pub fn f_internal_conj(&self) -> Tensor {
+        self.internal_conj().unwrap()
     }
 
-    pub fn internal_conj_copy(&self) -> Tensor {
-        self.f_internal_conj_copy().unwrap()
+    pub fn f_internal_conj_copy(&self) -> Tensor {
+        self.internal_conj_copy().unwrap()
     }
 
-    pub fn internal_conj_copy_out(&self, out: &Tensor) -> Tensor {
-        self.f_internal_conj_copy_out(out).unwrap()
+    pub fn f_internal_conj_copy_out(&self, out: &Tensor) -> Tensor {
+        self.internal_conj_copy_out(out).unwrap()
     }
 
-    pub fn internal_conj_physical(&self) -> Tensor {
-        self.f_internal_conj_physical().unwrap()
+    pub fn f_internal_conj_physical(&self) -> Tensor {
+        self.internal_conj_physical().unwrap()
     }
 
-    pub fn internal_conj_physical_out(&self, out: &Tensor) -> Tensor {
-        self.f_internal_conj_physical_out(out).unwrap()
+    pub fn f_internal_conj_physical_out(&self, out: &Tensor) -> Tensor {
+        self.internal_conj_physical_out(out).unwrap()
     }
 
-    pub fn internal_conv_depthwise2d<T: Borrow<Tensor>>(
+    pub fn f_internal_conv_depthwise2d<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         kernel_size: impl IntList,
@@ -445,11 +449,11 @@ impl Tensor {
         padding: impl IntList,
         dilation: impl IntList,
     ) -> Tensor {
-        self.f_internal_conv_depthwise2d(weight, kernel_size, bias, stride, padding, dilation)
+        self.internal_conv_depthwise2d(weight, kernel_size, bias, stride, padding, dilation)
             .unwrap()
     }
 
-    pub fn internal_conv_depthwise2d_out<T: Borrow<Tensor>>(
+    pub fn f_internal_conv_depthwise2d_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -459,7 +463,7 @@ impl Tensor {
         padding: impl IntList,
         dilation: impl IntList,
     ) -> Tensor {
-        self.f_internal_conv_depthwise2d_out(
+        self.internal_conv_depthwise2d_out(
             out,
             weight,
             kernel_size,
@@ -471,26 +475,26 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_convert_indices_from_coo_to_csr(&self, size: i64, out_int32: bool) -> Tensor {
-        self.f_internal_convert_indices_from_coo_to_csr(size, out_int32).unwrap()
+    pub fn f_internal_convert_indices_from_coo_to_csr(&self, size: i64, out_int32: bool) -> Tensor {
+        self.internal_convert_indices_from_coo_to_csr(size, out_int32).unwrap()
     }
 
-    pub fn internal_convert_indices_from_coo_to_csr_out(
+    pub fn f_internal_convert_indices_from_coo_to_csr_out(
         &self,
         out: &Tensor,
         size: i64,
         out_int32: bool,
     ) -> Tensor {
-        self.f_internal_convert_indices_from_coo_to_csr_out(out, size, out_int32).unwrap()
+        self.internal_convert_indices_from_coo_to_csr_out(out, size, out_int32).unwrap()
     }
 
-    pub fn internal_convert_indices_from_csr_to_coo(
+    pub fn f_internal_convert_indices_from_csr_to_coo(
         crow_indices: &Tensor,
         col_indices: &Tensor,
         out_int32: bool,
         transpose: bool,
     ) -> Tensor {
-        Tensor::f_internal_convert_indices_from_csr_to_coo(
+        Tensor::internal_convert_indices_from_csr_to_coo(
             crow_indices,
             col_indices,
             out_int32,
@@ -499,14 +503,14 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_convert_indices_from_csr_to_coo_out(
+    pub fn f_internal_convert_indices_from_csr_to_coo_out(
         out: &Tensor,
         crow_indices: &Tensor,
         col_indices: &Tensor,
         out_int32: bool,
         transpose: bool,
     ) -> Tensor {
-        Tensor::f_internal_convert_indices_from_csr_to_coo_out(
+        Tensor::internal_convert_indices_from_csr_to_coo_out(
             out,
             crow_indices,
             col_indices,
@@ -516,7 +520,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_convolution<T: Borrow<Tensor>>(
+    pub fn f_internal_convolution<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -531,7 +535,7 @@ impl Tensor {
         cudnn_enabled: bool,
         allow_tf32: bool,
     ) -> Tensor {
-        self.f_internal_convolution(
+        self.internal_convolution(
             weight,
             bias,
             stride,
@@ -548,7 +552,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_convolution_deprecated<T: Borrow<Tensor>>(
+    pub fn f_internal_convolution_deprecated<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -562,7 +566,7 @@ impl Tensor {
         deterministic: bool,
         cudnn_enabled: bool,
     ) -> Tensor {
-        self.f_internal_convolution_deprecated(
+        self.internal_convolution_deprecated(
             weight,
             bias,
             stride,
@@ -578,7 +582,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_convolution_mode<T: Borrow<Tensor>>(
+    pub fn f_internal_convolution_mode<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -587,10 +591,10 @@ impl Tensor {
         dilation: impl IntList,
         groups: i64,
     ) -> Tensor {
-        self.f_internal_convolution_mode(weight, bias, stride, padding, dilation, groups).unwrap()
+        self.internal_convolution_mode(weight, bias, stride, padding, dilation, groups).unwrap()
     }
 
-    pub fn internal_convolution_out<T: Borrow<Tensor>>(
+    pub fn f_internal_convolution_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -606,7 +610,7 @@ impl Tensor {
         cudnn_enabled: bool,
         allow_tf32: bool,
     ) -> Tensor {
-        self.f_internal_convolution_out(
+        self.internal_convolution_out(
             out,
             weight,
             bias,
@@ -624,23 +628,28 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_copy_from(&self, dst: &Tensor, non_blocking: bool) -> Tensor {
-        self.f_internal_copy_from(dst, non_blocking).unwrap()
+    pub fn f_internal_copy_from(&self, dst: &Tensor, non_blocking: bool) -> Tensor {
+        self.internal_copy_from(dst, non_blocking).unwrap()
     }
 
-    pub fn internal_copy_from_and_resize(&self, dst: &Tensor) -> Tensor {
-        self.f_internal_copy_from_and_resize(dst).unwrap()
+    pub fn f_internal_copy_from_and_resize(&self, dst: &Tensor) -> Tensor {
+        self.internal_copy_from_and_resize(dst).unwrap()
     }
 
-    pub fn internal_copy_from_and_resize_out(&self, out: &Tensor, dst: &Tensor) -> Tensor {
-        self.f_internal_copy_from_and_resize_out(out, dst).unwrap()
+    pub fn f_internal_copy_from_and_resize_out(&self, out: &Tensor, dst: &Tensor) -> Tensor {
+        self.internal_copy_from_and_resize_out(out, dst).unwrap()
     }
 
-    pub fn internal_copy_from_out(&self, out: &Tensor, dst: &Tensor, non_blocking: bool) -> Tensor {
-        self.f_internal_copy_from_out(out, dst, non_blocking).unwrap()
+    pub fn f_internal_copy_from_out(
+        &self,
+        out: &Tensor,
+        dst: &Tensor,
+        non_blocking: bool,
+    ) -> Tensor {
+        self.internal_copy_from_out(out, dst, non_blocking).unwrap()
     }
 
-    pub fn internal_ctc_loss(
+    pub fn f_internal_ctc_loss(
         log_probs: &Tensor,
         targets: &Tensor,
         input_lengths: impl IntList,
@@ -648,7 +657,7 @@ impl Tensor {
         blank: i64,
         zero_infinity: bool,
     ) -> (Tensor, Tensor) {
-        Tensor::f_internal_ctc_loss(
+        Tensor::internal_ctc_loss(
             log_probs,
             targets,
             input_lengths,
@@ -659,7 +668,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_ctc_loss_backward(
+    pub fn f_internal_ctc_loss_backward(
         grad: &Tensor,
         log_probs: &Tensor,
         targets: &Tensor,
@@ -670,7 +679,7 @@ impl Tensor {
         blank: i64,
         zero_infinity: bool,
     ) -> Tensor {
-        Tensor::f_internal_ctc_loss_backward(
+        Tensor::internal_ctc_loss_backward(
             grad,
             log_probs,
             targets,
@@ -684,7 +693,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_ctc_loss_backward_out(
+    pub fn f_internal_ctc_loss_backward_out(
         out: &Tensor,
         grad: &Tensor,
         log_probs: &Tensor,
@@ -696,7 +705,7 @@ impl Tensor {
         blank: i64,
         zero_infinity: bool,
     ) -> Tensor {
-        Tensor::f_internal_ctc_loss_backward_out(
+        Tensor::internal_ctc_loss_backward_out(
             out,
             grad,
             log_probs,
@@ -711,7 +720,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_ctc_loss_backward_tensor(
+    pub fn f_internal_ctc_loss_backward_tensor(
         grad: &Tensor,
         log_probs: &Tensor,
         targets: &Tensor,
@@ -722,7 +731,7 @@ impl Tensor {
         blank: i64,
         zero_infinity: bool,
     ) -> Tensor {
-        Tensor::f_internal_ctc_loss_backward_tensor(
+        Tensor::internal_ctc_loss_backward_tensor(
             grad,
             log_probs,
             targets,
@@ -736,7 +745,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_ctc_loss_out(
+    pub fn f_internal_ctc_loss_out(
         out0: &Tensor,
         out1: &Tensor,
         log_probs: &Tensor,
@@ -746,7 +755,7 @@ impl Tensor {
         blank: i64,
         zero_infinity: bool,
     ) -> (Tensor, Tensor) {
-        Tensor::f_internal_ctc_loss_out(
+        Tensor::internal_ctc_loss_out(
             out0,
             out1,
             log_probs,
@@ -759,7 +768,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_ctc_loss_tensor(
+    pub fn f_internal_ctc_loss_tensor(
         log_probs: &Tensor,
         targets: &Tensor,
         input_lengths: &Tensor,
@@ -767,7 +776,7 @@ impl Tensor {
         blank: i64,
         zero_infinity: bool,
     ) -> (Tensor, Tensor) {
-        Tensor::f_internal_ctc_loss_tensor(
+        Tensor::internal_ctc_loss_tensor(
             log_probs,
             targets,
             input_lengths,
@@ -778,7 +787,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_ctc_loss_tensor_out(
+    pub fn f_internal_ctc_loss_tensor_out(
         out0: &Tensor,
         out1: &Tensor,
         log_probs: &Tensor,
@@ -788,7 +797,7 @@ impl Tensor {
         blank: i64,
         zero_infinity: bool,
     ) -> (Tensor, Tensor) {
-        Tensor::f_internal_ctc_loss_tensor_out(
+        Tensor::internal_ctc_loss_tensor_out(
             out0,
             out1,
             log_probs,
@@ -801,7 +810,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_cudnn_ctc_loss(
+    pub fn f_internal_cudnn_ctc_loss(
         log_probs: &Tensor,
         targets: &Tensor,
         input_lengths: impl IntList,
@@ -810,7 +819,7 @@ impl Tensor {
         deterministic: bool,
         zero_infinity: bool,
     ) -> (Tensor, Tensor) {
-        Tensor::f_internal_cudnn_ctc_loss(
+        Tensor::internal_cudnn_ctc_loss(
             log_probs,
             targets,
             input_lengths,
@@ -822,7 +831,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_cudnn_ctc_loss_out(
+    pub fn f_internal_cudnn_ctc_loss_out(
         out0: &Tensor,
         out1: &Tensor,
         log_probs: &Tensor,
@@ -833,7 +842,7 @@ impl Tensor {
         deterministic: bool,
         zero_infinity: bool,
     ) -> (Tensor, Tensor) {
-        Tensor::f_internal_cudnn_ctc_loss_out(
+        Tensor::internal_cudnn_ctc_loss_out(
             out0,
             out1,
             log_probs,
@@ -847,7 +856,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_cudnn_ctc_loss_tensor(
+    pub fn f_internal_cudnn_ctc_loss_tensor(
         log_probs: &Tensor,
         targets: &Tensor,
         input_lengths: &Tensor,
@@ -856,7 +865,7 @@ impl Tensor {
         deterministic: bool,
         zero_infinity: bool,
     ) -> (Tensor, Tensor) {
-        Tensor::f_internal_cudnn_ctc_loss_tensor(
+        Tensor::internal_cudnn_ctc_loss_tensor(
             log_probs,
             targets,
             input_lengths,
@@ -868,25 +877,25 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_cudnn_init_dropout_state(
+    pub fn f_internal_cudnn_init_dropout_state(
         dropout: f64,
         train: bool,
         dropout_seed: i64,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_internal_cudnn_init_dropout_state(dropout, train, dropout_seed, options).unwrap()
+        Tensor::internal_cudnn_init_dropout_state(dropout, train, dropout_seed, options).unwrap()
     }
 
-    pub fn internal_cudnn_init_dropout_state_out(
+    pub fn f_internal_cudnn_init_dropout_state_out(
         out: &Tensor,
         dropout: f64,
         train: bool,
         dropout_seed: i64,
     ) -> Tensor {
-        Tensor::f_internal_cudnn_init_dropout_state_out(out, dropout, train, dropout_seed).unwrap()
+        Tensor::internal_cudnn_init_dropout_state_out(out, dropout, train, dropout_seed).unwrap()
     }
 
-    pub fn internal_cudnn_rnn<T: Borrow<Tensor>>(
+    pub fn f_internal_cudnn_rnn<T: Borrow<Tensor>>(
         &self,
         weight: &[T],
         weight_stride0: i64,
@@ -904,7 +913,7 @@ impl Tensor {
         batch_sizes: impl IntList,
         dropout_state: Option<T>,
     ) -> (Tensor, Tensor, Tensor, Tensor, Tensor) {
-        self.f_internal_cudnn_rnn(
+        self.internal_cudnn_rnn(
             weight,
             weight_stride0,
             weight_buf,
@@ -924,7 +933,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_cudnn_rnn_flatten_weight<T: Borrow<Tensor>>(
+    pub fn f_internal_cudnn_rnn_flatten_weight<T: Borrow<Tensor>>(
         weight_arr: &[T],
         weight_stride0: i64,
         input_size: i64,
@@ -935,7 +944,7 @@ impl Tensor {
         batch_first: bool,
         bidirectional: bool,
     ) -> Tensor {
-        Tensor::f_internal_cudnn_rnn_flatten_weight(
+        Tensor::internal_cudnn_rnn_flatten_weight(
             weight_arr,
             weight_stride0,
             input_size,
@@ -949,7 +958,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_cudnn_rnn_flatten_weight_out<T: Borrow<Tensor>>(
+    pub fn f_internal_cudnn_rnn_flatten_weight_out<T: Borrow<Tensor>>(
         out: &Tensor,
         weight_arr: &[T],
         weight_stride0: i64,
@@ -961,7 +970,7 @@ impl Tensor {
         batch_first: bool,
         bidirectional: bool,
     ) -> Tensor {
-        Tensor::f_internal_cudnn_rnn_flatten_weight_out(
+        Tensor::internal_cudnn_rnn_flatten_weight_out(
             out,
             weight_arr,
             weight_stride0,
@@ -976,7 +985,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_cudnn_rnn_out<T: Borrow<Tensor>>(
+    pub fn f_internal_cudnn_rnn_out<T: Borrow<Tensor>>(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -999,7 +1008,7 @@ impl Tensor {
         batch_sizes: impl IntList,
         dropout_state: Option<T>,
     ) -> (Tensor, Tensor, Tensor, Tensor, Tensor) {
-        self.f_internal_cudnn_rnn_out(
+        self.internal_cudnn_rnn_out(
             out0,
             out1,
             out2,
@@ -1024,44 +1033,44 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_cufft_get_plan_cache_max_size(device_index: i64) -> i64 {
-        Tensor::f_internal_cufft_get_plan_cache_max_size(device_index).unwrap()
+    pub fn f_internal_cufft_get_plan_cache_max_size(device_index: i64) -> i64 {
+        Tensor::internal_cufft_get_plan_cache_max_size(device_index).unwrap()
     }
 
-    pub fn internal_cufft_get_plan_cache_size(device_index: i64) -> i64 {
-        Tensor::f_internal_cufft_get_plan_cache_size(device_index).unwrap()
+    pub fn f_internal_cufft_get_plan_cache_size(device_index: i64) -> i64 {
+        Tensor::internal_cufft_get_plan_cache_size(device_index).unwrap()
     }
 
-    pub fn internal_debug_has_internal_overlap(&self) -> i64 {
-        self.f_internal_debug_has_internal_overlap().unwrap()
+    pub fn f_internal_debug_has_internal_overlap(&self) -> i64 {
+        self.internal_debug_has_internal_overlap().unwrap()
     }
 
-    pub fn internal_dim_arange(like: &Tensor, dim: i64) -> Tensor {
-        Tensor::f_internal_dim_arange(like, dim).unwrap()
+    pub fn f_internal_dim_arange(like: &Tensor, dim: i64) -> Tensor {
+        Tensor::internal_dim_arange(like, dim).unwrap()
     }
 
-    pub fn internal_dimi(&self) -> i64 {
-        self.f_internal_dimi().unwrap()
+    pub fn f_internal_dimi(&self) -> i64 {
+        self.internal_dimi().unwrap()
     }
 
-    pub fn internal_dimv(&self) -> i64 {
-        self.f_internal_dimv().unwrap()
+    pub fn f_internal_dimv(&self) -> i64 {
+        self.internal_dimv().unwrap()
     }
 
-    pub fn internal_dirichlet_grad(x: &Tensor, alpha: &Tensor, total: &Tensor) -> Tensor {
-        Tensor::f_internal_dirichlet_grad(x, alpha, total).unwrap()
+    pub fn f_internal_dirichlet_grad(x: &Tensor, alpha: &Tensor, total: &Tensor) -> Tensor {
+        Tensor::internal_dirichlet_grad(x, alpha, total).unwrap()
     }
 
-    pub fn internal_dirichlet_grad_out(
+    pub fn f_internal_dirichlet_grad_out(
         out: &Tensor,
         x: &Tensor,
         alpha: &Tensor,
         total: &Tensor,
     ) -> Tensor {
-        Tensor::f_internal_dirichlet_grad_out(out, x, alpha, total).unwrap()
+        Tensor::internal_dirichlet_grad_out(out, x, alpha, total).unwrap()
     }
 
-    pub fn internal_efficient_attention_backward(
+    pub fn f_internal_efficient_attention_backward(
         grad_out_: &Tensor,
         query: &Tensor,
         key: &Tensor,
@@ -1071,7 +1080,7 @@ impl Tensor {
         is_causal: bool,
         chunk_grad_outputs: bool,
     ) -> (Tensor, Tensor, Tensor) {
-        Tensor::f_internal_efficient_attention_backward(
+        Tensor::internal_efficient_attention_backward(
             grad_out_,
             query,
             key,
@@ -1084,15 +1093,15 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_efficientzerotensor(size: impl IntList, options: (Kind, Device)) -> Tensor {
-        Tensor::f_internal_efficientzerotensor(size, options).unwrap()
+    pub fn f_internal_efficientzerotensor(size: impl IntList, options: (Kind, Device)) -> Tensor {
+        Tensor::internal_efficientzerotensor(size, options).unwrap()
     }
 
-    pub fn internal_efficientzerotensor_out(out: &Tensor, size: impl IntList) -> Tensor {
-        Tensor::f_internal_efficientzerotensor_out(out, size).unwrap()
+    pub fn f_internal_efficientzerotensor_out(out: &Tensor, size: impl IntList) -> Tensor {
+        Tensor::internal_efficientzerotensor_out(out, size).unwrap()
     }
 
-    pub fn internal_embedding_bag<T: Borrow<Tensor>>(
+    pub fn f_internal_embedding_bag<T: Borrow<Tensor>>(
         weight: &Tensor,
         indices: &Tensor,
         offsets: &Tensor,
@@ -1103,7 +1112,7 @@ impl Tensor {
         include_last_offset: bool,
         padding_idx: i64,
     ) -> (Tensor, Tensor, Tensor, Tensor) {
-        Tensor::f_internal_embedding_bag(
+        Tensor::internal_embedding_bag(
             weight,
             indices,
             offsets,
@@ -1117,7 +1126,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_embedding_bag_backward<T: Borrow<Tensor>>(
+    pub fn f_internal_embedding_bag_backward<T: Borrow<Tensor>>(
         grad: &Tensor,
         indices: &Tensor,
         offsets: &Tensor,
@@ -1131,7 +1140,7 @@ impl Tensor {
         per_sample_weights: Option<T>,
         padding_idx: i64,
     ) -> Tensor {
-        Tensor::f_internal_embedding_bag_backward(
+        Tensor::internal_embedding_bag_backward(
             grad,
             indices,
             offsets,
@@ -1148,7 +1157,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_embedding_bag_dense_backward<T: Borrow<Tensor>>(
+    pub fn f_internal_embedding_bag_dense_backward<T: Borrow<Tensor>>(
         grad: &Tensor,
         indices: &Tensor,
         offset2bag: &Tensor,
@@ -1160,7 +1169,7 @@ impl Tensor {
         per_sample_weights: Option<T>,
         padding_idx: i64,
     ) -> Tensor {
-        Tensor::f_internal_embedding_bag_dense_backward(
+        Tensor::internal_embedding_bag_dense_backward(
             grad,
             indices,
             offset2bag,
@@ -1175,7 +1184,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_embedding_bag_dense_backward_out<T: Borrow<Tensor>>(
+    pub fn f_internal_embedding_bag_dense_backward_out<T: Borrow<Tensor>>(
         out: &Tensor,
         grad: &Tensor,
         indices: &Tensor,
@@ -1188,7 +1197,7 @@ impl Tensor {
         per_sample_weights: Option<T>,
         padding_idx: i64,
     ) -> Tensor {
-        Tensor::f_internal_embedding_bag_dense_backward_out(
+        Tensor::internal_embedding_bag_dense_backward_out(
             out,
             grad,
             indices,
@@ -1204,7 +1213,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_embedding_bag_forward_only<T: Borrow<Tensor>>(
+    pub fn f_internal_embedding_bag_forward_only<T: Borrow<Tensor>>(
         weight: &Tensor,
         indices: &Tensor,
         offsets: &Tensor,
@@ -1215,7 +1224,7 @@ impl Tensor {
         include_last_offset: bool,
         padding_idx: i64,
     ) -> (Tensor, Tensor, Tensor, Tensor) {
-        Tensor::f_internal_embedding_bag_forward_only(
+        Tensor::internal_embedding_bag_forward_only(
             weight,
             indices,
             offsets,
@@ -1229,7 +1238,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_embedding_bag_forward_only_out<T: Borrow<Tensor>>(
+    pub fn f_internal_embedding_bag_forward_only_out<T: Borrow<Tensor>>(
         out0: &Tensor,
         out1: &Tensor,
         out2: &Tensor,
@@ -1244,7 +1253,7 @@ impl Tensor {
         include_last_offset: bool,
         padding_idx: i64,
     ) -> (Tensor, Tensor, Tensor, Tensor) {
-        Tensor::f_internal_embedding_bag_forward_only_out(
+        Tensor::internal_embedding_bag_forward_only_out(
             out0,
             out1,
             out2,
@@ -1262,7 +1271,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_embedding_bag_out<T: Borrow<Tensor>>(
+    pub fn f_internal_embedding_bag_out<T: Borrow<Tensor>>(
         out0: &Tensor,
         out1: &Tensor,
         out2: &Tensor,
@@ -1277,7 +1286,7 @@ impl Tensor {
         include_last_offset: bool,
         padding_idx: i64,
     ) -> (Tensor, Tensor, Tensor, Tensor) {
-        Tensor::f_internal_embedding_bag_out(
+        Tensor::internal_embedding_bag_out(
             out0,
             out1,
             out2,
@@ -1295,7 +1304,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_embedding_bag_per_sample_weights_backward(
+    pub fn f_internal_embedding_bag_per_sample_weights_backward(
         grad: &Tensor,
         weight: &Tensor,
         indices: &Tensor,
@@ -1304,7 +1313,7 @@ impl Tensor {
         mode: i64,
         padding_idx: i64,
     ) -> Tensor {
-        Tensor::f_internal_embedding_bag_per_sample_weights_backward(
+        Tensor::internal_embedding_bag_per_sample_weights_backward(
             grad,
             weight,
             indices,
@@ -1316,7 +1325,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_embedding_bag_per_sample_weights_backward_out(
+    pub fn f_internal_embedding_bag_per_sample_weights_backward_out(
         out: &Tensor,
         grad: &Tensor,
         weight: &Tensor,
@@ -1326,7 +1335,7 @@ impl Tensor {
         mode: i64,
         padding_idx: i64,
     ) -> Tensor {
-        Tensor::f_internal_embedding_bag_per_sample_weights_backward_out(
+        Tensor::internal_embedding_bag_per_sample_weights_backward_out(
             out,
             grad,
             weight,
@@ -1339,7 +1348,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_embedding_bag_sparse_backward<T: Borrow<Tensor>>(
+    pub fn f_internal_embedding_bag_sparse_backward<T: Borrow<Tensor>>(
         grad: &Tensor,
         indices: &Tensor,
         offsets: &Tensor,
@@ -1351,7 +1360,7 @@ impl Tensor {
         per_sample_weights: Option<T>,
         padding_idx: i64,
     ) -> Tensor {
-        Tensor::f_internal_embedding_bag_sparse_backward(
+        Tensor::internal_embedding_bag_sparse_backward(
             grad,
             indices,
             offsets,
@@ -1366,32 +1375,32 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_empty_affine_quantized(
+    pub fn f_internal_empty_affine_quantized(
         size: impl IntList,
         options: (Kind, Device),
         scale: f64,
         zero_point: i64,
     ) -> Tensor {
-        Tensor::f_internal_empty_affine_quantized(size, options, scale, zero_point).unwrap()
+        Tensor::internal_empty_affine_quantized(size, options, scale, zero_point).unwrap()
     }
 
-    pub fn internal_empty_affine_quantized_out(
+    pub fn f_internal_empty_affine_quantized_out(
         out: &Tensor,
         size: impl IntList,
         scale: f64,
         zero_point: i64,
     ) -> Tensor {
-        Tensor::f_internal_empty_affine_quantized_out(out, size, scale, zero_point).unwrap()
+        Tensor::internal_empty_affine_quantized_out(out, size, scale, zero_point).unwrap()
     }
 
-    pub fn internal_empty_per_channel_affine_quantized(
+    pub fn f_internal_empty_per_channel_affine_quantized(
         size: impl IntList,
         scales: &Tensor,
         zero_points: &Tensor,
         axis: i64,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_internal_empty_per_channel_affine_quantized(
+        Tensor::internal_empty_per_channel_affine_quantized(
             size,
             scales,
             zero_points,
@@ -1401,14 +1410,14 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_empty_per_channel_affine_quantized_out(
+    pub fn f_internal_empty_per_channel_affine_quantized_out(
         out: &Tensor,
         size: impl IntList,
         scales: &Tensor,
         zero_points: &Tensor,
         axis: i64,
     ) -> Tensor {
-        Tensor::f_internal_empty_per_channel_affine_quantized_out(
+        Tensor::internal_empty_per_channel_affine_quantized_out(
             out,
             size,
             scales,
@@ -1418,15 +1427,15 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_euclidean_dist(x1: &Tensor, x2: &Tensor) -> Tensor {
-        Tensor::f_internal_euclidean_dist(x1, x2).unwrap()
+    pub fn f_internal_euclidean_dist(x1: &Tensor, x2: &Tensor) -> Tensor {
+        Tensor::internal_euclidean_dist(x1, x2).unwrap()
     }
 
-    pub fn internal_euclidean_dist_out(out: &Tensor, x1: &Tensor, x2: &Tensor) -> Tensor {
-        Tensor::f_internal_euclidean_dist_out(out, x1, x2).unwrap()
+    pub fn f_internal_euclidean_dist_out(out: &Tensor, x1: &Tensor, x2: &Tensor) -> Tensor {
+        Tensor::internal_euclidean_dist_out(out, x1, x2).unwrap()
     }
 
-    pub fn internal_fake_quantize_learnable_per_channel_affine(
+    pub fn f_internal_fake_quantize_learnable_per_channel_affine(
         &self,
         scale: &Tensor,
         zero_point: &Tensor,
@@ -1435,7 +1444,7 @@ impl Tensor {
         quant_max: i64,
         grad_factor: f64,
     ) -> Tensor {
-        self.f_internal_fake_quantize_learnable_per_channel_affine(
+        self.internal_fake_quantize_learnable_per_channel_affine(
             scale,
             zero_point,
             axis,
@@ -1446,7 +1455,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_fake_quantize_learnable_per_channel_affine_backward(
+    pub fn f_internal_fake_quantize_learnable_per_channel_affine_backward(
         &self,
         grad: &Tensor,
         scale: &Tensor,
@@ -1456,7 +1465,7 @@ impl Tensor {
         quant_max: i64,
         grad_factor: f64,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_internal_fake_quantize_learnable_per_channel_affine_backward(
+        self.internal_fake_quantize_learnable_per_channel_affine_backward(
             grad,
             scale,
             zero_point,
@@ -1468,7 +1477,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_fake_quantize_learnable_per_channel_affine_out(
+    pub fn f_internal_fake_quantize_learnable_per_channel_affine_out(
         &self,
         out: &Tensor,
         scale: &Tensor,
@@ -1478,7 +1487,7 @@ impl Tensor {
         quant_max: i64,
         grad_factor: f64,
     ) -> Tensor {
-        self.f_internal_fake_quantize_learnable_per_channel_affine_out(
+        self.internal_fake_quantize_learnable_per_channel_affine_out(
             out,
             scale,
             zero_point,
@@ -1490,7 +1499,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_fake_quantize_learnable_per_tensor_affine(
+    pub fn f_internal_fake_quantize_learnable_per_tensor_affine(
         &self,
         scale: &Tensor,
         zero_point: &Tensor,
@@ -1498,7 +1507,7 @@ impl Tensor {
         quant_max: i64,
         grad_factor: f64,
     ) -> Tensor {
-        self.f_internal_fake_quantize_learnable_per_tensor_affine(
+        self.internal_fake_quantize_learnable_per_tensor_affine(
             scale,
             zero_point,
             quant_min,
@@ -1508,7 +1517,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_fake_quantize_learnable_per_tensor_affine_backward(
+    pub fn f_internal_fake_quantize_learnable_per_tensor_affine_backward(
         &self,
         grad: &Tensor,
         scale: &Tensor,
@@ -1517,7 +1526,7 @@ impl Tensor {
         quant_max: i64,
         grad_factor: f64,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_internal_fake_quantize_learnable_per_tensor_affine_backward(
+        self.internal_fake_quantize_learnable_per_tensor_affine_backward(
             grad,
             scale,
             zero_point,
@@ -1528,7 +1537,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_fake_quantize_learnable_per_tensor_affine_out(
+    pub fn f_internal_fake_quantize_learnable_per_tensor_affine_out(
         &self,
         out: &Tensor,
         scale: &Tensor,
@@ -1537,7 +1546,7 @@ impl Tensor {
         quant_max: i64,
         grad_factor: f64,
     ) -> Tensor {
-        self.f_internal_fake_quantize_learnable_per_tensor_affine_out(
+        self.internal_fake_quantize_learnable_per_tensor_affine_out(
             out,
             scale,
             zero_point,
@@ -1548,7 +1557,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_fake_quantize_per_tensor_affine_cachemask_tensor_qparams(
+    pub fn f_internal_fake_quantize_per_tensor_affine_cachemask_tensor_qparams(
         &self,
         scale: &Tensor,
         zero_point: &Tensor,
@@ -1556,7 +1565,7 @@ impl Tensor {
         quant_min: i64,
         quant_max: i64,
     ) -> (Tensor, Tensor) {
-        self.f_internal_fake_quantize_per_tensor_affine_cachemask_tensor_qparams(
+        self.internal_fake_quantize_per_tensor_affine_cachemask_tensor_qparams(
             scale,
             zero_point,
             fake_quant_enabled,
@@ -1566,7 +1575,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_fake_quantize_per_tensor_affine_cachemask_tensor_qparams_out(
+    pub fn f_internal_fake_quantize_per_tensor_affine_cachemask_tensor_qparams_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -1576,7 +1585,7 @@ impl Tensor {
         quant_min: i64,
         quant_max: i64,
     ) -> (Tensor, Tensor) {
-        self.f_internal_fake_quantize_per_tensor_affine_cachemask_tensor_qparams_out(
+        self.internal_fake_quantize_per_tensor_affine_cachemask_tensor_qparams_out(
             out0,
             out1,
             scale,
@@ -1588,59 +1597,64 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_fft_c2c(&self, dim: impl IntList, normalization: i64, forward: bool) -> Tensor {
-        self.f_internal_fft_c2c(dim, normalization, forward).unwrap()
+    pub fn f_internal_fft_c2c(
+        &self,
+        dim: impl IntList,
+        normalization: i64,
+        forward: bool,
+    ) -> Tensor {
+        self.internal_fft_c2c(dim, normalization, forward).unwrap()
     }
 
-    pub fn internal_fft_c2c_out(
+    pub fn f_internal_fft_c2c_out(
         &self,
         out: &Tensor,
         dim: impl IntList,
         normalization: i64,
         forward: bool,
     ) -> Tensor {
-        self.f_internal_fft_c2c_out(out, dim, normalization, forward).unwrap()
+        self.internal_fft_c2c_out(out, dim, normalization, forward).unwrap()
     }
 
-    pub fn internal_fft_c2r(
+    pub fn f_internal_fft_c2r(
         &self,
         dim: impl IntList,
         normalization: i64,
         last_dim_size: i64,
     ) -> Tensor {
-        self.f_internal_fft_c2r(dim, normalization, last_dim_size).unwrap()
+        self.internal_fft_c2r(dim, normalization, last_dim_size).unwrap()
     }
 
-    pub fn internal_fft_c2r_out(
+    pub fn f_internal_fft_c2r_out(
         &self,
         out: &Tensor,
         dim: impl IntList,
         normalization: i64,
         last_dim_size: i64,
     ) -> Tensor {
-        self.f_internal_fft_c2r_out(out, dim, normalization, last_dim_size).unwrap()
+        self.internal_fft_c2r_out(out, dim, normalization, last_dim_size).unwrap()
     }
 
-    pub fn internal_fft_r2c(
+    pub fn f_internal_fft_r2c(
         &self,
         dim: impl IntList,
         normalization: i64,
         onesided: bool,
     ) -> Tensor {
-        self.f_internal_fft_r2c(dim, normalization, onesided).unwrap()
+        self.internal_fft_r2c(dim, normalization, onesided).unwrap()
     }
 
-    pub fn internal_fft_r2c_out(
+    pub fn f_internal_fft_r2c_out(
         &self,
         out: &Tensor,
         dim: impl IntList,
         normalization: i64,
         onesided: bool,
     ) -> Tensor {
-        self.f_internal_fft_r2c_out(out, dim, normalization, onesided).unwrap()
+        self.internal_fft_r2c_out(out, dim, normalization, onesided).unwrap()
     }
 
-    pub fn internal_flash_attention_backward(
+    pub fn f_internal_flash_attention_backward(
         grad_out: &Tensor,
         query: &Tensor,
         key: &Tensor,
@@ -1656,7 +1670,7 @@ impl Tensor {
         philox_seed: i64,
         philox_offset: i64,
     ) -> (Tensor, Tensor, Tensor) {
-        Tensor::f_internal_flash_attention_backward(
+        Tensor::internal_flash_attention_backward(
             grad_out,
             query,
             key,
@@ -1675,28 +1689,34 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_foobar(&self, arg1: bool, arg2: bool, arg3: bool) -> Tensor {
-        self.f_internal_foobar(arg1, arg2, arg3).unwrap()
+    pub fn f_internal_foobar(&self, arg1: bool, arg2: bool, arg3: bool) -> Tensor {
+        self.internal_foobar(arg1, arg2, arg3).unwrap()
     }
 
-    pub fn internal_foobar_out(&self, out: &Tensor, arg1: bool, arg2: bool, arg3: bool) -> Tensor {
-        self.f_internal_foobar_out(out, arg1, arg2, arg3).unwrap()
+    pub fn f_internal_foobar_out(
+        &self,
+        out: &Tensor,
+        arg1: bool,
+        arg2: bool,
+        arg3: bool,
+    ) -> Tensor {
+        self.internal_foobar_out(out, arg1, arg2, arg3).unwrap()
     }
 
-    pub fn internal_fused_dropout(&self, p: f64) -> (Tensor, Tensor) {
-        self.f_internal_fused_dropout(p).unwrap()
+    pub fn f_internal_fused_dropout(&self, p: f64) -> (Tensor, Tensor) {
+        self.internal_fused_dropout(p).unwrap()
     }
 
-    pub fn internal_fused_dropout_out(
+    pub fn f_internal_fused_dropout_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
         p: f64,
     ) -> (Tensor, Tensor) {
-        self.f_internal_fused_dropout_out(out0, out1, p).unwrap()
+        self.internal_fused_dropout_out(out0, out1, p).unwrap()
     }
 
-    pub fn internal_fused_moving_avg_obs_fq_helper(
+    pub fn f_internal_fused_moving_avg_obs_fq_helper(
         &self,
         observer_on: &Tensor,
         fake_quant_on: &Tensor,
@@ -1711,7 +1731,7 @@ impl Tensor {
         per_row_fake_quant: bool,
         symmetric_quant: bool,
     ) -> (Tensor, Tensor) {
-        self.f_internal_fused_moving_avg_obs_fq_helper(
+        self.internal_fused_moving_avg_obs_fq_helper(
             observer_on,
             fake_quant_on,
             running_min,
@@ -1728,7 +1748,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_fused_moving_avg_obs_fq_helper_functional(
+    pub fn f_internal_fused_moving_avg_obs_fq_helper_functional(
         &self,
         observer_on: &Tensor,
         fake_quant_on: &Tensor,
@@ -1743,7 +1763,7 @@ impl Tensor {
         per_row_fake_quant: bool,
         symmetric_quant: bool,
     ) -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor) {
-        self.f_internal_fused_moving_avg_obs_fq_helper_functional(
+        self.internal_fused_moving_avg_obs_fq_helper_functional(
             observer_on,
             fake_quant_on,
             running_min,
@@ -1760,7 +1780,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_fused_moving_avg_obs_fq_helper_out(
+    pub fn f_internal_fused_moving_avg_obs_fq_helper_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -1777,7 +1797,7 @@ impl Tensor {
         per_row_fake_quant: bool,
         symmetric_quant: bool,
     ) -> (Tensor, Tensor) {
-        self.f_internal_fused_moving_avg_obs_fq_helper_out(
+        self.internal_fused_moving_avg_obs_fq_helper_out(
             out0,
             out1,
             observer_on,
@@ -1796,7 +1816,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_fused_sdp_choice<T: Borrow<Tensor>>(
+    pub fn f_internal_fused_sdp_choice<T: Borrow<Tensor>>(
         query: &Tensor,
         key: &Tensor,
         value: &Tensor,
@@ -1804,39 +1824,39 @@ impl Tensor {
         dropout_p: f64,
         is_causal: bool,
     ) -> i64 {
-        Tensor::f_internal_fused_sdp_choice(query, key, value, attn_mask, dropout_p, is_causal)
+        Tensor::internal_fused_sdp_choice(query, key, value, attn_mask, dropout_p, is_causal)
             .unwrap()
     }
 
-    pub fn internal_fw_primal(&self, level: i64) -> Tensor {
-        self.f_internal_fw_primal(level).unwrap()
+    pub fn f_internal_fw_primal(&self, level: i64) -> Tensor {
+        self.internal_fw_primal(level).unwrap()
     }
 
-    pub fn internal_fw_primal_copy(&self, level: i64) -> Tensor {
-        self.f_internal_fw_primal_copy(level).unwrap()
+    pub fn f_internal_fw_primal_copy(&self, level: i64) -> Tensor {
+        self.internal_fw_primal_copy(level).unwrap()
     }
 
-    pub fn internal_fw_primal_copy_out(&self, out: &Tensor, level: i64) -> Tensor {
-        self.f_internal_fw_primal_copy_out(out, level).unwrap()
+    pub fn f_internal_fw_primal_copy_out(&self, out: &Tensor, level: i64) -> Tensor {
+        self.internal_fw_primal_copy_out(out, level).unwrap()
     }
 
-    pub fn internal_gather_sparse_backward(
+    pub fn f_internal_gather_sparse_backward(
         &self,
         dim: i64,
         index: &Tensor,
         grad: &Tensor,
     ) -> Tensor {
-        self.f_internal_gather_sparse_backward(dim, index, grad).unwrap()
+        self.internal_gather_sparse_backward(dim, index, grad).unwrap()
     }
 
-    pub fn internal_grid_sampler_2d_cpu_fallback(
+    pub fn f_internal_grid_sampler_2d_cpu_fallback(
         &self,
         grid: &Tensor,
         interpolation_mode: i64,
         padding_mode: i64,
         align_corners: bool,
     ) -> Tensor {
-        self.f_internal_grid_sampler_2d_cpu_fallback(
+        self.internal_grid_sampler_2d_cpu_fallback(
             grid,
             interpolation_mode,
             padding_mode,
@@ -1845,7 +1865,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_grid_sampler_2d_cpu_fallback_backward(
+    pub fn f_internal_grid_sampler_2d_cpu_fallback_backward(
         &self,
         grad_output: &Tensor,
         grid: &Tensor,
@@ -1853,7 +1873,7 @@ impl Tensor {
         padding_mode: i64,
         align_corners: bool,
     ) -> (Tensor, Tensor) {
-        self.f_internal_grid_sampler_2d_cpu_fallback_backward(
+        self.internal_grid_sampler_2d_cpu_fallback_backward(
             grad_output,
             grid,
             interpolation_mode,
@@ -1863,7 +1883,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_grid_sampler_2d_cpu_fallback_out(
+    pub fn f_internal_grid_sampler_2d_cpu_fallback_out(
         &self,
         out: &Tensor,
         grid: &Tensor,
@@ -1871,7 +1891,7 @@ impl Tensor {
         padding_mode: i64,
         align_corners: bool,
     ) -> Tensor {
-        self.f_internal_grid_sampler_2d_cpu_fallback_out(
+        self.internal_grid_sampler_2d_cpu_fallback_out(
             out,
             grid,
             interpolation_mode,
@@ -1881,25 +1901,25 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_has_compatible_shallow_copy_type(&self, from: &Tensor) -> bool {
-        self.f_internal_has_compatible_shallow_copy_type(from).unwrap()
+    pub fn f_internal_has_compatible_shallow_copy_type(&self, from: &Tensor) -> bool {
+        self.internal_has_compatible_shallow_copy_type(from).unwrap()
     }
 
-    pub fn internal_has_same_storage_numel(&self, other: &Tensor) -> bool {
-        self.f_internal_has_same_storage_numel(other).unwrap()
+    pub fn f_internal_has_same_storage_numel(&self, other: &Tensor) -> bool {
+        self.internal_has_same_storage_numel(other).unwrap()
     }
 
-    pub fn internal_histogramdd_bin_edges<T: Borrow<Tensor>>(
+    pub fn f_internal_histogramdd_bin_edges<T: Borrow<Tensor>>(
         &self,
         bins: impl IntList,
         range: impl DoubleList,
         weight: Option<T>,
         density: bool,
     ) -> Vec<Tensor> {
-        self.f_internal_histogramdd_bin_edges(bins, range, weight, density).unwrap()
+        self.internal_histogramdd_bin_edges(bins, range, weight, density).unwrap()
     }
 
-    pub fn internal_histogramdd_bin_edges_out<T: Borrow<Tensor>>(
+    pub fn f_internal_histogramdd_bin_edges_out<T: Borrow<Tensor>>(
         &self,
         out: &[T],
         bins: impl IntList,
@@ -1907,20 +1927,20 @@ impl Tensor {
         weight: Option<T>,
         density: bool,
     ) {
-        self.f_internal_histogramdd_bin_edges_out(out, bins, range, weight, density).unwrap()
+        self.internal_histogramdd_bin_edges_out(out, bins, range, weight, density).unwrap()
     }
 
-    pub fn internal_histogramdd_from_bin_cts<T: Borrow<Tensor>>(
+    pub fn f_internal_histogramdd_from_bin_cts<T: Borrow<Tensor>>(
         &self,
         bins: impl IntList,
         range: impl DoubleList,
         weight: Option<T>,
         density: bool,
     ) -> Tensor {
-        self.f_internal_histogramdd_from_bin_cts(bins, range, weight, density).unwrap()
+        self.internal_histogramdd_from_bin_cts(bins, range, weight, density).unwrap()
     }
 
-    pub fn internal_histogramdd_from_bin_cts_out<T: Borrow<Tensor>>(
+    pub fn f_internal_histogramdd_from_bin_cts_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         bins: impl IntList,
@@ -1928,49 +1948,49 @@ impl Tensor {
         weight: Option<T>,
         density: bool,
     ) -> Tensor {
-        self.f_internal_histogramdd_from_bin_cts_out(out, bins, range, weight, density).unwrap()
+        self.internal_histogramdd_from_bin_cts_out(out, bins, range, weight, density).unwrap()
     }
 
-    pub fn internal_histogramdd_from_bin_tensors<T: Borrow<Tensor>>(
+    pub fn f_internal_histogramdd_from_bin_tensors<T: Borrow<Tensor>>(
         &self,
         bins: &[T],
         weight: Option<T>,
         density: bool,
     ) -> Tensor {
-        self.f_internal_histogramdd_from_bin_tensors(bins, weight, density).unwrap()
+        self.internal_histogramdd_from_bin_tensors(bins, weight, density).unwrap()
     }
 
-    pub fn internal_histogramdd_from_bin_tensors_out<T: Borrow<Tensor>>(
+    pub fn f_internal_histogramdd_from_bin_tensors_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         bins: &[T],
         weight: Option<T>,
         density: bool,
     ) -> Tensor {
-        self.f_internal_histogramdd_from_bin_tensors_out(out, bins, weight, density).unwrap()
+        self.internal_histogramdd_from_bin_tensors_out(out, bins, weight, density).unwrap()
     }
 
-    pub fn internal_index_put_impl<T: Borrow<Tensor>>(
+    pub fn f_internal_index_put_impl<T: Borrow<Tensor>>(
         &self,
         indices: &[Option<T>],
         values: &Tensor,
         accumulate: bool,
         unsafe_: bool,
     ) -> Tensor {
-        self.f_internal_index_put_impl(indices, values, accumulate, unsafe_).unwrap()
+        self.internal_index_put_impl(indices, values, accumulate, unsafe_).unwrap()
     }
 
-    pub fn internal_index_put_impl_<T: Borrow<Tensor>>(
+    pub fn f_internal_index_put_impl_<T: Borrow<Tensor>>(
         &mut self,
         indices: &[Option<T>],
         values: &Tensor,
         accumulate: bool,
         unsafe_: bool,
     ) -> Tensor {
-        self.f_internal_index_put_impl_(indices, values, accumulate, unsafe_).unwrap()
+        self.internal_index_put_impl_(indices, values, accumulate, unsafe_).unwrap()
     }
 
-    pub fn internal_index_put_impl_out<T: Borrow<Tensor>>(
+    pub fn f_internal_index_put_impl_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         indices: &[Option<T>],
@@ -1978,89 +1998,89 @@ impl Tensor {
         accumulate: bool,
         unsafe_: bool,
     ) -> Tensor {
-        self.f_internal_index_put_impl_out(out, indices, values, accumulate, unsafe_).unwrap()
+        self.internal_index_put_impl_out(out, indices, values, accumulate, unsafe_).unwrap()
     }
 
-    pub fn internal_indices(&self) -> Tensor {
-        self.f_internal_indices().unwrap()
+    pub fn f_internal_indices(&self) -> Tensor {
+        self.internal_indices().unwrap()
     }
 
-    pub fn internal_indices_copy(&self) -> Tensor {
-        self.f_internal_indices_copy().unwrap()
+    pub fn f_internal_indices_copy(&self) -> Tensor {
+        self.internal_indices_copy().unwrap()
     }
 
-    pub fn internal_indices_copy_out(&self, out: &Tensor) -> Tensor {
-        self.f_internal_indices_copy_out(out).unwrap()
+    pub fn f_internal_indices_copy_out(&self, out: &Tensor) -> Tensor {
+        self.internal_indices_copy_out(out).unwrap()
     }
 
-    pub fn internal_is_all_true(&self) -> Tensor {
-        self.f_internal_is_all_true().unwrap()
+    pub fn f_internal_is_all_true(&self) -> Tensor {
+        self.internal_is_all_true().unwrap()
     }
 
-    pub fn internal_is_any_true(&self) -> Tensor {
-        self.f_internal_is_any_true().unwrap()
+    pub fn f_internal_is_any_true(&self) -> Tensor {
+        self.internal_is_any_true().unwrap()
     }
 
-    pub fn internal_is_zerotensor(&self) -> bool {
-        self.f_internal_is_zerotensor().unwrap()
+    pub fn f_internal_is_zerotensor(&self) -> bool {
+        self.internal_is_zerotensor().unwrap()
     }
 
-    pub fn internal_linalg_check_errors(info: &Tensor, api_name: &str, is_matrix: bool) {
-        Tensor::f_internal_linalg_check_errors(info, api_name, is_matrix).unwrap()
+    pub fn f_internal_linalg_check_errors(info: &Tensor, api_name: &str, is_matrix: bool) {
+        Tensor::internal_linalg_check_errors(info, api_name, is_matrix).unwrap()
     }
 
-    pub fn internal_linalg_det(a: &Tensor) -> (Tensor, Tensor, Tensor) {
-        Tensor::f_internal_linalg_det(a).unwrap()
+    pub fn f_internal_linalg_det(a: &Tensor) -> (Tensor, Tensor, Tensor) {
+        Tensor::internal_linalg_det(a).unwrap()
     }
 
-    pub fn internal_linalg_det_result(
+    pub fn f_internal_linalg_det_result(
         result: &Tensor,
         lu: &Tensor,
         pivots: &Tensor,
         a: &Tensor,
     ) -> (Tensor, Tensor, Tensor) {
-        Tensor::f_internal_linalg_det_result(result, lu, pivots, a).unwrap()
+        Tensor::internal_linalg_det_result(result, lu, pivots, a).unwrap()
     }
 
-    pub fn internal_linalg_eigh(a: &Tensor, uplo: &str, compute_v: bool) -> (Tensor, Tensor) {
-        Tensor::f_internal_linalg_eigh(a, uplo, compute_v).unwrap()
+    pub fn f_internal_linalg_eigh(a: &Tensor, uplo: &str, compute_v: bool) -> (Tensor, Tensor) {
+        Tensor::internal_linalg_eigh(a, uplo, compute_v).unwrap()
     }
 
-    pub fn internal_linalg_eigh_eigenvalues(
+    pub fn f_internal_linalg_eigh_eigenvalues(
         eigenvalues: &Tensor,
         eigenvectors: &Tensor,
         a: &Tensor,
         uplo: &str,
         compute_v: bool,
     ) -> (Tensor, Tensor) {
-        Tensor::f_internal_linalg_eigh_eigenvalues(eigenvalues, eigenvectors, a, uplo, compute_v)
+        Tensor::internal_linalg_eigh_eigenvalues(eigenvalues, eigenvectors, a, uplo, compute_v)
             .unwrap()
     }
 
-    pub fn internal_linalg_slogdet(a: &Tensor) -> (Tensor, Tensor, Tensor, Tensor) {
-        Tensor::f_internal_linalg_slogdet(a).unwrap()
+    pub fn f_internal_linalg_slogdet(a: &Tensor) -> (Tensor, Tensor, Tensor, Tensor) {
+        Tensor::internal_linalg_slogdet(a).unwrap()
     }
 
-    pub fn internal_linalg_slogdet_sign(
+    pub fn f_internal_linalg_slogdet_sign(
         sign: &Tensor,
         logabsdet: &Tensor,
         lu: &Tensor,
         pivots: &Tensor,
         a: &Tensor,
     ) -> (Tensor, Tensor, Tensor, Tensor) {
-        Tensor::f_internal_linalg_slogdet_sign(sign, logabsdet, lu, pivots, a).unwrap()
+        Tensor::internal_linalg_slogdet_sign(sign, logabsdet, lu, pivots, a).unwrap()
     }
 
-    pub fn internal_linalg_solve_ex(
+    pub fn f_internal_linalg_solve_ex(
         a: &Tensor,
         b: &Tensor,
         left: bool,
         check_errors: bool,
     ) -> (Tensor, Tensor, Tensor, Tensor) {
-        Tensor::f_internal_linalg_solve_ex(a, b, left, check_errors).unwrap()
+        Tensor::internal_linalg_solve_ex(a, b, left, check_errors).unwrap()
     }
 
-    pub fn internal_linalg_solve_ex_result(
+    pub fn f_internal_linalg_solve_ex_result(
         result: &Tensor,
         lu: &Tensor,
         pivots: &Tensor,
@@ -2070,29 +2090,20 @@ impl Tensor {
         left: bool,
         check_errors: bool,
     ) -> (Tensor, Tensor, Tensor, Tensor) {
-        Tensor::f_internal_linalg_solve_ex_result(
-            result,
-            lu,
-            pivots,
-            info,
-            a,
-            b,
-            left,
-            check_errors,
-        )
-        .unwrap()
+        Tensor::internal_linalg_solve_ex_result(result, lu, pivots, info, a, b, left, check_errors)
+            .unwrap()
     }
 
-    pub fn internal_linalg_svd(
+    pub fn f_internal_linalg_svd(
         a: &Tensor,
         full_matrices: bool,
         compute_uv: bool,
         driver: &str,
     ) -> (Tensor, Tensor, Tensor) {
-        Tensor::f_internal_linalg_svd(a, full_matrices, compute_uv, driver).unwrap()
+        Tensor::internal_linalg_svd(a, full_matrices, compute_uv, driver).unwrap()
     }
 
-    pub fn internal_linalg_svd_u(
+    pub fn f_internal_linalg_svd_u(
         u: &Tensor,
         s: &Tensor,
         vh: &Tensor,
@@ -2101,46 +2112,51 @@ impl Tensor {
         compute_uv: bool,
         driver: &str,
     ) -> (Tensor, Tensor, Tensor) {
-        Tensor::f_internal_linalg_svd_u(u, s, vh, a, full_matrices, compute_uv, driver).unwrap()
+        Tensor::internal_linalg_svd_u(u, s, vh, a, full_matrices, compute_uv, driver).unwrap()
     }
 
-    pub fn internal_log_softmax(&self, dim: i64, half_to_float: bool) -> Tensor {
-        self.f_internal_log_softmax(dim, half_to_float).unwrap()
+    pub fn f_internal_log_softmax(&self, dim: i64, half_to_float: bool) -> Tensor {
+        self.internal_log_softmax(dim, half_to_float).unwrap()
     }
 
-    pub fn internal_log_softmax_backward_data(
+    pub fn f_internal_log_softmax_backward_data(
         grad_output: &Tensor,
         output: &Tensor,
         dim: i64,
         input_dtype: Kind,
     ) -> Tensor {
-        Tensor::f_internal_log_softmax_backward_data(grad_output, output, dim, input_dtype).unwrap()
+        Tensor::internal_log_softmax_backward_data(grad_output, output, dim, input_dtype).unwrap()
     }
 
-    pub fn internal_log_softmax_backward_data_out(
+    pub fn f_internal_log_softmax_backward_data_out(
         out: &Tensor,
         grad_output: &Tensor,
         output: &Tensor,
         dim: i64,
         input_dtype: Kind,
     ) -> Tensor {
-        Tensor::f_internal_log_softmax_backward_data_out(out, grad_output, output, dim, input_dtype)
+        Tensor::internal_log_softmax_backward_data_out(out, grad_output, output, dim, input_dtype)
             .unwrap()
     }
 
-    pub fn internal_log_softmax_out(&self, out: &Tensor, dim: i64, half_to_float: bool) -> Tensor {
-        self.f_internal_log_softmax_out(out, dim, half_to_float).unwrap()
+    pub fn f_internal_log_softmax_out(
+        &self,
+        out: &Tensor,
+        dim: i64,
+        half_to_float: bool,
+    ) -> Tensor {
+        self.internal_log_softmax_out(out, dim, half_to_float).unwrap()
     }
 
-    pub fn internal_logcumsumexp(&self, dim: i64) -> Tensor {
-        self.f_internal_logcumsumexp(dim).unwrap()
+    pub fn f_internal_logcumsumexp(&self, dim: i64) -> Tensor {
+        self.internal_logcumsumexp(dim).unwrap()
     }
 
-    pub fn internal_logcumsumexp_out(&self, out: &Tensor, dim: i64) -> Tensor {
-        self.f_internal_logcumsumexp_out(out, dim).unwrap()
+    pub fn f_internal_logcumsumexp_out(&self, out: &Tensor, dim: i64) -> Tensor {
+        self.internal_logcumsumexp_out(out, dim).unwrap()
     }
 
-    pub fn internal_lstm_mps<T: Borrow<Tensor>>(
+    pub fn f_internal_lstm_mps<T: Borrow<Tensor>>(
         &self,
         hx: &[T],
         params: &[T],
@@ -2151,7 +2167,7 @@ impl Tensor {
         bidirectional: bool,
         batch_first: bool,
     ) -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor) {
-        self.f_internal_lstm_mps(
+        self.internal_lstm_mps(
             hx,
             params,
             has_biases,
@@ -2164,7 +2180,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_lstm_mps_out<T: Borrow<Tensor>>(
+    pub fn f_internal_lstm_mps_out<T: Borrow<Tensor>>(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -2181,7 +2197,7 @@ impl Tensor {
         bidirectional: bool,
         batch_first: bool,
     ) -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor) {
-        self.f_internal_lstm_mps_out(
+        self.internal_lstm_mps_out(
             out0,
             out1,
             out2,
@@ -2200,130 +2216,134 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_lu_with_info(
+    pub fn f_internal_lu_with_info(
         &self,
         pivot: bool,
         check_errors: bool,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_internal_lu_with_info(pivot, check_errors).unwrap()
+        self.internal_lu_with_info(pivot, check_errors).unwrap()
     }
 
-    pub fn internal_make_dual(primal: &Tensor, tangent: &Tensor, level: i64) -> Tensor {
-        Tensor::f_internal_make_dual(primal, tangent, level).unwrap()
+    pub fn f_internal_make_dual(primal: &Tensor, tangent: &Tensor, level: i64) -> Tensor {
+        Tensor::internal_make_dual(primal, tangent, level).unwrap()
     }
 
-    pub fn internal_make_dual_copy(primal: &Tensor, tangent: &Tensor, level: i64) -> Tensor {
-        Tensor::f_internal_make_dual_copy(primal, tangent, level).unwrap()
+    pub fn f_internal_make_dual_copy(primal: &Tensor, tangent: &Tensor, level: i64) -> Tensor {
+        Tensor::internal_make_dual_copy(primal, tangent, level).unwrap()
     }
 
-    pub fn internal_make_dual_copy_out(
+    pub fn f_internal_make_dual_copy_out(
         out: &Tensor,
         primal: &Tensor,
         tangent: &Tensor,
         level: i64,
     ) -> Tensor {
-        Tensor::f_internal_make_dual_copy_out(out, primal, tangent, level).unwrap()
+        Tensor::internal_make_dual_copy_out(out, primal, tangent, level).unwrap()
     }
 
-    pub fn internal_make_per_channel_quantized_tensor(
+    pub fn f_internal_make_per_channel_quantized_tensor(
         &self,
         scale: &Tensor,
         zero_point: &Tensor,
         axis: i64,
     ) -> Tensor {
-        self.f_internal_make_per_channel_quantized_tensor(scale, zero_point, axis).unwrap()
+        self.internal_make_per_channel_quantized_tensor(scale, zero_point, axis).unwrap()
     }
 
-    pub fn internal_make_per_channel_quantized_tensor_out(
+    pub fn f_internal_make_per_channel_quantized_tensor_out(
         &self,
         out: &Tensor,
         scale: &Tensor,
         zero_point: &Tensor,
         axis: i64,
     ) -> Tensor {
-        self.f_internal_make_per_channel_quantized_tensor_out(out, scale, zero_point, axis).unwrap()
+        self.internal_make_per_channel_quantized_tensor_out(out, scale, zero_point, axis).unwrap()
     }
 
-    pub fn internal_make_per_tensor_quantized_tensor(&self, scale: f64, zero_point: i64) -> Tensor {
-        self.f_internal_make_per_tensor_quantized_tensor(scale, zero_point).unwrap()
+    pub fn f_internal_make_per_tensor_quantized_tensor(
+        &self,
+        scale: f64,
+        zero_point: i64,
+    ) -> Tensor {
+        self.internal_make_per_tensor_quantized_tensor(scale, zero_point).unwrap()
     }
 
-    pub fn internal_make_per_tensor_quantized_tensor_out(
+    pub fn f_internal_make_per_tensor_quantized_tensor_out(
         &self,
         out: &Tensor,
         scale: f64,
         zero_point: i64,
     ) -> Tensor {
-        self.f_internal_make_per_tensor_quantized_tensor_out(out, scale, zero_point).unwrap()
+        self.internal_make_per_tensor_quantized_tensor_out(out, scale, zero_point).unwrap()
     }
 
-    pub fn internal_masked_scale(&self, mask: &Tensor, scale: f64) -> Tensor {
-        self.f_internal_masked_scale(mask, scale).unwrap()
+    pub fn f_internal_masked_scale(&self, mask: &Tensor, scale: f64) -> Tensor {
+        self.internal_masked_scale(mask, scale).unwrap()
     }
 
-    pub fn internal_masked_scale_out(&self, out: &Tensor, mask: &Tensor, scale: f64) -> Tensor {
-        self.f_internal_masked_scale_out(out, mask, scale).unwrap()
+    pub fn f_internal_masked_scale_out(&self, out: &Tensor, mask: &Tensor, scale: f64) -> Tensor {
+        self.internal_masked_scale_out(out, mask, scale).unwrap()
     }
 
-    pub fn internal_masked_softmax(
+    pub fn f_internal_masked_softmax(
         &self,
         mask: &Tensor,
         dim: impl Into<Option<i64>>,
         mask_type: impl Into<Option<i64>>,
     ) -> Tensor {
-        self.f_internal_masked_softmax(mask, dim, mask_type).unwrap()
+        self.internal_masked_softmax(mask, dim, mask_type).unwrap()
     }
 
-    pub fn internal_masked_softmax_backward(
+    pub fn f_internal_masked_softmax_backward(
         grad_output: &Tensor,
         output: &Tensor,
         mask: &Tensor,
         dim: impl Into<Option<i64>>,
     ) -> Tensor {
-        Tensor::f_internal_masked_softmax_backward(grad_output, output, mask, dim).unwrap()
+        Tensor::internal_masked_softmax_backward(grad_output, output, mask, dim).unwrap()
     }
 
-    pub fn internal_masked_softmax_backward_out(
+    pub fn f_internal_masked_softmax_backward_out(
         out: &Tensor,
         grad_output: &Tensor,
         output: &Tensor,
         mask: &Tensor,
         dim: impl Into<Option<i64>>,
     ) -> Tensor {
-        Tensor::f_internal_masked_softmax_backward_out(out, grad_output, output, mask, dim).unwrap()
+        Tensor::internal_masked_softmax_backward_out(out, grad_output, output, mask, dim).unwrap()
     }
 
-    pub fn internal_masked_softmax_out(
+    pub fn f_internal_masked_softmax_out(
         &self,
         out: &Tensor,
         mask: &Tensor,
         dim: impl Into<Option<i64>>,
         mask_type: impl Into<Option<i64>>,
     ) -> Tensor {
-        self.f_internal_masked_softmax_out(out, mask, dim, mask_type).unwrap()
+        self.internal_masked_softmax_out(out, mask, dim, mask_type).unwrap()
     }
 
-    pub fn internal_mkldnn_reshape(&self, shape: impl IntList) -> Tensor {
-        self.f_internal_mkldnn_reshape(shape).unwrap()
+    pub fn f_internal_mkldnn_reshape(&self, shape: impl IntList) -> Tensor {
+        self.internal_mkldnn_reshape(shape).unwrap()
     }
 
-    pub fn internal_mkldnn_reshape_out(&self, out: &Tensor, shape: impl IntList) -> Tensor {
-        self.f_internal_mkldnn_reshape_out(out, shape).unwrap()
+    pub fn f_internal_mkldnn_reshape_out(&self, out: &Tensor, shape: impl IntList) -> Tensor {
+        self.internal_mkldnn_reshape_out(out, shape).unwrap()
     }
 
-    pub fn internal_mkldnn_transpose(&self, dim0: i64, dim1: i64) -> Tensor {
-        self.f_internal_mkldnn_transpose(dim0, dim1).unwrap()
+    pub fn f_internal_mkldnn_transpose(&self, dim0: i64, dim1: i64) -> Tensor {
+        self.internal_mkldnn_transpose(dim0, dim1).unwrap()
     }
 
-    pub fn internal_mkldnn_transpose_(&mut self, dim0: i64, dim1: i64) -> Tensor {
-        self.f_internal_mkldnn_transpose_(dim0, dim1).unwrap()
+    pub fn f_internal_mkldnn_transpose_(&mut self, dim0: i64, dim1: i64) -> Tensor {
+        self.internal_mkldnn_transpose_(dim0, dim1).unwrap()
     }
 
-    pub fn internal_mkldnn_transpose_out(&self, out: &Tensor, dim0: i64, dim1: i64) -> Tensor {
-        self.f_internal_mkldnn_transpose_out(out, dim0, dim1).unwrap()
+    pub fn f_internal_mkldnn_transpose_out(&self, out: &Tensor, dim0: i64, dim1: i64) -> Tensor {
+        self.internal_mkldnn_transpose_out(out, dim0, dim1).unwrap()
     }
 
-    pub fn internal_mps_convolution<T: Borrow<Tensor>>(
+    pub fn f_internal_mps_convolution<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -2332,10 +2352,10 @@ impl Tensor {
         dilation: impl IntList,
         groups: i64,
     ) -> Tensor {
-        self.f_internal_mps_convolution(weight, bias, padding, stride, dilation, groups).unwrap()
+        self.internal_mps_convolution(weight, bias, padding, stride, dilation, groups).unwrap()
     }
 
-    pub fn internal_mps_convolution_out<T: Borrow<Tensor>>(
+    pub fn f_internal_mps_convolution_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -2345,11 +2365,11 @@ impl Tensor {
         dilation: impl IntList,
         groups: i64,
     ) -> Tensor {
-        self.f_internal_mps_convolution_out(out, weight, bias, padding, stride, dilation, groups)
+        self.internal_mps_convolution_out(out, weight, bias, padding, stride, dilation, groups)
             .unwrap()
     }
 
-    pub fn internal_mps_convolution_transpose(
+    pub fn f_internal_mps_convolution_transpose(
         &self,
         weight: &Tensor,
         padding: impl IntList,
@@ -2358,7 +2378,7 @@ impl Tensor {
         dilation: impl IntList,
         groups: i64,
     ) -> Tensor {
-        self.f_internal_mps_convolution_transpose(
+        self.internal_mps_convolution_transpose(
             weight,
             padding,
             output_padding,
@@ -2369,7 +2389,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_mps_convolution_transpose_out(
+    pub fn f_internal_mps_convolution_transpose_out(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -2379,7 +2399,7 @@ impl Tensor {
         dilation: impl IntList,
         groups: i64,
     ) -> Tensor {
-        self.f_internal_mps_convolution_transpose_out(
+        self.internal_mps_convolution_transpose_out(
             out,
             weight,
             padding,
@@ -2391,7 +2411,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_native_batch_norm_legit<T: Borrow<Tensor>>(
+    pub fn f_internal_native_batch_norm_legit<T: Borrow<Tensor>>(
         &self,
         weight: Option<T>,
         bias: Option<T>,
@@ -2401,7 +2421,7 @@ impl Tensor {
         momentum: f64,
         eps: f64,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_internal_native_batch_norm_legit(
+        self.internal_native_batch_norm_legit(
             weight,
             bias,
             running_mean,
@@ -2413,7 +2433,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_native_batch_norm_legit_functional<T: Borrow<Tensor>>(
+    pub fn f_internal_native_batch_norm_legit_functional<T: Borrow<Tensor>>(
         &self,
         weight: Option<T>,
         bias: Option<T>,
@@ -2423,7 +2443,7 @@ impl Tensor {
         momentum: f64,
         eps: f64,
     ) -> (Tensor, Tensor, Tensor, Tensor, Tensor) {
-        self.f_internal_native_batch_norm_legit_functional(
+        self.internal_native_batch_norm_legit_functional(
             weight,
             bias,
             running_mean,
@@ -2435,7 +2455,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_native_batch_norm_legit_no_stats<T: Borrow<Tensor>>(
+    pub fn f_internal_native_batch_norm_legit_no_stats<T: Borrow<Tensor>>(
         &self,
         weight: Option<T>,
         bias: Option<T>,
@@ -2443,11 +2463,11 @@ impl Tensor {
         momentum: f64,
         eps: f64,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_internal_native_batch_norm_legit_no_stats(weight, bias, training, momentum, eps)
+        self.internal_native_batch_norm_legit_no_stats(weight, bias, training, momentum, eps)
             .unwrap()
     }
 
-    pub fn internal_native_batch_norm_legit_no_stats_out<T: Borrow<Tensor>>(
+    pub fn f_internal_native_batch_norm_legit_no_stats_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         save_mean: &Tensor,
@@ -2458,7 +2478,7 @@ impl Tensor {
         momentum: f64,
         eps: f64,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_internal_native_batch_norm_legit_no_stats_out(
+        self.internal_native_batch_norm_legit_no_stats_out(
             out,
             save_mean,
             save_invstd,
@@ -2471,7 +2491,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_native_batch_norm_legit_out<T: Borrow<Tensor>>(
+    pub fn f_internal_native_batch_norm_legit_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         save_mean: &Tensor,
@@ -2484,7 +2504,7 @@ impl Tensor {
         momentum: f64,
         eps: f64,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_internal_native_batch_norm_legit_out(
+        self.internal_native_batch_norm_legit_out(
             out,
             save_mean,
             save_invstd,
@@ -2499,7 +2519,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_native_decoder_only_multi_head_attention<T: Borrow<Tensor>>(
+    pub fn f_internal_native_decoder_only_multi_head_attention<T: Borrow<Tensor>>(
         query: &Tensor,
         key: &Tensor,
         value: &Tensor,
@@ -2515,7 +2535,7 @@ impl Tensor {
         need_weights: bool,
         average_attn_weights: bool,
     ) -> (Tensor, Tensor, Tensor, Tensor) {
-        Tensor::f_internal_native_decoder_only_multi_head_attention(
+        Tensor::internal_native_decoder_only_multi_head_attention(
             query,
             key,
             value,
@@ -2534,7 +2554,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_native_decoder_only_multi_head_attention_out<T: Borrow<Tensor>>(
+    pub fn f_internal_native_decoder_only_multi_head_attention_out<T: Borrow<Tensor>>(
         out0: &Tensor,
         out1: &Tensor,
         out2: &Tensor,
@@ -2554,7 +2574,7 @@ impl Tensor {
         need_weights: bool,
         average_attn_weights: bool,
     ) -> (Tensor, Tensor, Tensor, Tensor) {
-        Tensor::f_internal_native_decoder_only_multi_head_attention_out(
+        Tensor::internal_native_decoder_only_multi_head_attention_out(
             out0,
             out1,
             out2,
@@ -2577,7 +2597,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_native_multi_head_attention<T: Borrow<Tensor>>(
+    pub fn f_internal_native_multi_head_attention<T: Borrow<Tensor>>(
         query: &Tensor,
         key: &Tensor,
         value: &Tensor,
@@ -2592,7 +2612,7 @@ impl Tensor {
         average_attn_weights: bool,
         mask_type: impl Into<Option<i64>>,
     ) -> (Tensor, Tensor) {
-        Tensor::f_internal_native_multi_head_attention(
+        Tensor::internal_native_multi_head_attention(
             query,
             key,
             value,
@@ -2610,7 +2630,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_native_multi_head_attention_out<T: Borrow<Tensor>>(
+    pub fn f_internal_native_multi_head_attention_out<T: Borrow<Tensor>>(
         out0: &Tensor,
         out1: &Tensor,
         query: &Tensor,
@@ -2627,7 +2647,7 @@ impl Tensor {
         average_attn_weights: bool,
         mask_type: impl Into<Option<i64>>,
     ) -> (Tensor, Tensor) {
-        Tensor::f_internal_native_multi_head_attention_out(
+        Tensor::internal_native_multi_head_attention_out(
             out0,
             out1,
             query,
@@ -2647,50 +2667,49 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_neg_view(&self) -> Tensor {
-        self.f_internal_neg_view().unwrap()
+    pub fn f_internal_neg_view(&self) -> Tensor {
+        self.internal_neg_view().unwrap()
     }
 
-    pub fn internal_neg_view_copy(&self) -> Tensor {
-        self.f_internal_neg_view_copy().unwrap()
+    pub fn f_internal_neg_view_copy(&self) -> Tensor {
+        self.internal_neg_view_copy().unwrap()
     }
 
-    pub fn internal_neg_view_copy_out(&self, out: &Tensor) -> Tensor {
-        self.f_internal_neg_view_copy_out(out).unwrap()
+    pub fn f_internal_neg_view_copy_out(&self, out: &Tensor) -> Tensor {
+        self.internal_neg_view_copy_out(out).unwrap()
     }
 
-    pub fn internal_nested_from_padded(
+    pub fn f_internal_nested_from_padded(
         padded: &Tensor,
         cpu_nested_shape_example: &Tensor,
         fuse_transform_0213: bool,
     ) -> Tensor {
-        Tensor::f_internal_nested_from_padded(padded, cpu_nested_shape_example, fuse_transform_0213)
+        Tensor::internal_nested_from_padded(padded, cpu_nested_shape_example, fuse_transform_0213)
             .unwrap()
     }
 
-    pub fn internal_nested_from_padded_and_nested_example(
+    pub fn f_internal_nested_from_padded_and_nested_example(
         padded: &Tensor,
         nt_example: &Tensor,
     ) -> Tensor {
-        Tensor::f_internal_nested_from_padded_and_nested_example(padded, nt_example).unwrap()
+        Tensor::internal_nested_from_padded_and_nested_example(padded, nt_example).unwrap()
     }
 
-    pub fn internal_nested_from_padded_and_nested_example_out(
+    pub fn f_internal_nested_from_padded_and_nested_example_out(
         out: &Tensor,
         padded: &Tensor,
         nt_example: &Tensor,
     ) -> Tensor {
-        Tensor::f_internal_nested_from_padded_and_nested_example_out(out, padded, nt_example)
-            .unwrap()
+        Tensor::internal_nested_from_padded_and_nested_example_out(out, padded, nt_example).unwrap()
     }
 
-    pub fn internal_nested_from_padded_out(
+    pub fn f_internal_nested_from_padded_out(
         out: &Tensor,
         padded: &Tensor,
         cpu_nested_shape_example: &Tensor,
         fuse_transform_0213: bool,
     ) -> Tensor {
-        Tensor::f_internal_nested_from_padded_out(
+        Tensor::internal_nested_from_padded_out(
             out,
             padded,
             cpu_nested_shape_example,
@@ -2699,86 +2718,85 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_nested_select_backward(
+    pub fn f_internal_nested_select_backward(
         &self,
         grad_output: &Tensor,
         dim: i64,
         index: i64,
     ) -> Tensor {
-        self.f_internal_nested_select_backward(grad_output, dim, index).unwrap()
+        self.internal_nested_select_backward(grad_output, dim, index).unwrap()
     }
 
-    pub fn internal_nested_sum_backward(
+    pub fn f_internal_nested_sum_backward(
         &self,
         grad: &Tensor,
         dim: impl IntListOption,
         keepdim: bool,
     ) -> Tensor {
-        self.f_internal_nested_sum_backward(grad, dim, keepdim).unwrap()
+        self.internal_nested_sum_backward(grad, dim, keepdim).unwrap()
     }
 
-    pub fn internal_nested_view_from_buffer(
+    pub fn f_internal_nested_view_from_buffer(
         &self,
         nested_size: &Tensor,
         nested_strides: &Tensor,
         offsets: impl IntList,
     ) -> Tensor {
-        self.f_internal_nested_view_from_buffer(nested_size, nested_strides, offsets).unwrap()
+        self.internal_nested_view_from_buffer(nested_size, nested_strides, offsets).unwrap()
     }
 
-    pub fn internal_nested_view_from_buffer_copy(
+    pub fn f_internal_nested_view_from_buffer_copy(
         &self,
         nested_size: &Tensor,
         nested_strides: &Tensor,
         offsets: impl IntList,
     ) -> Tensor {
-        self.f_internal_nested_view_from_buffer_copy(nested_size, nested_strides, offsets).unwrap()
+        self.internal_nested_view_from_buffer_copy(nested_size, nested_strides, offsets).unwrap()
     }
 
-    pub fn internal_nested_view_from_buffer_copy_out(
+    pub fn f_internal_nested_view_from_buffer_copy_out(
         &self,
         out: &Tensor,
         nested_size: &Tensor,
         nested_strides: &Tensor,
         offsets: impl IntList,
     ) -> Tensor {
-        self.f_internal_nested_view_from_buffer_copy_out(out, nested_size, nested_strides, offsets)
+        self.internal_nested_view_from_buffer_copy_out(out, nested_size, nested_strides, offsets)
             .unwrap()
     }
 
-    pub fn internal_new_zeros_with_same_feature_meta(
+    pub fn f_internal_new_zeros_with_same_feature_meta(
         &self,
         other: &Tensor,
         self_num_batch_dims: i64,
     ) -> Tensor {
-        self.f_internal_new_zeros_with_same_feature_meta(other, self_num_batch_dims).unwrap()
+        self.internal_new_zeros_with_same_feature_meta(other, self_num_batch_dims).unwrap()
     }
 
-    pub fn internal_new_zeros_with_same_feature_meta_out(
+    pub fn f_internal_new_zeros_with_same_feature_meta_out(
         &self,
         out: &Tensor,
         other: &Tensor,
         self_num_batch_dims: i64,
     ) -> Tensor {
-        self.f_internal_new_zeros_with_same_feature_meta_out(out, other, self_num_batch_dims)
-            .unwrap()
+        self.internal_new_zeros_with_same_feature_meta_out(out, other, self_num_batch_dims).unwrap()
     }
 
-    pub fn internal_nnpack_available() -> bool {
-        Tensor::f_internal_nnpack_available().unwrap()
+    pub fn f_internal_nnpack_available() -> bool {
+        Tensor::internal_nnpack_available().unwrap()
     }
 
-    pub fn internal_nnpack_spatial_convolution<T: Borrow<Tensor>>(
+    pub fn f_internal_nnpack_spatial_convolution<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
         padding: impl IntList,
         stride: impl IntList,
     ) -> Tensor {
-        self.f_internal_nnpack_spatial_convolution(weight, bias, padding, stride).unwrap()
+        self.internal_nnpack_spatial_convolution(weight, bias, padding, stride).unwrap()
     }
 
-    pub fn internal_nnpack_spatial_convolution_out<T: Borrow<Tensor>>(
+    pub fn f_internal_nnpack_spatial_convolution_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -2786,62 +2804,62 @@ impl Tensor {
         padding: impl IntList,
         stride: impl IntList,
     ) -> Tensor {
-        self.f_internal_nnpack_spatial_convolution_out(out, weight, bias, padding, stride).unwrap()
+        self.internal_nnpack_spatial_convolution_out(out, weight, bias, padding, stride).unwrap()
     }
 
-    pub fn internal_nnz(&self) -> i64 {
-        self.f_internal_nnz().unwrap()
+    pub fn f_internal_nnz(&self) -> i64 {
+        self.internal_nnz().unwrap()
     }
 
-    pub fn internal_pack_padded_sequence(
+    pub fn f_internal_pack_padded_sequence(
         &self,
         lengths: &Tensor,
         batch_first: bool,
     ) -> (Tensor, Tensor) {
-        self.f_internal_pack_padded_sequence(lengths, batch_first).unwrap()
+        self.internal_pack_padded_sequence(lengths, batch_first).unwrap()
     }
 
-    pub fn internal_pack_padded_sequence_backward(
+    pub fn f_internal_pack_padded_sequence_backward(
         grad: &Tensor,
         input_size: impl IntList,
         batch_sizes: &Tensor,
         batch_first: bool,
     ) -> Tensor {
-        Tensor::f_internal_pack_padded_sequence_backward(grad, input_size, batch_sizes, batch_first)
+        Tensor::internal_pack_padded_sequence_backward(grad, input_size, batch_sizes, batch_first)
             .unwrap()
     }
 
-    pub fn internal_pack_padded_sequence_out(
+    pub fn f_internal_pack_padded_sequence_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
         lengths: &Tensor,
         batch_first: bool,
     ) -> (Tensor, Tensor) {
-        self.f_internal_pack_padded_sequence_out(out0, out1, lengths, batch_first).unwrap()
+        self.internal_pack_padded_sequence_out(out0, out1, lengths, batch_first).unwrap()
     }
 
-    pub fn internal_pad_circular(&self, pad: impl IntList) -> Tensor {
-        self.f_internal_pad_circular(pad).unwrap()
+    pub fn f_internal_pad_circular(&self, pad: impl IntList) -> Tensor {
+        self.internal_pad_circular(pad).unwrap()
     }
 
-    pub fn internal_pad_enum(
+    pub fn f_internal_pad_enum(
         &self,
         pad: impl IntList,
         mode: i64,
         value: impl Into<Option<f64>>,
     ) -> Tensor {
-        self.f_internal_pad_enum(pad, mode, value).unwrap()
+        self.internal_pad_enum(pad, mode, value).unwrap()
     }
 
-    pub fn internal_pad_packed_sequence<S: Into<Scalar>>(
+    pub fn f_internal_pad_packed_sequence<S: Into<Scalar>>(
         data: &Tensor,
         batch_sizes: &Tensor,
         batch_first: bool,
         padding_value: S,
         total_length: i64,
     ) -> (Tensor, Tensor) {
-        Tensor::f_internal_pad_packed_sequence(
+        Tensor::internal_pad_packed_sequence(
             data,
             batch_sizes,
             batch_first,
@@ -2851,107 +2869,111 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_pdist_backward(&self, grad: &Tensor, p: f64, pdist: &Tensor) -> Tensor {
-        self.f_internal_pdist_backward(grad, p, pdist).unwrap()
+    pub fn f_internal_pdist_backward(&self, grad: &Tensor, p: f64, pdist: &Tensor) -> Tensor {
+        self.internal_pdist_backward(grad, p, pdist).unwrap()
     }
 
-    pub fn internal_pdist_backward_out(
+    pub fn f_internal_pdist_backward_out(
         &self,
         out: &Tensor,
         grad: &Tensor,
         p: f64,
         pdist: &Tensor,
     ) -> Tensor {
-        self.f_internal_pdist_backward_out(out, grad, p, pdist).unwrap()
+        self.internal_pdist_backward_out(out, grad, p, pdist).unwrap()
     }
 
-    pub fn internal_pin_memory(&self, device: Device) -> Tensor {
-        self.f_internal_pin_memory(device).unwrap()
+    pub fn f_internal_pin_memory(&self, device: Device) -> Tensor {
+        self.internal_pin_memory(device).unwrap()
     }
 
-    pub fn internal_pin_memory_out(&self, out: &Tensor, device: Device) -> Tensor {
-        self.f_internal_pin_memory_out(out, device).unwrap()
+    pub fn f_internal_pin_memory_out(&self, out: &Tensor, device: Device) -> Tensor {
+        self.internal_pin_memory_out(out, device).unwrap()
     }
 
-    pub fn internal_prelu_kernel(&self, weight: &Tensor) -> Tensor {
-        self.f_internal_prelu_kernel(weight).unwrap()
+    pub fn f_internal_prelu_kernel(&self, weight: &Tensor) -> Tensor {
+        self.internal_prelu_kernel(weight).unwrap()
     }
 
-    pub fn internal_prelu_kernel_backward(
+    pub fn f_internal_prelu_kernel_backward(
         &self,
         grad_output: &Tensor,
         weight: &Tensor,
     ) -> (Tensor, Tensor) {
-        self.f_internal_prelu_kernel_backward(grad_output, weight).unwrap()
+        self.internal_prelu_kernel_backward(grad_output, weight).unwrap()
     }
 
-    pub fn internal_remove_batch_dim(&self, level: i64, batch_size: i64, out_dim: i64) -> Tensor {
-        self.f_internal_remove_batch_dim(level, batch_size, out_dim).unwrap()
+    pub fn f_internal_remove_batch_dim(&self, level: i64, batch_size: i64, out_dim: i64) -> Tensor {
+        self.internal_remove_batch_dim(level, batch_size, out_dim).unwrap()
     }
 
-    pub fn internal_reshape_alias(&self, size: impl IntList, stride: impl IntList) -> Tensor {
-        self.f_internal_reshape_alias(size, stride).unwrap()
+    pub fn f_internal_reshape_alias(&self, size: impl IntList, stride: impl IntList) -> Tensor {
+        self.internal_reshape_alias(size, stride).unwrap()
     }
 
-    pub fn internal_reshape_alias_copy(&self, size: impl IntList, stride: impl IntList) -> Tensor {
-        self.f_internal_reshape_alias_copy(size, stride).unwrap()
+    pub fn f_internal_reshape_alias_copy(
+        &self,
+        size: impl IntList,
+        stride: impl IntList,
+    ) -> Tensor {
+        self.internal_reshape_alias_copy(size, stride).unwrap()
     }
 
-    pub fn internal_reshape_alias_copy_out(
+    pub fn f_internal_reshape_alias_copy_out(
         &self,
         out: &Tensor,
         size: impl IntList,
         stride: impl IntList,
     ) -> Tensor {
-        self.f_internal_reshape_alias_copy_out(out, size, stride).unwrap()
+        self.internal_reshape_alias_copy_out(out, size, stride).unwrap()
     }
 
-    pub fn internal_reshape_copy(&self, size: impl IntList) -> Tensor {
-        self.f_internal_reshape_copy(size).unwrap()
+    pub fn f_internal_reshape_copy(&self, size: impl IntList) -> Tensor {
+        self.internal_reshape_copy(size).unwrap()
     }
 
-    pub fn internal_reshape_from_tensor(&self, shape: &Tensor) -> Tensor {
-        self.f_internal_reshape_from_tensor(shape).unwrap()
+    pub fn f_internal_reshape_from_tensor(&self, shape: &Tensor) -> Tensor {
+        self.internal_reshape_from_tensor(shape).unwrap()
     }
 
-    pub fn internal_resize_output(&self, size: impl IntList, device: Device) -> Tensor {
-        self.f_internal_resize_output(size, device).unwrap()
+    pub fn f_internal_resize_output(&self, size: impl IntList, device: Device) -> Tensor {
+        self.internal_resize_output(size, device).unwrap()
     }
 
-    pub fn internal_resize_output_(&mut self, size: impl IntList, device: Device) -> Tensor {
-        self.f_internal_resize_output_(size, device).unwrap()
+    pub fn f_internal_resize_output_(&mut self, size: impl IntList, device: Device) -> Tensor {
+        self.internal_resize_output_(size, device).unwrap()
     }
 
-    pub fn internal_resize_output_out(
+    pub fn f_internal_resize_output_out(
         &self,
         out: &Tensor,
         size: impl IntList,
         device: Device,
     ) -> Tensor {
-        self.f_internal_resize_output_out(out, size, device).unwrap()
+        self.internal_resize_output_out(out, size, device).unwrap()
     }
 
-    pub fn internal_rowwise_prune(
+    pub fn f_internal_rowwise_prune(
         weight: &Tensor,
         mask: &Tensor,
         compressed_indices_dtype: Kind,
     ) -> (Tensor, Tensor) {
-        Tensor::f_internal_rowwise_prune(weight, mask, compressed_indices_dtype).unwrap()
+        Tensor::internal_rowwise_prune(weight, mask, compressed_indices_dtype).unwrap()
     }
 
-    pub fn internal_sample_dirichlet(&self) -> Tensor {
-        self.f_internal_sample_dirichlet().unwrap()
+    pub fn f_internal_sample_dirichlet(&self) -> Tensor {
+        self.internal_sample_dirichlet().unwrap()
     }
 
-    pub fn internal_sample_dirichlet_out(&self, out: &Tensor) -> Tensor {
-        self.f_internal_sample_dirichlet_out(out).unwrap()
+    pub fn f_internal_sample_dirichlet_out(&self, out: &Tensor) -> Tensor {
+        self.internal_sample_dirichlet_out(out).unwrap()
     }
 
-    pub fn internal_saturate_weight_to_fp16(weight: &Tensor) -> Tensor {
-        Tensor::f_internal_saturate_weight_to_fp16(weight).unwrap()
+    pub fn f_internal_saturate_weight_to_fp16(weight: &Tensor) -> Tensor {
+        Tensor::internal_saturate_weight_to_fp16(weight).unwrap()
     }
 
-    pub fn internal_scaled_dot_product_attention<T: Borrow<Tensor>>(
+    pub fn f_internal_scaled_dot_product_attention<T: Borrow<Tensor>>(
         query: &Tensor,
         key: &Tensor,
         value: &Tensor,
@@ -2960,7 +2982,7 @@ impl Tensor {
         need_attn_weights: bool,
         is_causal: bool,
     ) -> (Tensor, Tensor) {
-        Tensor::f_internal_scaled_dot_product_attention(
+        Tensor::internal_scaled_dot_product_attention(
             query,
             key,
             value,
@@ -2972,7 +2994,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_scaled_dot_product_attention_math<T: Borrow<Tensor>>(
+    pub fn f_internal_scaled_dot_product_attention_math<T: Borrow<Tensor>>(
         query: &Tensor,
         key: &Tensor,
         value: &Tensor,
@@ -2981,7 +3003,7 @@ impl Tensor {
         is_causal: bool,
         dropout_mask: Option<T>,
     ) -> (Tensor, Tensor) {
-        Tensor::f_internal_scaled_dot_product_attention_math(
+        Tensor::internal_scaled_dot_product_attention_math(
             query,
             key,
             value,
@@ -2993,14 +3015,14 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_scaled_dot_product_efficient_attention(
+    pub fn f_internal_scaled_dot_product_efficient_attention(
         query: &Tensor,
         key: &Tensor,
         value: &Tensor,
         compute_log_sumexp: bool,
         is_causal: bool,
     ) -> (Tensor, Tensor) {
-        Tensor::f_internal_scaled_dot_product_efficient_attention(
+        Tensor::internal_scaled_dot_product_efficient_attention(
             query,
             key,
             value,
@@ -3010,7 +3032,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_scaled_dot_product_efficient_attention_backward(
+    pub fn f_internal_scaled_dot_product_efficient_attention_backward(
         grad_out_: &Tensor,
         query: &Tensor,
         key: &Tensor,
@@ -3020,7 +3042,7 @@ impl Tensor {
         is_causal: bool,
         chunk_grad_outputs: bool,
     ) -> (Tensor, Tensor, Tensor) {
-        Tensor::f_internal_scaled_dot_product_efficient_attention_backward(
+        Tensor::internal_scaled_dot_product_efficient_attention_backward(
             grad_out_,
             query,
             key,
@@ -3033,7 +3055,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_scaled_dot_product_flash_attention_backward(
+    pub fn f_internal_scaled_dot_product_flash_attention_backward(
         grad_out: &Tensor,
         query: &Tensor,
         key: &Tensor,
@@ -3049,7 +3071,7 @@ impl Tensor {
         philox_seed: i64,
         philox_offset: i64,
     ) -> (Tensor, Tensor, Tensor) {
-        Tensor::f_internal_scaled_dot_product_flash_attention_backward(
+        Tensor::internal_scaled_dot_product_flash_attention_backward(
             grad_out,
             query,
             key,
@@ -3068,7 +3090,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_scatter_reduce(
+    pub fn f_internal_scatter_reduce(
         &self,
         dim: i64,
         index: &Tensor,
@@ -3076,10 +3098,10 @@ impl Tensor {
         reduce: &str,
         include_self: bool,
     ) -> Tensor {
-        self.f_internal_scatter_reduce(dim, index, src, reduce, include_self).unwrap()
+        self.internal_scatter_reduce(dim, index, src, reduce, include_self).unwrap()
     }
 
-    pub fn internal_scatter_reduce_(
+    pub fn f_internal_scatter_reduce_(
         &mut self,
         dim: i64,
         index: &Tensor,
@@ -3087,10 +3109,10 @@ impl Tensor {
         reduce: &str,
         include_self: bool,
     ) -> Tensor {
-        self.f_internal_scatter_reduce_(dim, index, src, reduce, include_self).unwrap()
+        self.internal_scatter_reduce_(dim, index, src, reduce, include_self).unwrap()
     }
 
-    pub fn internal_scatter_reduce_two_out(
+    pub fn f_internal_scatter_reduce_two_out(
         &self,
         out: &Tensor,
         dim: i64,
@@ -3099,10 +3121,10 @@ impl Tensor {
         reduce: &str,
         include_self: bool,
     ) -> Tensor {
-        self.f_internal_scatter_reduce_two_out(out, dim, index, src, reduce, include_self).unwrap()
+        self.internal_scatter_reduce_two_out(out, dim, index, src, reduce, include_self).unwrap()
     }
 
-    pub fn internal_segment_reduce_backward<T: Borrow<Tensor>, S: Into<Scalar>>(
+    pub fn f_internal_segment_reduce_backward<T: Borrow<Tensor>, S: Into<Scalar>>(
         grad: &Tensor,
         output: &Tensor,
         data: &Tensor,
@@ -3112,13 +3134,13 @@ impl Tensor {
         axis: i64,
         initial: S,
     ) -> Tensor {
-        Tensor::f_internal_segment_reduce_backward(
+        Tensor::internal_segment_reduce_backward(
             grad, output, data, reduce, lengths, offsets, axis, initial,
         )
         .unwrap()
     }
 
-    pub fn internal_segment_reduce_backward_out<T: Borrow<Tensor>, S: Into<Scalar>>(
+    pub fn f_internal_segment_reduce_backward_out<T: Borrow<Tensor>, S: Into<Scalar>>(
         out: &Tensor,
         grad: &Tensor,
         output: &Tensor,
@@ -3129,17 +3151,17 @@ impl Tensor {
         axis: i64,
         initial: S,
     ) -> Tensor {
-        Tensor::f_internal_segment_reduce_backward_out(
+        Tensor::internal_segment_reduce_backward_out(
             out, grad, output, data, reduce, lengths, offsets, axis, initial,
         )
         .unwrap()
     }
 
-    pub fn internal_shape_as_tensor(&self) -> Tensor {
-        self.f_internal_shape_as_tensor().unwrap()
+    pub fn f_internal_shape_as_tensor(&self) -> Tensor {
+        self.internal_shape_as_tensor().unwrap()
     }
 
-    pub fn internal_slow_conv2d_backward(
+    pub fn f_internal_slow_conv2d_backward(
         &self,
         grad_input: &Tensor,
         grad_weight: &Tensor,
@@ -3150,7 +3172,7 @@ impl Tensor {
         stride: impl IntList,
         padding: impl IntList,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_internal_slow_conv2d_backward(
+        self.internal_slow_conv2d_backward(
             grad_input,
             grad_weight,
             grad_bias,
@@ -3163,7 +3185,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_sobol_engine_draw(
+    pub fn f_internal_sobol_engine_draw(
         quasi: &Tensor,
         n: i64,
         sobolstate: &Tensor,
@@ -3171,49 +3193,49 @@ impl Tensor {
         num_generated: i64,
         dtype: impl Into<Option<Kind>>,
     ) -> (Tensor, Tensor) {
-        Tensor::f_internal_sobol_engine_draw(quasi, n, sobolstate, dimension, num_generated, dtype)
+        Tensor::internal_sobol_engine_draw(quasi, n, sobolstate, dimension, num_generated, dtype)
             .unwrap()
     }
 
-    pub fn internal_sobol_engine_ff_(
+    pub fn f_internal_sobol_engine_ff_(
         &mut self,
         n: i64,
         sobolstate: &Tensor,
         dimension: i64,
         num_generated: i64,
     ) -> Tensor {
-        self.f_internal_sobol_engine_ff_(n, sobolstate, dimension, num_generated).unwrap()
+        self.internal_sobol_engine_ff_(n, sobolstate, dimension, num_generated).unwrap()
     }
 
-    pub fn internal_sobol_engine_initialize_state_(&mut self, dimension: i64) -> Tensor {
-        self.f_internal_sobol_engine_initialize_state_(dimension).unwrap()
+    pub fn f_internal_sobol_engine_initialize_state_(&mut self, dimension: i64) -> Tensor {
+        self.internal_sobol_engine_initialize_state_(dimension).unwrap()
     }
 
-    pub fn internal_sobol_engine_scramble_(&mut self, ltm: &Tensor, dimension: i64) -> Tensor {
-        self.f_internal_sobol_engine_scramble_(ltm, dimension).unwrap()
+    pub fn f_internal_sobol_engine_scramble_(&mut self, ltm: &Tensor, dimension: i64) -> Tensor {
+        self.internal_sobol_engine_scramble_(ltm, dimension).unwrap()
     }
 
-    pub fn internal_softmax(&self, dim: i64, half_to_float: bool) -> Tensor {
-        self.f_internal_softmax(dim, half_to_float).unwrap()
+    pub fn f_internal_softmax(&self, dim: i64, half_to_float: bool) -> Tensor {
+        self.internal_softmax(dim, half_to_float).unwrap()
     }
 
-    pub fn internal_softmax_backward_data(
+    pub fn f_internal_softmax_backward_data(
         grad_output: &Tensor,
         output: &Tensor,
         dim: i64,
         input_dtype: Kind,
     ) -> Tensor {
-        Tensor::f_internal_softmax_backward_data(grad_output, output, dim, input_dtype).unwrap()
+        Tensor::internal_softmax_backward_data(grad_output, output, dim, input_dtype).unwrap()
     }
 
-    pub fn internal_softmax_backward_data_out(
+    pub fn f_internal_softmax_backward_data_out(
         grad_input: &Tensor,
         grad_output: &Tensor,
         output: &Tensor,
         dim: i64,
         input_dtype: Kind,
     ) -> Tensor {
-        Tensor::f_internal_softmax_backward_data_out(
+        Tensor::internal_softmax_backward_data_out(
             grad_input,
             grad_output,
             output,
@@ -3223,76 +3245,69 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_softmax_out(&self, out: &Tensor, dim: i64, half_to_float: bool) -> Tensor {
-        self.f_internal_softmax_out(out, dim, half_to_float).unwrap()
+    pub fn f_internal_softmax_out(&self, out: &Tensor, dim: i64, half_to_float: bool) -> Tensor {
+        self.internal_softmax_out(out, dim, half_to_float).unwrap()
     }
 
-    pub fn internal_sparse_addmm(&self, mat1: &Tensor, mat2: &Tensor) -> Tensor {
-        self.f_internal_sparse_addmm(mat1, mat2).unwrap()
+    pub fn f_internal_sparse_addmm(&self, mat1: &Tensor, mat2: &Tensor) -> Tensor {
+        self.internal_sparse_addmm(mat1, mat2).unwrap()
     }
 
-    pub fn internal_sparse_addmm_out(&self, out: &Tensor, mat1: &Tensor, mat2: &Tensor) -> Tensor {
-        self.f_internal_sparse_addmm_out(out, mat1, mat2).unwrap()
+    pub fn f_internal_sparse_addmm_out(
+        &self,
+        out: &Tensor,
+        mat1: &Tensor,
+        mat2: &Tensor,
+    ) -> Tensor {
+        self.internal_sparse_addmm_out(out, mat1, mat2).unwrap()
     }
 
-    pub fn internal_sparse_broadcast_to(&self, size: impl IntList) -> Tensor {
-        self.f_internal_sparse_broadcast_to(size).unwrap()
+    pub fn f_internal_sparse_broadcast_to(&self, size: impl IntList) -> Tensor {
+        self.internal_sparse_broadcast_to(size).unwrap()
     }
 
-    pub fn internal_sparse_broadcast_to_copy(&self, size: impl IntList) -> Tensor {
-        self.f_internal_sparse_broadcast_to_copy(size).unwrap()
+    pub fn f_internal_sparse_broadcast_to_copy(&self, size: impl IntList) -> Tensor {
+        self.internal_sparse_broadcast_to_copy(size).unwrap()
     }
 
-    pub fn internal_sparse_broadcast_to_copy_out(
+    pub fn f_internal_sparse_broadcast_to_copy_out(
         &self,
         out: &Tensor,
         size: impl IntList,
     ) -> Tensor {
-        self.f_internal_sparse_broadcast_to_copy_out(out, size).unwrap()
+        self.internal_sparse_broadcast_to_copy_out(out, size).unwrap()
     }
 
-    pub fn internal_sparse_bsc_tensor_unsafe(
+    pub fn f_internal_sparse_bsc_tensor_unsafe(
         ccol_indices: &Tensor,
         row_indices: &Tensor,
         values: &Tensor,
         size: impl IntList,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_internal_sparse_bsc_tensor_unsafe(
-            ccol_indices,
-            row_indices,
-            values,
-            size,
-            options,
-        )
-        .unwrap()
+        Tensor::internal_sparse_bsc_tensor_unsafe(ccol_indices, row_indices, values, size, options)
+            .unwrap()
     }
 
-    pub fn internal_sparse_bsr_tensor_unsafe(
+    pub fn f_internal_sparse_bsr_tensor_unsafe(
         crow_indices: &Tensor,
         col_indices: &Tensor,
         values: &Tensor,
         size: impl IntList,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_internal_sparse_bsr_tensor_unsafe(
-            crow_indices,
-            col_indices,
-            values,
-            size,
-            options,
-        )
-        .unwrap()
+        Tensor::internal_sparse_bsr_tensor_unsafe(crow_indices, col_indices, values, size, options)
+            .unwrap()
     }
 
-    pub fn internal_sparse_compressed_tensor_unsafe(
+    pub fn f_internal_sparse_compressed_tensor_unsafe(
         compressed_indices: &Tensor,
         plain_indices: &Tensor,
         values: &Tensor,
         size: impl IntList,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_internal_sparse_compressed_tensor_unsafe(
+        Tensor::internal_sparse_compressed_tensor_unsafe(
             compressed_indices,
             plain_indices,
             values,
@@ -3302,26 +3317,25 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_sparse_coo_tensor_unsafe(
+    pub fn f_internal_sparse_coo_tensor_unsafe(
         indices: &Tensor,
         values: &Tensor,
         size: impl IntList,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_internal_sparse_coo_tensor_unsafe(indices, values, size, options).unwrap()
+        Tensor::internal_sparse_coo_tensor_unsafe(indices, values, size, options).unwrap()
     }
 
-    pub fn internal_sparse_coo_tensor_with_dims(
+    pub fn f_internal_sparse_coo_tensor_with_dims(
         sparse_dim: i64,
         dense_dim: i64,
         size: impl IntList,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_internal_sparse_coo_tensor_with_dims(sparse_dim, dense_dim, size, options)
-            .unwrap()
+        Tensor::internal_sparse_coo_tensor_with_dims(sparse_dim, dense_dim, size, options).unwrap()
     }
 
-    pub fn internal_sparse_coo_tensor_with_dims_and_tensors(
+    pub fn f_internal_sparse_coo_tensor_with_dims_and_tensors(
         sparse_dim: i64,
         dense_dim: i64,
         size: impl IntList,
@@ -3329,13 +3343,13 @@ impl Tensor {
         values: &Tensor,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_internal_sparse_coo_tensor_with_dims_and_tensors(
+        Tensor::internal_sparse_coo_tensor_with_dims_and_tensors(
             sparse_dim, dense_dim, size, indices, values, options,
         )
         .unwrap()
     }
 
-    pub fn internal_sparse_coo_tensor_with_dims_and_tensors_out(
+    pub fn f_internal_sparse_coo_tensor_with_dims_and_tensors_out(
         out: &Tensor,
         sparse_dim: i64,
         dense_dim: i64,
@@ -3343,389 +3357,391 @@ impl Tensor {
         indices: &Tensor,
         values: &Tensor,
     ) -> Tensor {
-        Tensor::f_internal_sparse_coo_tensor_with_dims_and_tensors_out(
+        Tensor::internal_sparse_coo_tensor_with_dims_and_tensors_out(
             out, sparse_dim, dense_dim, size, indices, values,
         )
         .unwrap()
     }
 
-    pub fn internal_sparse_coo_tensor_with_dims_out(
+    pub fn f_internal_sparse_coo_tensor_with_dims_out(
         out: &Tensor,
         sparse_dim: i64,
         dense_dim: i64,
         size: impl IntList,
     ) -> Tensor {
-        Tensor::f_internal_sparse_coo_tensor_with_dims_out(out, sparse_dim, dense_dim, size)
-            .unwrap()
+        Tensor::internal_sparse_coo_tensor_with_dims_out(out, sparse_dim, dense_dim, size).unwrap()
     }
 
-    pub fn internal_sparse_csc_tensor_unsafe(
+    pub fn f_internal_sparse_csc_tensor_unsafe(
         ccol_indices: &Tensor,
         row_indices: &Tensor,
         values: &Tensor,
         size: impl IntList,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_internal_sparse_csc_tensor_unsafe(
-            ccol_indices,
-            row_indices,
-            values,
-            size,
-            options,
-        )
-        .unwrap()
+        Tensor::internal_sparse_csc_tensor_unsafe(ccol_indices, row_indices, values, size, options)
+            .unwrap()
     }
 
-    pub fn internal_sparse_csr_prod(
+    pub fn f_internal_sparse_csr_prod(
         &self,
         dim: impl IntList,
         keepdim: bool,
         dtype: impl Into<Option<Kind>>,
     ) -> Tensor {
-        self.f_internal_sparse_csr_prod(dim, keepdim, dtype).unwrap()
+        self.internal_sparse_csr_prod(dim, keepdim, dtype).unwrap()
     }
 
-    pub fn internal_sparse_csr_prod_dim_dtype_out(
+    pub fn f_internal_sparse_csr_prod_dim_dtype_out(
         &self,
         out: &Tensor,
         dim: impl IntList,
         keepdim: bool,
         dtype: impl Into<Option<Kind>>,
     ) -> Tensor {
-        self.f_internal_sparse_csr_prod_dim_dtype_out(out, dim, keepdim, dtype).unwrap()
+        self.internal_sparse_csr_prod_dim_dtype_out(out, dim, keepdim, dtype).unwrap()
     }
 
-    pub fn internal_sparse_csr_sum(
+    pub fn f_internal_sparse_csr_sum(
         &self,
         dim: impl IntList,
         keepdim: bool,
         dtype: impl Into<Option<Kind>>,
     ) -> Tensor {
-        self.f_internal_sparse_csr_sum(dim, keepdim, dtype).unwrap()
+        self.internal_sparse_csr_sum(dim, keepdim, dtype).unwrap()
     }
 
-    pub fn internal_sparse_csr_sum_dim_dtype_out(
+    pub fn f_internal_sparse_csr_sum_dim_dtype_out(
         &self,
         out: &Tensor,
         dim: impl IntList,
         keepdim: bool,
         dtype: impl Into<Option<Kind>>,
     ) -> Tensor {
-        self.f_internal_sparse_csr_sum_dim_dtype_out(out, dim, keepdim, dtype).unwrap()
+        self.internal_sparse_csr_sum_dim_dtype_out(out, dim, keepdim, dtype).unwrap()
     }
 
-    pub fn internal_sparse_csr_tensor_unsafe(
+    pub fn f_internal_sparse_csr_tensor_unsafe(
         crow_indices: &Tensor,
         col_indices: &Tensor,
         values: &Tensor,
         size: impl IntList,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_internal_sparse_csr_tensor_unsafe(
-            crow_indices,
-            col_indices,
-            values,
-            size,
-            options,
-        )
-        .unwrap()
+        Tensor::internal_sparse_csr_tensor_unsafe(crow_indices, col_indices, values, size, options)
+            .unwrap()
     }
 
-    pub fn internal_sparse_log_softmax(&self, dim: i64, half_to_float: bool) -> Tensor {
-        self.f_internal_sparse_log_softmax(dim, half_to_float).unwrap()
+    pub fn f_internal_sparse_log_softmax(&self, dim: i64, half_to_float: bool) -> Tensor {
+        self.internal_sparse_log_softmax(dim, half_to_float).unwrap()
     }
 
-    pub fn internal_sparse_log_softmax_backward_data(
+    pub fn f_internal_sparse_log_softmax_backward_data(
         &self,
         grad_output: &Tensor,
         output: &Tensor,
         dim: i64,
     ) -> Tensor {
-        self.f_internal_sparse_log_softmax_backward_data(grad_output, output, dim).unwrap()
+        self.internal_sparse_log_softmax_backward_data(grad_output, output, dim).unwrap()
     }
 
-    pub fn internal_sparse_log_softmax_backward_data_out(
+    pub fn f_internal_sparse_log_softmax_backward_data_out(
         &self,
         out: &Tensor,
         grad_output: &Tensor,
         output: &Tensor,
         dim: i64,
     ) -> Tensor {
-        self.f_internal_sparse_log_softmax_backward_data_out(out, grad_output, output, dim).unwrap()
+        self.internal_sparse_log_softmax_backward_data_out(out, grad_output, output, dim).unwrap()
     }
 
-    pub fn internal_sparse_log_softmax_int(
+    pub fn f_internal_sparse_log_softmax_int(
         &self,
         dim: i64,
         dtype: impl Into<Option<Kind>>,
     ) -> Tensor {
-        self.f_internal_sparse_log_softmax_int(dim, dtype).unwrap()
+        self.internal_sparse_log_softmax_int(dim, dtype).unwrap()
     }
 
-    pub fn internal_sparse_log_softmax_out(
+    pub fn f_internal_sparse_log_softmax_out(
         &self,
         out: &Tensor,
         dim: i64,
         half_to_float: bool,
     ) -> Tensor {
-        self.f_internal_sparse_log_softmax_out(out, dim, half_to_float).unwrap()
+        self.internal_sparse_log_softmax_out(out, dim, half_to_float).unwrap()
     }
 
-    pub fn internal_sparse_mm(sparse: &Tensor, dense: &Tensor) -> Tensor {
-        Tensor::f_internal_sparse_mm(sparse, dense).unwrap()
+    pub fn f_internal_sparse_mm(sparse: &Tensor, dense: &Tensor) -> Tensor {
+        Tensor::internal_sparse_mm(sparse, dense).unwrap()
     }
 
-    pub fn internal_sparse_mm_reduce(sparse: &Tensor, dense: &Tensor, reduce: &str) -> Tensor {
-        Tensor::f_internal_sparse_mm_reduce(sparse, dense, reduce).unwrap()
+    pub fn f_internal_sparse_mm_reduce(sparse: &Tensor, dense: &Tensor, reduce: &str) -> Tensor {
+        Tensor::internal_sparse_mm_reduce(sparse, dense, reduce).unwrap()
     }
 
-    pub fn internal_sparse_mm_reduce_impl(&self, other: &Tensor, reduce: &str) -> (Tensor, Tensor) {
-        self.f_internal_sparse_mm_reduce_impl(other, reduce).unwrap()
+    pub fn f_internal_sparse_mm_reduce_impl(
+        &self,
+        other: &Tensor,
+        reduce: &str,
+    ) -> (Tensor, Tensor) {
+        self.internal_sparse_mm_reduce_impl(other, reduce).unwrap()
     }
 
-    pub fn internal_sparse_softmax(&self, dim: i64, half_to_float: bool) -> Tensor {
-        self.f_internal_sparse_softmax(dim, half_to_float).unwrap()
+    pub fn f_internal_sparse_softmax(&self, dim: i64, half_to_float: bool) -> Tensor {
+        self.internal_sparse_softmax(dim, half_to_float).unwrap()
     }
 
-    pub fn internal_sparse_softmax_backward_data(
+    pub fn f_internal_sparse_softmax_backward_data(
         &self,
         grad_output: &Tensor,
         output: &Tensor,
         dim: i64,
     ) -> Tensor {
-        self.f_internal_sparse_softmax_backward_data(grad_output, output, dim).unwrap()
+        self.internal_sparse_softmax_backward_data(grad_output, output, dim).unwrap()
     }
 
-    pub fn internal_sparse_softmax_backward_data_out(
+    pub fn f_internal_sparse_softmax_backward_data_out(
         &self,
         out: &Tensor,
         grad_output: &Tensor,
         output: &Tensor,
         dim: i64,
     ) -> Tensor {
-        self.f_internal_sparse_softmax_backward_data_out(out, grad_output, output, dim).unwrap()
+        self.internal_sparse_softmax_backward_data_out(out, grad_output, output, dim).unwrap()
     }
 
-    pub fn internal_sparse_softmax_int(&self, dim: i64, dtype: impl Into<Option<Kind>>) -> Tensor {
-        self.f_internal_sparse_softmax_int(dim, dtype).unwrap()
+    pub fn f_internal_sparse_softmax_int(
+        &self,
+        dim: i64,
+        dtype: impl Into<Option<Kind>>,
+    ) -> Tensor {
+        self.internal_sparse_softmax_int(dim, dtype).unwrap()
     }
 
-    pub fn internal_sparse_softmax_out(
+    pub fn f_internal_sparse_softmax_out(
         &self,
         out: &Tensor,
         dim: i64,
         half_to_float: bool,
     ) -> Tensor {
-        self.f_internal_sparse_softmax_out(out, dim, half_to_float).unwrap()
+        self.internal_sparse_softmax_out(out, dim, half_to_float).unwrap()
     }
 
-    pub fn internal_sparse_sparse_matmul(&self, other: &Tensor) -> Tensor {
-        self.f_internal_sparse_sparse_matmul(other).unwrap()
+    pub fn f_internal_sparse_sparse_matmul(&self, other: &Tensor) -> Tensor {
+        self.internal_sparse_sparse_matmul(other).unwrap()
     }
 
-    pub fn internal_sparse_sparse_matmul_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_internal_sparse_sparse_matmul_out(out, other).unwrap()
+    pub fn f_internal_sparse_sparse_matmul_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.internal_sparse_sparse_matmul_out(out, other).unwrap()
     }
 
-    pub fn internal_sparse_sum(&self) -> Tensor {
-        self.f_internal_sparse_sum().unwrap()
+    pub fn f_internal_sparse_sum(&self) -> Tensor {
+        self.internal_sparse_sum().unwrap()
     }
 
-    pub fn internal_sparse_sum_backward(&self, grad: &Tensor, dim: impl IntList) -> Tensor {
-        self.f_internal_sparse_sum_backward(grad, dim).unwrap()
+    pub fn f_internal_sparse_sum_backward(&self, grad: &Tensor, dim: impl IntList) -> Tensor {
+        self.internal_sparse_sum_backward(grad, dim).unwrap()
     }
 
-    pub fn internal_sparse_sum_backward_out(
+    pub fn f_internal_sparse_sum_backward_out(
         &self,
         out: &Tensor,
         grad: &Tensor,
         dim: impl IntList,
     ) -> Tensor {
-        self.f_internal_sparse_sum_backward_out(out, grad, dim).unwrap()
+        self.internal_sparse_sum_backward_out(out, grad, dim).unwrap()
     }
 
-    pub fn internal_sparse_sum_dim(&self, dim: impl IntList) -> Tensor {
-        self.f_internal_sparse_sum_dim(dim).unwrap()
+    pub fn f_internal_sparse_sum_dim(&self, dim: impl IntList) -> Tensor {
+        self.internal_sparse_sum_dim(dim).unwrap()
     }
 
-    pub fn internal_sparse_sum_dim_dtype(&self, dim: impl IntList, dtype: Kind) -> Tensor {
-        self.f_internal_sparse_sum_dim_dtype(dim, dtype).unwrap()
+    pub fn f_internal_sparse_sum_dim_dtype(&self, dim: impl IntList, dtype: Kind) -> Tensor {
+        self.internal_sparse_sum_dim_dtype(dim, dtype).unwrap()
     }
 
-    pub fn internal_sparse_sum_dim_out(&self, out: &Tensor, dim: impl IntList) -> Tensor {
-        self.f_internal_sparse_sum_dim_out(out, dim).unwrap()
+    pub fn f_internal_sparse_sum_dim_out(&self, out: &Tensor, dim: impl IntList) -> Tensor {
+        self.internal_sparse_sum_dim_out(out, dim).unwrap()
     }
 
-    pub fn internal_sparse_sum_dtype(&self, dtype: Kind) -> Tensor {
-        self.f_internal_sparse_sum_dtype(dtype).unwrap()
+    pub fn f_internal_sparse_sum_dtype(&self, dtype: Kind) -> Tensor {
+        self.internal_sparse_sum_dtype(dtype).unwrap()
     }
 
-    pub fn internal_spdiags(
+    pub fn f_internal_spdiags(
         diagonals: &Tensor,
         offsets: &Tensor,
         shape: impl IntList,
         layout: Option<Layout>,
     ) -> Tensor {
-        Tensor::f_internal_spdiags(diagonals, offsets, shape, layout).unwrap()
+        Tensor::internal_spdiags(diagonals, offsets, shape, layout).unwrap()
     }
 
-    pub fn internal_spdiags_out(
+    pub fn f_internal_spdiags_out(
         out: &Tensor,
         diagonals: &Tensor,
         offsets: &Tensor,
         shape: impl IntList,
         layout: Option<Layout>,
     ) -> Tensor {
-        Tensor::f_internal_spdiags_out(out, diagonals, offsets, shape, layout).unwrap()
+        Tensor::internal_spdiags_out(out, diagonals, offsets, shape, layout).unwrap()
     }
 
-    pub fn internal_stack<T: Borrow<Tensor>>(tensors: &[T], dim: i64) -> Tensor {
-        Tensor::f_internal_stack(tensors, dim).unwrap()
+    pub fn f_internal_stack<T: Borrow<Tensor>>(tensors: &[T], dim: i64) -> Tensor {
+        Tensor::internal_stack(tensors, dim).unwrap()
     }
 
-    pub fn internal_stack_out<T: Borrow<Tensor>>(out: &Tensor, tensors: &[T], dim: i64) -> Tensor {
-        Tensor::f_internal_stack_out(out, tensors, dim).unwrap()
+    pub fn f_internal_stack_out<T: Borrow<Tensor>>(
+        out: &Tensor,
+        tensors: &[T],
+        dim: i64,
+    ) -> Tensor {
+        Tensor::internal_stack_out(out, tensors, dim).unwrap()
     }
 
-    pub fn internal_standard_gamma(&self) -> Tensor {
-        self.f_internal_standard_gamma().unwrap()
+    pub fn f_internal_standard_gamma(&self) -> Tensor {
+        self.internal_standard_gamma().unwrap()
     }
 
-    pub fn internal_standard_gamma_grad(&self, output: &Tensor) -> Tensor {
-        self.f_internal_standard_gamma_grad(output).unwrap()
+    pub fn f_internal_standard_gamma_grad(&self, output: &Tensor) -> Tensor {
+        self.internal_standard_gamma_grad(output).unwrap()
     }
 
-    pub fn internal_standard_gamma_grad_out(&self, out: &Tensor, output: &Tensor) -> Tensor {
-        self.f_internal_standard_gamma_grad_out(out, output).unwrap()
+    pub fn f_internal_standard_gamma_grad_out(&self, out: &Tensor, output: &Tensor) -> Tensor {
+        self.internal_standard_gamma_grad_out(out, output).unwrap()
     }
 
-    pub fn internal_standard_gamma_out(&self, out: &Tensor) -> Tensor {
-        self.f_internal_standard_gamma_out(out).unwrap()
+    pub fn f_internal_standard_gamma_out(&self, out: &Tensor) -> Tensor {
+        self.internal_standard_gamma_out(out).unwrap()
     }
 
-    pub fn internal_test_ambiguous_defaults(dummy: &Tensor, a: i64, b: i64) -> Tensor {
-        Tensor::f_internal_test_ambiguous_defaults(dummy, a, b).unwrap()
+    pub fn f_internal_test_ambiguous_defaults(dummy: &Tensor, a: i64, b: i64) -> Tensor {
+        Tensor::internal_test_ambiguous_defaults(dummy, a, b).unwrap()
     }
 
-    pub fn internal_test_ambiguous_defaults_b(dummy: &Tensor, a: i64, b: &str) -> Tensor {
-        Tensor::f_internal_test_ambiguous_defaults_b(dummy, a, b).unwrap()
+    pub fn f_internal_test_ambiguous_defaults_b(dummy: &Tensor, a: i64, b: &str) -> Tensor {
+        Tensor::internal_test_ambiguous_defaults_b(dummy, a, b).unwrap()
     }
 
-    pub fn internal_test_autograd_multiple_dispatch(&self) -> Tensor {
-        self.f_internal_test_autograd_multiple_dispatch().unwrap()
+    pub fn f_internal_test_autograd_multiple_dispatch(&self) -> Tensor {
+        self.internal_test_autograd_multiple_dispatch().unwrap()
     }
 
-    pub fn internal_test_autograd_multiple_dispatch_fullcoverage_out(
+    pub fn f_internal_test_autograd_multiple_dispatch_fullcoverage_out(
         &self,
         out: &Tensor,
     ) -> Tensor {
-        self.f_internal_test_autograd_multiple_dispatch_fullcoverage_out(out).unwrap()
+        self.internal_test_autograd_multiple_dispatch_fullcoverage_out(out).unwrap()
     }
 
-    pub fn internal_test_autograd_multiple_dispatch_ntonly(&self, b: bool) -> Tensor {
-        self.f_internal_test_autograd_multiple_dispatch_ntonly(b).unwrap()
+    pub fn f_internal_test_autograd_multiple_dispatch_ntonly(&self, b: bool) -> Tensor {
+        self.internal_test_autograd_multiple_dispatch_ntonly(b).unwrap()
     }
 
-    pub fn internal_test_autograd_multiple_dispatch_view(&self) -> Tensor {
-        self.f_internal_test_autograd_multiple_dispatch_view().unwrap()
+    pub fn f_internal_test_autograd_multiple_dispatch_view(&self) -> Tensor {
+        self.internal_test_autograd_multiple_dispatch_view().unwrap()
     }
 
-    pub fn internal_test_autograd_multiple_dispatch_view_copy(&self) -> Tensor {
-        self.f_internal_test_autograd_multiple_dispatch_view_copy().unwrap()
+    pub fn f_internal_test_autograd_multiple_dispatch_view_copy(&self) -> Tensor {
+        self.internal_test_autograd_multiple_dispatch_view_copy().unwrap()
     }
 
-    pub fn internal_test_autograd_multiple_dispatch_view_copy_out(&self, out: &Tensor) -> Tensor {
-        self.f_internal_test_autograd_multiple_dispatch_view_copy_out(out).unwrap()
+    pub fn f_internal_test_autograd_multiple_dispatch_view_copy_out(&self, out: &Tensor) -> Tensor {
+        self.internal_test_autograd_multiple_dispatch_view_copy_out(out).unwrap()
     }
 
-    pub fn internal_test_check_tensor(&self) -> Tensor {
-        self.f_internal_test_check_tensor().unwrap()
+    pub fn f_internal_test_check_tensor(&self) -> Tensor {
+        self.internal_test_check_tensor().unwrap()
     }
 
-    pub fn internal_test_optional_filled_intlist(
+    pub fn f_internal_test_optional_filled_intlist(
         values: &Tensor,
         addends: impl IntListOption,
     ) -> Tensor {
-        Tensor::f_internal_test_optional_filled_intlist(values, addends).unwrap()
+        Tensor::internal_test_optional_filled_intlist(values, addends).unwrap()
     }
 
-    pub fn internal_test_optional_filled_intlist_out(
+    pub fn f_internal_test_optional_filled_intlist_out(
         out: &Tensor,
         values: &Tensor,
         addends: impl IntListOption,
     ) -> Tensor {
-        Tensor::f_internal_test_optional_filled_intlist_out(out, values, addends).unwrap()
+        Tensor::internal_test_optional_filled_intlist_out(out, values, addends).unwrap()
     }
 
-    pub fn internal_test_optional_floatlist(values: &Tensor, addends: impl DoubleList) -> Tensor {
-        Tensor::f_internal_test_optional_floatlist(values, addends).unwrap()
+    pub fn f_internal_test_optional_floatlist(values: &Tensor, addends: impl DoubleList) -> Tensor {
+        Tensor::internal_test_optional_floatlist(values, addends).unwrap()
     }
 
-    pub fn internal_test_optional_floatlist_out(
+    pub fn f_internal_test_optional_floatlist_out(
         out: &Tensor,
         values: &Tensor,
         addends: impl DoubleList,
     ) -> Tensor {
-        Tensor::f_internal_test_optional_floatlist_out(out, values, addends).unwrap()
+        Tensor::internal_test_optional_floatlist_out(out, values, addends).unwrap()
     }
 
-    pub fn internal_test_optional_intlist(values: &Tensor, addends: impl IntListOption) -> Tensor {
-        Tensor::f_internal_test_optional_intlist(values, addends).unwrap()
+    pub fn f_internal_test_optional_intlist(
+        values: &Tensor,
+        addends: impl IntListOption,
+    ) -> Tensor {
+        Tensor::internal_test_optional_intlist(values, addends).unwrap()
     }
 
-    pub fn internal_test_optional_intlist_out(
+    pub fn f_internal_test_optional_intlist_out(
         out: &Tensor,
         values: &Tensor,
         addends: impl IntListOption,
     ) -> Tensor {
-        Tensor::f_internal_test_optional_intlist_out(out, values, addends).unwrap()
+        Tensor::internal_test_optional_intlist_out(out, values, addends).unwrap()
     }
 
-    pub fn internal_test_serialization_subcmul(&self, other: &Tensor) -> Tensor {
-        self.f_internal_test_serialization_subcmul(other).unwrap()
+    pub fn f_internal_test_serialization_subcmul(&self, other: &Tensor) -> Tensor {
+        self.internal_test_serialization_subcmul(other).unwrap()
     }
 
-    pub fn internal_test_string_default(dummy: &Tensor, a: &str, b: &str) -> Tensor {
-        Tensor::f_internal_test_string_default(dummy, a, b).unwrap()
+    pub fn f_internal_test_string_default(dummy: &Tensor, a: &str, b: &str) -> Tensor {
+        Tensor::internal_test_string_default(dummy, a, b).unwrap()
     }
 
-    pub fn internal_test_warn_in_autograd(&self) -> Tensor {
-        self.f_internal_test_warn_in_autograd().unwrap()
+    pub fn f_internal_test_warn_in_autograd(&self) -> Tensor {
+        self.internal_test_warn_in_autograd().unwrap()
     }
 
-    pub fn internal_test_warn_in_autograd_out(&self, out: &Tensor) -> Tensor {
-        self.f_internal_test_warn_in_autograd_out(out).unwrap()
+    pub fn f_internal_test_warn_in_autograd_out(&self, out: &Tensor) -> Tensor {
+        self.internal_test_warn_in_autograd_out(out).unwrap()
     }
 
-    pub fn internal_to_copy(&self, options: (Kind, Device), non_blocking: bool) -> Tensor {
-        self.f_internal_to_copy(options, non_blocking).unwrap()
+    pub fn f_internal_to_copy(&self, options: (Kind, Device), non_blocking: bool) -> Tensor {
+        self.internal_to_copy(options, non_blocking).unwrap()
     }
 
-    pub fn internal_to_copy_out(&self, out: &Tensor, non_blocking: bool) -> Tensor {
-        self.f_internal_to_copy_out(out, non_blocking).unwrap()
+    pub fn f_internal_to_copy_out(&self, out: &Tensor, non_blocking: bool) -> Tensor {
+        self.internal_to_copy_out(out, non_blocking).unwrap()
     }
 
-    pub fn internal_to_cpu<T: Borrow<Tensor>>(tensors: &[T]) -> Vec<Tensor> {
-        Tensor::f_internal_to_cpu(tensors).unwrap()
+    pub fn f_internal_to_cpu<T: Borrow<Tensor>>(tensors: &[T]) -> Vec<Tensor> {
+        Tensor::internal_to_cpu(tensors).unwrap()
     }
 
-    pub fn internal_to_dense(&self, dtype: impl Into<Option<Kind>>) -> Tensor {
-        self.f_internal_to_dense(dtype).unwrap()
+    pub fn f_internal_to_dense(&self, dtype: impl Into<Option<Kind>>) -> Tensor {
+        self.internal_to_dense(dtype).unwrap()
     }
 
-    pub fn internal_to_dense_out(&self, out: &Tensor, dtype: impl Into<Option<Kind>>) -> Tensor {
-        self.f_internal_to_dense_out(out, dtype).unwrap()
+    pub fn f_internal_to_dense_out(&self, out: &Tensor, dtype: impl Into<Option<Kind>>) -> Tensor {
+        self.internal_to_dense_out(out, dtype).unwrap()
     }
 
-    pub fn internal_transform_bias_rescale_qkv(
+    pub fn f_internal_transform_bias_rescale_qkv(
         qkv: &Tensor,
         qkv_bias: &Tensor,
         num_heads: i64,
     ) -> (Tensor, Tensor, Tensor) {
-        Tensor::f_internal_transform_bias_rescale_qkv(qkv, qkv_bias, num_heads).unwrap()
+        Tensor::internal_transform_bias_rescale_qkv(qkv, qkv_bias, num_heads).unwrap()
     }
 
-    pub fn internal_transform_bias_rescale_qkv_out(
+    pub fn f_internal_transform_bias_rescale_qkv_out(
         out0: &Tensor,
         out1: &Tensor,
         out2: &Tensor,
@@ -3733,13 +3749,11 @@ impl Tensor {
         qkv_bias: &Tensor,
         num_heads: i64,
     ) -> (Tensor, Tensor, Tensor) {
-        Tensor::f_internal_transform_bias_rescale_qkv_out(
-            out0, out1, out2, qkv, qkv_bias, num_heads,
-        )
-        .unwrap()
+        Tensor::internal_transform_bias_rescale_qkv_out(out0, out1, out2, qkv, qkv_bias, num_heads)
+            .unwrap()
     }
 
-    pub fn internal_transformer_decoder_only_layer_fwd<T: Borrow<Tensor>>(
+    pub fn f_internal_transformer_decoder_only_layer_fwd<T: Borrow<Tensor>>(
         src: &Tensor,
         embed_dim: i64,
         num_heads: i64,
@@ -3762,7 +3776,7 @@ impl Tensor {
         incr_key: Option<T>,
         incr_value: Option<T>,
     ) -> (Tensor, Tensor, Tensor) {
-        Tensor::f_internal_transformer_decoder_only_layer_fwd(
+        Tensor::internal_transformer_decoder_only_layer_fwd(
             src,
             embed_dim,
             num_heads,
@@ -3788,7 +3802,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_transformer_decoder_only_layer_fwd_out<T: Borrow<Tensor>>(
+    pub fn f_internal_transformer_decoder_only_layer_fwd_out<T: Borrow<Tensor>>(
         out0: &Tensor,
         out1: &Tensor,
         out2: &Tensor,
@@ -3814,7 +3828,7 @@ impl Tensor {
         incr_key: Option<T>,
         incr_value: Option<T>,
     ) -> (Tensor, Tensor, Tensor) {
-        Tensor::f_internal_transformer_decoder_only_layer_fwd_out(
+        Tensor::internal_transformer_decoder_only_layer_fwd_out(
             out0,
             out1,
             out2,
@@ -3843,7 +3857,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_transformer_encoder_layer_fwd<T: Borrow<Tensor>>(
+    pub fn f_internal_transformer_encoder_layer_fwd<T: Borrow<Tensor>>(
         src: &Tensor,
         embed_dim: i64,
         num_heads: i64,
@@ -3865,7 +3879,7 @@ impl Tensor {
         mask: Option<T>,
         mask_type: impl Into<Option<i64>>,
     ) -> Tensor {
-        Tensor::f_internal_transformer_encoder_layer_fwd(
+        Tensor::internal_transformer_encoder_layer_fwd(
             src,
             embed_dim,
             num_heads,
@@ -3890,7 +3904,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_transformer_encoder_layer_fwd_out<T: Borrow<Tensor>>(
+    pub fn f_internal_transformer_encoder_layer_fwd_out<T: Borrow<Tensor>>(
         out: &Tensor,
         src: &Tensor,
         embed_dim: i64,
@@ -3913,7 +3927,7 @@ impl Tensor {
         mask: Option<T>,
         mask_type: impl Into<Option<i64>>,
     ) -> Tensor {
-        Tensor::f_internal_transformer_encoder_layer_fwd_out(
+        Tensor::internal_transformer_encoder_layer_fwd_out(
             out,
             src,
             embed_dim,
@@ -3939,7 +3953,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_trilinear(
+    pub fn f_internal_trilinear(
         i1: &Tensor,
         i2: &Tensor,
         i3: &Tensor,
@@ -3949,11 +3963,11 @@ impl Tensor {
         sumdim: impl IntList,
         unroll_dim: i64,
     ) -> Tensor {
-        Tensor::f_internal_trilinear(i1, i2, i3, expand1, expand2, expand3, sumdim, unroll_dim)
+        Tensor::internal_trilinear(i1, i2, i3, expand1, expand2, expand3, sumdim, unroll_dim)
             .unwrap()
     }
 
-    pub fn internal_trilinear_out(
+    pub fn f_internal_trilinear_out(
         out: &Tensor,
         i1: &Tensor,
         i2: &Tensor,
@@ -3964,13 +3978,13 @@ impl Tensor {
         sumdim: impl IntList,
         unroll_dim: i64,
     ) -> Tensor {
-        Tensor::f_internal_trilinear_out(
+        Tensor::internal_trilinear_out(
             out, i1, i2, i3, expand1, expand2, expand3, sumdim, unroll_dim,
         )
         .unwrap()
     }
 
-    pub fn internal_triton_multi_head_attention<T: Borrow<Tensor>>(
+    pub fn f_internal_triton_multi_head_attention<T: Borrow<Tensor>>(
         query: &Tensor,
         key: &Tensor,
         value: &Tensor,
@@ -3982,7 +3996,7 @@ impl Tensor {
         proj_bias: &Tensor,
         mask: Option<T>,
     ) -> Tensor {
-        Tensor::f_internal_triton_multi_head_attention(
+        Tensor::internal_triton_multi_head_attention(
             query,
             key,
             value,
@@ -3997,7 +4011,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_triton_multi_head_attention_out<T: Borrow<Tensor>>(
+    pub fn f_internal_triton_multi_head_attention_out<T: Borrow<Tensor>>(
         out: &Tensor,
         query: &Tensor,
         key: &Tensor,
@@ -4010,7 +4024,7 @@ impl Tensor {
         proj_bias: &Tensor,
         mask: Option<T>,
     ) -> Tensor {
-        Tensor::f_internal_triton_multi_head_attention_out(
+        Tensor::internal_triton_multi_head_attention_out(
             out,
             query,
             key,
@@ -4026,39 +4040,39 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_triton_scaled_dot_attention(
+    pub fn f_internal_triton_scaled_dot_attention(
         q: &Tensor,
         k: &Tensor,
         v: &Tensor,
         dropout_p: f64,
     ) -> Tensor {
-        Tensor::f_internal_triton_scaled_dot_attention(q, k, v, dropout_p).unwrap()
+        Tensor::internal_triton_scaled_dot_attention(q, k, v, dropout_p).unwrap()
     }
 
-    pub fn internal_triton_scaled_dot_attention_out(
+    pub fn f_internal_triton_scaled_dot_attention_out(
         out: &Tensor,
         q: &Tensor,
         k: &Tensor,
         v: &Tensor,
         dropout_p: f64,
     ) -> Tensor {
-        Tensor::f_internal_triton_scaled_dot_attention_out(out, q, k, v, dropout_p).unwrap()
+        Tensor::internal_triton_scaled_dot_attention_out(out, q, k, v, dropout_p).unwrap()
     }
 
-    pub fn internal_unique(&self, sorted: bool, return_inverse: bool) -> (Tensor, Tensor) {
-        self.f_internal_unique(sorted, return_inverse).unwrap()
+    pub fn f_internal_unique(&self, sorted: bool, return_inverse: bool) -> (Tensor, Tensor) {
+        self.internal_unique(sorted, return_inverse).unwrap()
     }
 
-    pub fn internal_unique2(
+    pub fn f_internal_unique2(
         &self,
         sorted: bool,
         return_inverse: bool,
         return_counts: bool,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_internal_unique2(sorted, return_inverse, return_counts).unwrap()
+        self.internal_unique2(sorted, return_inverse, return_counts).unwrap()
     }
 
-    pub fn internal_unique2_out(
+    pub fn f_internal_unique2_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -4067,44 +4081,42 @@ impl Tensor {
         return_inverse: bool,
         return_counts: bool,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_internal_unique2_out(out0, out1, out2, sorted, return_inverse, return_counts)
-            .unwrap()
+        self.internal_unique2_out(out0, out1, out2, sorted, return_inverse, return_counts).unwrap()
     }
 
-    pub fn internal_unique_out(
+    pub fn f_internal_unique_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
         sorted: bool,
         return_inverse: bool,
     ) -> (Tensor, Tensor) {
-        self.f_internal_unique_out(out0, out1, sorted, return_inverse).unwrap()
+        self.internal_unique_out(out0, out1, sorted, return_inverse).unwrap()
     }
 
-    pub fn internal_unpack_dual(dual: &Tensor, level: i64) -> (Tensor, Tensor) {
-        Tensor::f_internal_unpack_dual(dual, level).unwrap()
+    pub fn f_internal_unpack_dual(dual: &Tensor, level: i64) -> (Tensor, Tensor) {
+        Tensor::internal_unpack_dual(dual, level).unwrap()
     }
 
-    pub fn internal_unsafe_view(&self, size: impl IntList) -> Tensor {
-        self.f_internal_unsafe_view(size).unwrap()
+    pub fn f_internal_unsafe_view(&self, size: impl IntList) -> Tensor {
+        self.internal_unsafe_view(size).unwrap()
     }
 
-    pub fn internal_unsafe_view_out(&self, out: &Tensor, size: impl IntList) -> Tensor {
-        self.f_internal_unsafe_view_out(out, size).unwrap()
+    pub fn f_internal_unsafe_view_out(&self, out: &Tensor, size: impl IntList) -> Tensor {
+        self.internal_unsafe_view_out(out, size).unwrap()
     }
 
-    pub fn internal_upsample_bicubic2d_aa(
+    pub fn f_internal_upsample_bicubic2d_aa(
         &self,
         output_size: impl IntList,
         align_corners: bool,
         scales_h: impl Into<Option<f64>>,
         scales_w: impl Into<Option<f64>>,
     ) -> Tensor {
-        self.f_internal_upsample_bicubic2d_aa(output_size, align_corners, scales_h, scales_w)
-            .unwrap()
+        self.internal_upsample_bicubic2d_aa(output_size, align_corners, scales_h, scales_w).unwrap()
     }
 
-    pub fn internal_upsample_bicubic2d_aa_backward(
+    pub fn f_internal_upsample_bicubic2d_aa_backward(
         grad_output: &Tensor,
         output_size: impl IntList,
         input_size: impl IntList,
@@ -4112,7 +4124,7 @@ impl Tensor {
         scales_h: impl Into<Option<f64>>,
         scales_w: impl Into<Option<f64>>,
     ) -> Tensor {
-        Tensor::f_internal_upsample_bicubic2d_aa_backward(
+        Tensor::internal_upsample_bicubic2d_aa_backward(
             grad_output,
             output_size,
             input_size,
@@ -4123,7 +4135,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_upsample_bicubic2d_aa_backward_grad_input(
+    pub fn f_internal_upsample_bicubic2d_aa_backward_grad_input(
         grad_input: &Tensor,
         grad_output: &Tensor,
         output_size: impl IntList,
@@ -4132,7 +4144,7 @@ impl Tensor {
         scales_h: impl Into<Option<f64>>,
         scales_w: impl Into<Option<f64>>,
     ) -> Tensor {
-        Tensor::f_internal_upsample_bicubic2d_aa_backward_grad_input(
+        Tensor::internal_upsample_bicubic2d_aa_backward_grad_input(
             grad_input,
             grad_output,
             output_size,
@@ -4144,7 +4156,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_upsample_bicubic2d_aa_out(
+    pub fn f_internal_upsample_bicubic2d_aa_out(
         &self,
         out: &Tensor,
         output_size: impl IntList,
@@ -4152,7 +4164,79 @@ impl Tensor {
         scales_h: impl Into<Option<f64>>,
         scales_w: impl Into<Option<f64>>,
     ) -> Tensor {
-        self.f_internal_upsample_bicubic2d_aa_out(
+        self.internal_upsample_bicubic2d_aa_out(out, output_size, align_corners, scales_h, scales_w)
+            .unwrap()
+    }
+
+    pub fn f_internal_upsample_bicubic2d_aa_vec(
+        &self,
+        output_size: impl IntListOption,
+        align_corners: bool,
+        scale_factors: impl DoubleList,
+    ) -> Tensor {
+        self.internal_upsample_bicubic2d_aa_vec(output_size, align_corners, scale_factors).unwrap()
+    }
+
+    pub fn f_internal_upsample_bilinear2d_aa(
+        &self,
+        output_size: impl IntList,
+        align_corners: bool,
+        scales_h: impl Into<Option<f64>>,
+        scales_w: impl Into<Option<f64>>,
+    ) -> Tensor {
+        self.internal_upsample_bilinear2d_aa(output_size, align_corners, scales_h, scales_w)
+            .unwrap()
+    }
+
+    pub fn f_internal_upsample_bilinear2d_aa_backward(
+        grad_output: &Tensor,
+        output_size: impl IntList,
+        input_size: impl IntList,
+        align_corners: bool,
+        scales_h: impl Into<Option<f64>>,
+        scales_w: impl Into<Option<f64>>,
+    ) -> Tensor {
+        Tensor::internal_upsample_bilinear2d_aa_backward(
+            grad_output,
+            output_size,
+            input_size,
+            align_corners,
+            scales_h,
+            scales_w,
+        )
+        .unwrap()
+    }
+
+    pub fn f_internal_upsample_bilinear2d_aa_backward_grad_input(
+        grad_input: &Tensor,
+        grad_output: &Tensor,
+        output_size: impl IntList,
+        input_size: impl IntList,
+        align_corners: bool,
+        scales_h: impl Into<Option<f64>>,
+        scales_w: impl Into<Option<f64>>,
+    ) -> Tensor {
+        Tensor::internal_upsample_bilinear2d_aa_backward_grad_input(
+            grad_input,
+            grad_output,
+            output_size,
+            input_size,
+            align_corners,
+            scales_h,
+            scales_w,
+        )
+        .unwrap()
+    }
+
+    pub fn f_internal_upsample_bilinear2d_aa_out(
+        &self,
+        out: &Tensor,
+        output_size: impl IntList,
+        align_corners: bool,
+        scales_h: impl Into<Option<f64>>,
+        scales_w: impl Into<Option<f64>>,
+    ) -> Tensor {
+        self.internal_upsample_bilinear2d_aa_out(
             out,
             output_size,
             align_corners,
@@ -4162,110 +4246,30 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_upsample_bicubic2d_aa_vec(
+    pub fn f_internal_upsample_bilinear2d_aa_vec(
         &self,
         output_size: impl IntListOption,
         align_corners: bool,
         scale_factors: impl DoubleList,
     ) -> Tensor {
-        self.f_internal_upsample_bicubic2d_aa_vec(output_size, align_corners, scale_factors)
-            .unwrap()
+        self.internal_upsample_bilinear2d_aa_vec(output_size, align_corners, scale_factors).unwrap()
     }
 
-    pub fn internal_upsample_bilinear2d_aa(
-        &self,
-        output_size: impl IntList,
-        align_corners: bool,
-        scales_h: impl Into<Option<f64>>,
-        scales_w: impl Into<Option<f64>>,
-    ) -> Tensor {
-        self.f_internal_upsample_bilinear2d_aa(output_size, align_corners, scales_h, scales_w)
-            .unwrap()
-    }
-
-    pub fn internal_upsample_bilinear2d_aa_backward(
-        grad_output: &Tensor,
-        output_size: impl IntList,
-        input_size: impl IntList,
-        align_corners: bool,
-        scales_h: impl Into<Option<f64>>,
-        scales_w: impl Into<Option<f64>>,
-    ) -> Tensor {
-        Tensor::f_internal_upsample_bilinear2d_aa_backward(
-            grad_output,
-            output_size,
-            input_size,
-            align_corners,
-            scales_h,
-            scales_w,
-        )
-        .unwrap()
-    }
-
-    pub fn internal_upsample_bilinear2d_aa_backward_grad_input(
-        grad_input: &Tensor,
-        grad_output: &Tensor,
-        output_size: impl IntList,
-        input_size: impl IntList,
-        align_corners: bool,
-        scales_h: impl Into<Option<f64>>,
-        scales_w: impl Into<Option<f64>>,
-    ) -> Tensor {
-        Tensor::f_internal_upsample_bilinear2d_aa_backward_grad_input(
-            grad_input,
-            grad_output,
-            output_size,
-            input_size,
-            align_corners,
-            scales_h,
-            scales_w,
-        )
-        .unwrap()
-    }
-
-    pub fn internal_upsample_bilinear2d_aa_out(
-        &self,
-        out: &Tensor,
-        output_size: impl IntList,
-        align_corners: bool,
-        scales_h: impl Into<Option<f64>>,
-        scales_w: impl Into<Option<f64>>,
-    ) -> Tensor {
-        self.f_internal_upsample_bilinear2d_aa_out(
-            out,
-            output_size,
-            align_corners,
-            scales_h,
-            scales_w,
-        )
-        .unwrap()
-    }
-
-    pub fn internal_upsample_bilinear2d_aa_vec(
-        &self,
-        output_size: impl IntListOption,
-        align_corners: bool,
-        scale_factors: impl DoubleList,
-    ) -> Tensor {
-        self.f_internal_upsample_bilinear2d_aa_vec(output_size, align_corners, scale_factors)
-            .unwrap()
-    }
-
-    pub fn internal_upsample_nearest_exact1d(
+    pub fn f_internal_upsample_nearest_exact1d(
         &self,
         output_size: impl IntList,
         scales: impl Into<Option<f64>>,
     ) -> Tensor {
-        self.f_internal_upsample_nearest_exact1d(output_size, scales).unwrap()
+        self.internal_upsample_nearest_exact1d(output_size, scales).unwrap()
     }
 
-    pub fn internal_upsample_nearest_exact1d_backward(
+    pub fn f_internal_upsample_nearest_exact1d_backward(
         grad_output: &Tensor,
         output_size: impl IntList,
         input_size: impl IntList,
         scales: impl Into<Option<f64>>,
     ) -> Tensor {
-        Tensor::f_internal_upsample_nearest_exact1d_backward(
+        Tensor::internal_upsample_nearest_exact1d_backward(
             grad_output,
             output_size,
             input_size,
@@ -4274,14 +4278,14 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_upsample_nearest_exact1d_backward_grad_input(
+    pub fn f_internal_upsample_nearest_exact1d_backward_grad_input(
         grad_input: &Tensor,
         grad_output: &Tensor,
         output_size: impl IntList,
         input_size: impl IntList,
         scales: impl Into<Option<f64>>,
     ) -> Tensor {
-        Tensor::f_internal_upsample_nearest_exact1d_backward_grad_input(
+        Tensor::internal_upsample_nearest_exact1d_backward_grad_input(
             grad_input,
             grad_output,
             output_size,
@@ -4291,40 +4295,40 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_upsample_nearest_exact1d_out(
+    pub fn f_internal_upsample_nearest_exact1d_out(
         &self,
         out: &Tensor,
         output_size: impl IntList,
         scales: impl Into<Option<f64>>,
     ) -> Tensor {
-        self.f_internal_upsample_nearest_exact1d_out(out, output_size, scales).unwrap()
+        self.internal_upsample_nearest_exact1d_out(out, output_size, scales).unwrap()
     }
 
-    pub fn internal_upsample_nearest_exact1d_vec(
+    pub fn f_internal_upsample_nearest_exact1d_vec(
         &self,
         output_size: impl IntListOption,
         scale_factors: impl DoubleList,
     ) -> Tensor {
-        self.f_internal_upsample_nearest_exact1d_vec(output_size, scale_factors).unwrap()
+        self.internal_upsample_nearest_exact1d_vec(output_size, scale_factors).unwrap()
     }
 
-    pub fn internal_upsample_nearest_exact2d(
+    pub fn f_internal_upsample_nearest_exact2d(
         &self,
         output_size: impl IntList,
         scales_h: impl Into<Option<f64>>,
         scales_w: impl Into<Option<f64>>,
     ) -> Tensor {
-        self.f_internal_upsample_nearest_exact2d(output_size, scales_h, scales_w).unwrap()
+        self.internal_upsample_nearest_exact2d(output_size, scales_h, scales_w).unwrap()
     }
 
-    pub fn internal_upsample_nearest_exact2d_backward(
+    pub fn f_internal_upsample_nearest_exact2d_backward(
         grad_output: &Tensor,
         output_size: impl IntList,
         input_size: impl IntList,
         scales_h: impl Into<Option<f64>>,
         scales_w: impl Into<Option<f64>>,
     ) -> Tensor {
-        Tensor::f_internal_upsample_nearest_exact2d_backward(
+        Tensor::internal_upsample_nearest_exact2d_backward(
             grad_output,
             output_size,
             input_size,
@@ -4334,7 +4338,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_upsample_nearest_exact2d_backward_grad_input(
+    pub fn f_internal_upsample_nearest_exact2d_backward_grad_input(
         grad_input: &Tensor,
         grad_output: &Tensor,
         output_size: impl IntList,
@@ -4342,7 +4346,7 @@ impl Tensor {
         scales_h: impl Into<Option<f64>>,
         scales_w: impl Into<Option<f64>>,
     ) -> Tensor {
-        Tensor::f_internal_upsample_nearest_exact2d_backward_grad_input(
+        Tensor::internal_upsample_nearest_exact2d_backward_grad_input(
             grad_input,
             grad_output,
             output_size,
@@ -4353,35 +4357,35 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_upsample_nearest_exact2d_out(
+    pub fn f_internal_upsample_nearest_exact2d_out(
         &self,
         out: &Tensor,
         output_size: impl IntList,
         scales_h: impl Into<Option<f64>>,
         scales_w: impl Into<Option<f64>>,
     ) -> Tensor {
-        self.f_internal_upsample_nearest_exact2d_out(out, output_size, scales_h, scales_w).unwrap()
+        self.internal_upsample_nearest_exact2d_out(out, output_size, scales_h, scales_w).unwrap()
     }
 
-    pub fn internal_upsample_nearest_exact2d_vec(
+    pub fn f_internal_upsample_nearest_exact2d_vec(
         &self,
         output_size: impl IntListOption,
         scale_factors: impl DoubleList,
     ) -> Tensor {
-        self.f_internal_upsample_nearest_exact2d_vec(output_size, scale_factors).unwrap()
+        self.internal_upsample_nearest_exact2d_vec(output_size, scale_factors).unwrap()
     }
 
-    pub fn internal_upsample_nearest_exact3d(
+    pub fn f_internal_upsample_nearest_exact3d(
         &self,
         output_size: impl IntList,
         scales_d: impl Into<Option<f64>>,
         scales_h: impl Into<Option<f64>>,
         scales_w: impl Into<Option<f64>>,
     ) -> Tensor {
-        self.f_internal_upsample_nearest_exact3d(output_size, scales_d, scales_h, scales_w).unwrap()
+        self.internal_upsample_nearest_exact3d(output_size, scales_d, scales_h, scales_w).unwrap()
     }
 
-    pub fn internal_upsample_nearest_exact3d_backward(
+    pub fn f_internal_upsample_nearest_exact3d_backward(
         grad_output: &Tensor,
         output_size: impl IntList,
         input_size: impl IntList,
@@ -4389,7 +4393,7 @@ impl Tensor {
         scales_h: impl Into<Option<f64>>,
         scales_w: impl Into<Option<f64>>,
     ) -> Tensor {
-        Tensor::f_internal_upsample_nearest_exact3d_backward(
+        Tensor::internal_upsample_nearest_exact3d_backward(
             grad_output,
             output_size,
             input_size,
@@ -4400,7 +4404,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_upsample_nearest_exact3d_backward_grad_input(
+    pub fn f_internal_upsample_nearest_exact3d_backward_grad_input(
         grad_input: &Tensor,
         grad_output: &Tensor,
         output_size: impl IntList,
@@ -4409,7 +4413,7 @@ impl Tensor {
         scales_h: impl Into<Option<f64>>,
         scales_w: impl Into<Option<f64>>,
     ) -> Tensor {
-        Tensor::f_internal_upsample_nearest_exact3d_backward_grad_input(
+        Tensor::internal_upsample_nearest_exact3d_backward_grad_input(
             grad_input,
             grad_output,
             output_size,
@@ -4421,7 +4425,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_upsample_nearest_exact3d_out(
+    pub fn f_internal_upsample_nearest_exact3d_out(
         &self,
         out: &Tensor,
         output_size: impl IntList,
@@ -4429,26 +4433,26 @@ impl Tensor {
         scales_h: impl Into<Option<f64>>,
         scales_w: impl Into<Option<f64>>,
     ) -> Tensor {
-        self.f_internal_upsample_nearest_exact3d_out(out, output_size, scales_d, scales_h, scales_w)
+        self.internal_upsample_nearest_exact3d_out(out, output_size, scales_d, scales_h, scales_w)
             .unwrap()
     }
 
-    pub fn internal_upsample_nearest_exact3d_vec(
+    pub fn f_internal_upsample_nearest_exact3d_vec(
         &self,
         output_size: impl IntListOption,
         scale_factors: impl DoubleList,
     ) -> Tensor {
-        self.f_internal_upsample_nearest_exact3d_vec(output_size, scale_factors).unwrap()
+        self.internal_upsample_nearest_exact3d_vec(output_size, scale_factors).unwrap()
     }
 
-    pub fn internal_use_cudnn_ctc_loss(
+    pub fn f_internal_use_cudnn_ctc_loss(
         log_probs: &Tensor,
         targets: &Tensor,
         input_lengths: impl IntList,
         target_lengths: impl IntList,
         blank: i64,
     ) -> bool {
-        Tensor::f_internal_use_cudnn_ctc_loss(
+        Tensor::internal_use_cudnn_ctc_loss(
             log_probs,
             targets,
             input_lengths,
@@ -4458,14 +4462,14 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_use_cudnn_ctc_loss_tensor(
+    pub fn f_internal_use_cudnn_ctc_loss_tensor(
         log_probs: &Tensor,
         targets: &Tensor,
         input_lengths: &Tensor,
         target_lengths: &Tensor,
         blank: i64,
     ) -> bool {
-        Tensor::f_internal_use_cudnn_ctc_loss_tensor(
+        Tensor::internal_use_cudnn_ctc_loss_tensor(
             log_probs,
             targets,
             input_lengths,
@@ -4475,11 +4479,11 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_use_cudnn_rnn_flatten_weight() -> bool {
-        Tensor::f_internal_use_cudnn_rnn_flatten_weight().unwrap()
+    pub fn f_internal_use_cudnn_rnn_flatten_weight() -> bool {
+        Tensor::internal_use_cudnn_rnn_flatten_weight().unwrap()
     }
 
-    pub fn internal_validate_compressed_sparse_indices(
+    pub fn f_internal_validate_compressed_sparse_indices(
         is_crow: bool,
         compressed_idx: &Tensor,
         plain_idx: &Tensor,
@@ -4487,7 +4491,7 @@ impl Tensor {
         dim: i64,
         nnz: i64,
     ) {
-        Tensor::f_internal_validate_compressed_sparse_indices(
+        Tensor::internal_validate_compressed_sparse_indices(
             is_crow,
             compressed_idx,
             plain_idx,
@@ -4498,34 +4502,34 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_validate_sparse_bsc_tensor_args(
+    pub fn f_internal_validate_sparse_bsc_tensor_args(
         ccol_indices: &Tensor,
         row_indices: &Tensor,
         values: &Tensor,
         size: impl IntList,
     ) {
-        Tensor::f_internal_validate_sparse_bsc_tensor_args(ccol_indices, row_indices, values, size)
+        Tensor::internal_validate_sparse_bsc_tensor_args(ccol_indices, row_indices, values, size)
             .unwrap()
     }
 
-    pub fn internal_validate_sparse_bsr_tensor_args(
+    pub fn f_internal_validate_sparse_bsr_tensor_args(
         crow_indices: &Tensor,
         col_indices: &Tensor,
         values: &Tensor,
         size: impl IntList,
     ) {
-        Tensor::f_internal_validate_sparse_bsr_tensor_args(crow_indices, col_indices, values, size)
+        Tensor::internal_validate_sparse_bsr_tensor_args(crow_indices, col_indices, values, size)
             .unwrap()
     }
 
-    pub fn internal_validate_sparse_compressed_tensor_args(
+    pub fn f_internal_validate_sparse_compressed_tensor_args(
         compressed_indices: &Tensor,
         plain_indices: &Tensor,
         values: &Tensor,
         size: impl IntList,
         layout: Layout,
     ) {
-        Tensor::f_internal_validate_sparse_compressed_tensor_args(
+        Tensor::internal_validate_sparse_compressed_tensor_args(
             compressed_indices,
             plain_indices,
             values,
@@ -4535,54 +4539,54 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_validate_sparse_csc_tensor_args(
+    pub fn f_internal_validate_sparse_csc_tensor_args(
         ccol_indices: &Tensor,
         row_indices: &Tensor,
         values: &Tensor,
         size: impl IntList,
     ) {
-        Tensor::f_internal_validate_sparse_csc_tensor_args(ccol_indices, row_indices, values, size)
+        Tensor::internal_validate_sparse_csc_tensor_args(ccol_indices, row_indices, values, size)
             .unwrap()
     }
 
-    pub fn internal_validate_sparse_csr_tensor_args(
+    pub fn f_internal_validate_sparse_csr_tensor_args(
         crow_indices: &Tensor,
         col_indices: &Tensor,
         values: &Tensor,
         size: impl IntList,
     ) {
-        Tensor::f_internal_validate_sparse_csr_tensor_args(crow_indices, col_indices, values, size)
+        Tensor::internal_validate_sparse_csr_tensor_args(crow_indices, col_indices, values, size)
             .unwrap()
     }
 
-    pub fn internal_values(&self) -> Tensor {
-        self.f_internal_values().unwrap()
+    pub fn f_internal_values(&self) -> Tensor {
+        self.internal_values().unwrap()
     }
 
-    pub fn internal_values_copy(&self) -> Tensor {
-        self.f_internal_values_copy().unwrap()
+    pub fn f_internal_values_copy(&self) -> Tensor {
+        self.internal_values_copy().unwrap()
     }
 
-    pub fn internal_values_copy_out(&self, out: &Tensor) -> Tensor {
-        self.f_internal_values_copy_out(out).unwrap()
+    pub fn f_internal_values_copy_out(&self, out: &Tensor) -> Tensor {
+        self.internal_values_copy_out(out).unwrap()
     }
 
-    pub fn internal_version(&self) -> i64 {
-        self.f_internal_version().unwrap()
+    pub fn f_internal_version(&self) -> i64 {
+        self.internal_version().unwrap()
     }
 
-    pub fn internal_weight_norm(v: &Tensor, g: &Tensor, dim: i64) -> Tensor {
-        Tensor::f_internal_weight_norm(v, g, dim).unwrap()
+    pub fn f_internal_weight_norm(v: &Tensor, g: &Tensor, dim: i64) -> Tensor {
+        Tensor::internal_weight_norm(v, g, dim).unwrap()
     }
 
-    pub fn internal_weight_norm_differentiable_backward(
+    pub fn f_internal_weight_norm_differentiable_backward(
         grad_w: &Tensor,
         saved_v: &Tensor,
         saved_g: &Tensor,
         saved_norms: &Tensor,
         dim: i64,
     ) -> (Tensor, Tensor) {
-        Tensor::f_internal_weight_norm_differentiable_backward(
+        Tensor::internal_weight_norm_differentiable_backward(
             grad_w,
             saved_v,
             saved_g,
@@ -4592,28 +4596,22 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_weight_norm_interface(v: &Tensor, g: &Tensor, dim: i64) -> (Tensor, Tensor) {
-        Tensor::f_internal_weight_norm_interface(v, g, dim).unwrap()
+    pub fn f_internal_weight_norm_interface(v: &Tensor, g: &Tensor, dim: i64) -> (Tensor, Tensor) {
+        Tensor::internal_weight_norm_interface(v, g, dim).unwrap()
     }
 
-    pub fn internal_weight_norm_interface_backward(
+    pub fn f_internal_weight_norm_interface_backward(
         grad_w: &Tensor,
         saved_v: &Tensor,
         saved_g: &Tensor,
         saved_norms: &Tensor,
         dim: i64,
     ) -> (Tensor, Tensor) {
-        Tensor::f_internal_weight_norm_interface_backward(
-            grad_w,
-            saved_v,
-            saved_g,
-            saved_norms,
-            dim,
-        )
-        .unwrap()
+        Tensor::internal_weight_norm_interface_backward(grad_w, saved_v, saved_g, saved_norms, dim)
+            .unwrap()
     }
 
-    pub fn internal_weight_norm_interface_backward_out(
+    pub fn f_internal_weight_norm_interface_backward_out(
         out0: &Tensor,
         out1: &Tensor,
         grad_w: &Tensor,
@@ -4622,7 +4620,7 @@ impl Tensor {
         saved_norms: &Tensor,
         dim: i64,
     ) -> (Tensor, Tensor) {
-        Tensor::f_internal_weight_norm_interface_backward_out(
+        Tensor::internal_weight_norm_interface_backward_out(
             out0,
             out1,
             grad_w,
@@ -4634,562 +4632,562 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn internal_weight_norm_interface_out(
+    pub fn f_internal_weight_norm_interface_out(
         out0: &Tensor,
         out1: &Tensor,
         v: &Tensor,
         g: &Tensor,
         dim: i64,
     ) -> (Tensor, Tensor) {
-        Tensor::f_internal_weight_norm_interface_out(out0, out1, v, g, dim).unwrap()
+        Tensor::internal_weight_norm_interface_out(out0, out1, v, g, dim).unwrap()
     }
 
-    pub fn abs(&self) -> Tensor {
-        self.f_abs().unwrap()
+    pub fn f_abs(&self) -> Tensor {
+        self.abs().unwrap()
     }
 
-    pub fn abs_(&mut self) -> Tensor {
-        self.f_abs_().unwrap()
+    pub fn f_abs_(&mut self) -> Tensor {
+        self.abs_().unwrap()
     }
 
-    pub fn abs_out(&self, out: &Tensor) -> Tensor {
-        self.f_abs_out(out).unwrap()
+    pub fn f_abs_out(&self, out: &Tensor) -> Tensor {
+        self.abs_out(out).unwrap()
     }
 
-    pub fn absolute(&self) -> Tensor {
-        self.f_absolute().unwrap()
+    pub fn f_absolute(&self) -> Tensor {
+        self.absolute().unwrap()
     }
 
-    pub fn absolute_(&mut self) -> Tensor {
-        self.f_absolute_().unwrap()
+    pub fn f_absolute_(&mut self) -> Tensor {
+        self.absolute_().unwrap()
     }
 
-    pub fn absolute_out(&self, out: &Tensor) -> Tensor {
-        self.f_absolute_out(out).unwrap()
+    pub fn f_absolute_out(&self, out: &Tensor) -> Tensor {
+        self.absolute_out(out).unwrap()
     }
 
-    pub fn acos(&self) -> Tensor {
-        self.f_acos().unwrap()
+    pub fn f_acos(&self) -> Tensor {
+        self.acos().unwrap()
     }
 
-    pub fn acos_(&mut self) -> Tensor {
-        self.f_acos_().unwrap()
+    pub fn f_acos_(&mut self) -> Tensor {
+        self.acos_().unwrap()
     }
 
-    pub fn acos_out(&self, out: &Tensor) -> Tensor {
-        self.f_acos_out(out).unwrap()
+    pub fn f_acos_out(&self, out: &Tensor) -> Tensor {
+        self.acos_out(out).unwrap()
     }
 
-    pub fn acosh(&self) -> Tensor {
-        self.f_acosh().unwrap()
+    pub fn f_acosh(&self) -> Tensor {
+        self.acosh().unwrap()
     }
 
-    pub fn acosh_(&mut self) -> Tensor {
-        self.f_acosh_().unwrap()
+    pub fn f_acosh_(&mut self) -> Tensor {
+        self.acosh_().unwrap()
     }
 
-    pub fn acosh_out(&self, out: &Tensor) -> Tensor {
-        self.f_acosh_out(out).unwrap()
+    pub fn f_acosh_out(&self, out: &Tensor) -> Tensor {
+        self.acosh_out(out).unwrap()
     }
 
-    pub fn adaptive_avg_pool1d(&self, output_size: impl IntList) -> Tensor {
-        self.f_adaptive_avg_pool1d(output_size).unwrap()
+    pub fn f_adaptive_avg_pool1d(&self, output_size: impl IntList) -> Tensor {
+        self.adaptive_avg_pool1d(output_size).unwrap()
     }
 
-    pub fn adaptive_avg_pool2d(&self, output_size: impl IntList) -> Tensor {
-        self.f_adaptive_avg_pool2d(output_size).unwrap()
+    pub fn f_adaptive_avg_pool2d(&self, output_size: impl IntList) -> Tensor {
+        self.adaptive_avg_pool2d(output_size).unwrap()
     }
 
-    pub fn adaptive_avg_pool2d_out(&self, out: &Tensor, output_size: impl IntList) -> Tensor {
-        self.f_adaptive_avg_pool2d_out(out, output_size).unwrap()
+    pub fn f_adaptive_avg_pool2d_out(&self, out: &Tensor, output_size: impl IntList) -> Tensor {
+        self.adaptive_avg_pool2d_out(out, output_size).unwrap()
     }
 
-    pub fn adaptive_avg_pool3d(&self, output_size: impl IntList) -> Tensor {
-        self.f_adaptive_avg_pool3d(output_size).unwrap()
+    pub fn f_adaptive_avg_pool3d(&self, output_size: impl IntList) -> Tensor {
+        self.adaptive_avg_pool3d(output_size).unwrap()
     }
 
-    pub fn adaptive_avg_pool3d_backward(
+    pub fn f_adaptive_avg_pool3d_backward(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
     ) -> Tensor {
-        self.f_adaptive_avg_pool3d_backward(grad_input, grad_output).unwrap()
+        self.adaptive_avg_pool3d_backward(grad_input, grad_output).unwrap()
     }
 
-    pub fn adaptive_avg_pool3d_out(&self, out: &Tensor, output_size: impl IntList) -> Tensor {
-        self.f_adaptive_avg_pool3d_out(out, output_size).unwrap()
+    pub fn f_adaptive_avg_pool3d_out(&self, out: &Tensor, output_size: impl IntList) -> Tensor {
+        self.adaptive_avg_pool3d_out(out, output_size).unwrap()
     }
 
-    pub fn adaptive_max_pool1d(&self, output_size: impl IntList) -> (Tensor, Tensor) {
-        self.f_adaptive_max_pool1d(output_size).unwrap()
+    pub fn f_adaptive_max_pool1d(&self, output_size: impl IntList) -> (Tensor, Tensor) {
+        self.adaptive_max_pool1d(output_size).unwrap()
     }
 
-    pub fn adaptive_max_pool2d(&self, output_size: impl IntList) -> (Tensor, Tensor) {
-        self.f_adaptive_max_pool2d(output_size).unwrap()
+    pub fn f_adaptive_max_pool2d(&self, output_size: impl IntList) -> (Tensor, Tensor) {
+        self.adaptive_max_pool2d(output_size).unwrap()
     }
 
-    pub fn adaptive_max_pool2d_backward(&self, grad_output: &Tensor, indices: &Tensor) -> Tensor {
-        self.f_adaptive_max_pool2d_backward(grad_output, indices).unwrap()
+    pub fn f_adaptive_max_pool2d_backward(&self, grad_output: &Tensor, indices: &Tensor) -> Tensor {
+        self.adaptive_max_pool2d_backward(grad_output, indices).unwrap()
     }
 
-    pub fn adaptive_max_pool2d_backward_grad_input(
+    pub fn f_adaptive_max_pool2d_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
         indices: &Tensor,
     ) -> Tensor {
-        self.f_adaptive_max_pool2d_backward_grad_input(grad_input, grad_output, indices).unwrap()
+        self.adaptive_max_pool2d_backward_grad_input(grad_input, grad_output, indices).unwrap()
     }
 
-    pub fn adaptive_max_pool2d_out(
+    pub fn f_adaptive_max_pool2d_out(
         &self,
         out: &Tensor,
         indices: &Tensor,
         output_size: impl IntList,
     ) -> (Tensor, Tensor) {
-        self.f_adaptive_max_pool2d_out(out, indices, output_size).unwrap()
+        self.adaptive_max_pool2d_out(out, indices, output_size).unwrap()
     }
 
-    pub fn adaptive_max_pool3d(&self, output_size: impl IntList) -> (Tensor, Tensor) {
-        self.f_adaptive_max_pool3d(output_size).unwrap()
+    pub fn f_adaptive_max_pool3d(&self, output_size: impl IntList) -> (Tensor, Tensor) {
+        self.adaptive_max_pool3d(output_size).unwrap()
     }
 
-    pub fn adaptive_max_pool3d_backward(&self, grad_output: &Tensor, indices: &Tensor) -> Tensor {
-        self.f_adaptive_max_pool3d_backward(grad_output, indices).unwrap()
+    pub fn f_adaptive_max_pool3d_backward(&self, grad_output: &Tensor, indices: &Tensor) -> Tensor {
+        self.adaptive_max_pool3d_backward(grad_output, indices).unwrap()
     }
 
-    pub fn adaptive_max_pool3d_backward_grad_input(
+    pub fn f_adaptive_max_pool3d_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
         indices: &Tensor,
     ) -> Tensor {
-        self.f_adaptive_max_pool3d_backward_grad_input(grad_input, grad_output, indices).unwrap()
+        self.adaptive_max_pool3d_backward_grad_input(grad_input, grad_output, indices).unwrap()
     }
 
-    pub fn adaptive_max_pool3d_out(
+    pub fn f_adaptive_max_pool3d_out(
         &self,
         out: &Tensor,
         indices: &Tensor,
         output_size: impl IntList,
     ) -> (Tensor, Tensor) {
-        self.f_adaptive_max_pool3d_out(out, indices, output_size).unwrap()
+        self.adaptive_max_pool3d_out(out, indices, output_size).unwrap()
     }
 
-    pub fn g_add(&self, other: &Tensor) -> Tensor {
-        self.f_add(other).unwrap()
+    pub fn f_add(&self, other: &Tensor) -> Tensor {
+        self.g_add(other).unwrap()
     }
 
-    pub fn g_add_(&mut self, other: &Tensor) -> Tensor {
-        self.f_add_(other).unwrap()
+    pub fn f_add_(&mut self, other: &Tensor) -> Tensor {
+        self.g_add_(other).unwrap()
     }
 
-    pub fn add_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_add_out(out, other).unwrap()
+    pub fn f_add_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.add_out(out, other).unwrap()
     }
 
-    pub fn g_add_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_add_scalar(other).unwrap()
+    pub fn f_add_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.g_add_scalar(other).unwrap()
     }
 
-    pub fn g_add_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_add_scalar_(other).unwrap()
+    pub fn f_add_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.g_add_scalar_(other).unwrap()
     }
 
-    pub fn add_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
-        self.f_add_scalar_out(out, other).unwrap()
+    pub fn f_add_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
+        self.add_scalar_out(out, other).unwrap()
     }
 
-    pub fn addbmm(&self, batch1: &Tensor, batch2: &Tensor) -> Tensor {
-        self.f_addbmm(batch1, batch2).unwrap()
+    pub fn f_addbmm(&self, batch1: &Tensor, batch2: &Tensor) -> Tensor {
+        self.addbmm(batch1, batch2).unwrap()
     }
 
-    pub fn addbmm_(&mut self, batch1: &Tensor, batch2: &Tensor) -> Tensor {
-        self.f_addbmm_(batch1, batch2).unwrap()
+    pub fn f_addbmm_(&mut self, batch1: &Tensor, batch2: &Tensor) -> Tensor {
+        self.addbmm_(batch1, batch2).unwrap()
     }
 
-    pub fn addbmm_out(&self, out: &Tensor, batch1: &Tensor, batch2: &Tensor) -> Tensor {
-        self.f_addbmm_out(out, batch1, batch2).unwrap()
+    pub fn f_addbmm_out(&self, out: &Tensor, batch1: &Tensor, batch2: &Tensor) -> Tensor {
+        self.addbmm_out(out, batch1, batch2).unwrap()
     }
 
-    pub fn addcdiv(&self, tensor1: &Tensor, tensor2: &Tensor) -> Tensor {
-        self.f_addcdiv(tensor1, tensor2).unwrap()
+    pub fn f_addcdiv(&self, tensor1: &Tensor, tensor2: &Tensor) -> Tensor {
+        self.addcdiv(tensor1, tensor2).unwrap()
     }
 
-    pub fn addcdiv_(&mut self, tensor1: &Tensor, tensor2: &Tensor) -> Tensor {
-        self.f_addcdiv_(tensor1, tensor2).unwrap()
+    pub fn f_addcdiv_(&mut self, tensor1: &Tensor, tensor2: &Tensor) -> Tensor {
+        self.addcdiv_(tensor1, tensor2).unwrap()
     }
 
-    pub fn addcdiv_out(&self, out: &Tensor, tensor1: &Tensor, tensor2: &Tensor) -> Tensor {
-        self.f_addcdiv_out(out, tensor1, tensor2).unwrap()
+    pub fn f_addcdiv_out(&self, out: &Tensor, tensor1: &Tensor, tensor2: &Tensor) -> Tensor {
+        self.addcdiv_out(out, tensor1, tensor2).unwrap()
     }
 
-    pub fn addcmul(&self, tensor1: &Tensor, tensor2: &Tensor) -> Tensor {
-        self.f_addcmul(tensor1, tensor2).unwrap()
+    pub fn f_addcmul(&self, tensor1: &Tensor, tensor2: &Tensor) -> Tensor {
+        self.addcmul(tensor1, tensor2).unwrap()
     }
 
-    pub fn addcmul_(&mut self, tensor1: &Tensor, tensor2: &Tensor) -> Tensor {
-        self.f_addcmul_(tensor1, tensor2).unwrap()
+    pub fn f_addcmul_(&mut self, tensor1: &Tensor, tensor2: &Tensor) -> Tensor {
+        self.addcmul_(tensor1, tensor2).unwrap()
     }
 
-    pub fn addcmul_out(&self, out: &Tensor, tensor1: &Tensor, tensor2: &Tensor) -> Tensor {
-        self.f_addcmul_out(out, tensor1, tensor2).unwrap()
+    pub fn f_addcmul_out(&self, out: &Tensor, tensor1: &Tensor, tensor2: &Tensor) -> Tensor {
+        self.addcmul_out(out, tensor1, tensor2).unwrap()
     }
 
-    pub fn addmm(&self, mat1: &Tensor, mat2: &Tensor) -> Tensor {
-        self.f_addmm(mat1, mat2).unwrap()
+    pub fn f_addmm(&self, mat1: &Tensor, mat2: &Tensor) -> Tensor {
+        self.addmm(mat1, mat2).unwrap()
     }
 
-    pub fn addmm_(&mut self, mat1: &Tensor, mat2: &Tensor) -> Tensor {
-        self.f_addmm_(mat1, mat2).unwrap()
+    pub fn f_addmm_(&mut self, mat1: &Tensor, mat2: &Tensor) -> Tensor {
+        self.addmm_(mat1, mat2).unwrap()
     }
 
-    pub fn addmm_out(&self, out: &Tensor, mat1: &Tensor, mat2: &Tensor) -> Tensor {
-        self.f_addmm_out(out, mat1, mat2).unwrap()
+    pub fn f_addmm_out(&self, out: &Tensor, mat1: &Tensor, mat2: &Tensor) -> Tensor {
+        self.addmm_out(out, mat1, mat2).unwrap()
     }
 
-    pub fn addmv(&self, mat: &Tensor, vec: &Tensor) -> Tensor {
-        self.f_addmv(mat, vec).unwrap()
+    pub fn f_addmv(&self, mat: &Tensor, vec: &Tensor) -> Tensor {
+        self.addmv(mat, vec).unwrap()
     }
 
-    pub fn addmv_(&mut self, mat: &Tensor, vec: &Tensor) -> Tensor {
-        self.f_addmv_(mat, vec).unwrap()
+    pub fn f_addmv_(&mut self, mat: &Tensor, vec: &Tensor) -> Tensor {
+        self.addmv_(mat, vec).unwrap()
     }
 
-    pub fn addmv_out(&self, out: &Tensor, mat: &Tensor, vec: &Tensor) -> Tensor {
-        self.f_addmv_out(out, mat, vec).unwrap()
+    pub fn f_addmv_out(&self, out: &Tensor, mat: &Tensor, vec: &Tensor) -> Tensor {
+        self.addmv_out(out, mat, vec).unwrap()
     }
 
-    pub fn addr(&self, vec1: &Tensor, vec2: &Tensor) -> Tensor {
-        self.f_addr(vec1, vec2).unwrap()
+    pub fn f_addr(&self, vec1: &Tensor, vec2: &Tensor) -> Tensor {
+        self.addr(vec1, vec2).unwrap()
     }
 
-    pub fn addr_(&mut self, vec1: &Tensor, vec2: &Tensor) -> Tensor {
-        self.f_addr_(vec1, vec2).unwrap()
+    pub fn f_addr_(&mut self, vec1: &Tensor, vec2: &Tensor) -> Tensor {
+        self.addr_(vec1, vec2).unwrap()
     }
 
-    pub fn addr_out(&self, out: &Tensor, vec1: &Tensor, vec2: &Tensor) -> Tensor {
-        self.f_addr_out(out, vec1, vec2).unwrap()
+    pub fn f_addr_out(&self, out: &Tensor, vec1: &Tensor, vec2: &Tensor) -> Tensor {
+        self.addr_out(out, vec1, vec2).unwrap()
     }
 
-    pub fn adjoint(&self) -> Tensor {
-        self.f_adjoint().unwrap()
+    pub fn f_adjoint(&self) -> Tensor {
+        self.adjoint().unwrap()
     }
 
-    pub fn affine_grid_generator(
+    pub fn f_affine_grid_generator(
         theta: &Tensor,
         size: impl IntList,
         align_corners: bool,
     ) -> Tensor {
-        Tensor::f_affine_grid_generator(theta, size, align_corners).unwrap()
+        Tensor::affine_grid_generator(theta, size, align_corners).unwrap()
     }
 
-    pub fn affine_grid_generator_backward(
+    pub fn f_affine_grid_generator_backward(
         grad: &Tensor,
         size: impl IntList,
         align_corners: bool,
     ) -> Tensor {
-        Tensor::f_affine_grid_generator_backward(grad, size, align_corners).unwrap()
+        Tensor::affine_grid_generator_backward(grad, size, align_corners).unwrap()
     }
 
-    pub fn affine_grid_generator_out(
+    pub fn f_affine_grid_generator_out(
         out: &Tensor,
         theta: &Tensor,
         size: impl IntList,
         align_corners: bool,
     ) -> Tensor {
-        Tensor::f_affine_grid_generator_out(out, theta, size, align_corners).unwrap()
+        Tensor::affine_grid_generator_out(out, theta, size, align_corners).unwrap()
     }
 
-    pub fn alias(&self) -> Tensor {
-        self.f_alias().unwrap()
+    pub fn f_alias(&self) -> Tensor {
+        self.alias().unwrap()
     }
 
-    pub fn alias_copy(&self) -> Tensor {
-        self.f_alias_copy().unwrap()
+    pub fn f_alias_copy(&self) -> Tensor {
+        self.alias_copy().unwrap()
     }
 
-    pub fn alias_copy_out(&self, out: &Tensor) -> Tensor {
-        self.f_alias_copy_out(out).unwrap()
+    pub fn f_alias_copy_out(&self, out: &Tensor) -> Tensor {
+        self.alias_copy_out(out).unwrap()
     }
 
-    pub fn align_as(&self, other: &Tensor) -> Tensor {
-        self.f_align_as(other).unwrap()
+    pub fn f_align_as(&self, other: &Tensor) -> Tensor {
+        self.align_as(other).unwrap()
     }
 
-    pub fn align_tensors<T: Borrow<Tensor>>(tensors: &[T]) -> Vec<Tensor> {
-        Tensor::f_align_tensors(tensors).unwrap()
+    pub fn f_align_tensors<T: Borrow<Tensor>>(tensors: &[T]) -> Vec<Tensor> {
+        Tensor::align_tensors(tensors).unwrap()
     }
 
-    pub fn all(&self) -> Tensor {
-        self.f_all().unwrap()
+    pub fn f_all(&self) -> Tensor {
+        self.all().unwrap()
     }
 
-    pub fn all_all_out(&self, out: &Tensor) -> Tensor {
-        self.f_all_all_out(out).unwrap()
+    pub fn f_all_all_out(&self, out: &Tensor) -> Tensor {
+        self.all_all_out(out).unwrap()
     }
 
-    pub fn all_dim(&self, dim: i64, keepdim: bool) -> Tensor {
-        self.f_all_dim(dim, keepdim).unwrap()
+    pub fn f_all_dim(&self, dim: i64, keepdim: bool) -> Tensor {
+        self.all_dim(dim, keepdim).unwrap()
     }
 
-    pub fn all_out(&self, out: &Tensor, dim: i64, keepdim: bool) -> Tensor {
-        self.f_all_out(out, dim, keepdim).unwrap()
+    pub fn f_all_out(&self, out: &Tensor, dim: i64, keepdim: bool) -> Tensor {
+        self.all_out(out, dim, keepdim).unwrap()
     }
 
-    pub fn allclose(&self, other: &Tensor, rtol: f64, atol: f64, equal_nan: bool) -> bool {
-        self.f_allclose(other, rtol, atol, equal_nan).unwrap()
+    pub fn f_allclose(&self, other: &Tensor, rtol: f64, atol: f64, equal_nan: bool) -> bool {
+        self.allclose(other, rtol, atol, equal_nan).unwrap()
     }
 
-    pub fn alpha_dropout(&self, p: f64, train: bool) -> Tensor {
-        self.f_alpha_dropout(p, train).unwrap()
+    pub fn f_alpha_dropout(&self, p: f64, train: bool) -> Tensor {
+        self.alpha_dropout(p, train).unwrap()
     }
 
-    pub fn alpha_dropout_(&mut self, p: f64, train: bool) -> Tensor {
-        self.f_alpha_dropout_(p, train).unwrap()
+    pub fn f_alpha_dropout_(&mut self, p: f64, train: bool) -> Tensor {
+        self.alpha_dropout_(p, train).unwrap()
     }
 
-    pub fn amax(&self, dim: impl IntList, keepdim: bool) -> Tensor {
-        self.f_amax(dim, keepdim).unwrap()
+    pub fn f_amax(&self, dim: impl IntList, keepdim: bool) -> Tensor {
+        self.amax(dim, keepdim).unwrap()
     }
 
-    pub fn amax_out(&self, out: &Tensor, dim: impl IntList, keepdim: bool) -> Tensor {
-        self.f_amax_out(out, dim, keepdim).unwrap()
+    pub fn f_amax_out(&self, out: &Tensor, dim: impl IntList, keepdim: bool) -> Tensor {
+        self.amax_out(out, dim, keepdim).unwrap()
     }
 
-    pub fn amin(&self, dim: impl IntList, keepdim: bool) -> Tensor {
-        self.f_amin(dim, keepdim).unwrap()
+    pub fn f_amin(&self, dim: impl IntList, keepdim: bool) -> Tensor {
+        self.amin(dim, keepdim).unwrap()
     }
 
-    pub fn amin_out(&self, out: &Tensor, dim: impl IntList, keepdim: bool) -> Tensor {
-        self.f_amin_out(out, dim, keepdim).unwrap()
+    pub fn f_amin_out(&self, out: &Tensor, dim: impl IntList, keepdim: bool) -> Tensor {
+        self.amin_out(out, dim, keepdim).unwrap()
     }
 
-    pub fn aminmax(&self, dim: impl Into<Option<i64>>, keepdim: bool) -> (Tensor, Tensor) {
-        self.f_aminmax(dim, keepdim).unwrap()
+    pub fn f_aminmax(&self, dim: impl Into<Option<i64>>, keepdim: bool) -> (Tensor, Tensor) {
+        self.aminmax(dim, keepdim).unwrap()
     }
 
-    pub fn aminmax_out(
+    pub fn f_aminmax_out(
         &self,
         min: &Tensor,
         max: &Tensor,
         dim: impl Into<Option<i64>>,
         keepdim: bool,
     ) -> (Tensor, Tensor) {
-        self.f_aminmax_out(min, max, dim, keepdim).unwrap()
+        self.aminmax_out(min, max, dim, keepdim).unwrap()
     }
 
-    pub fn angle(&self) -> Tensor {
-        self.f_angle().unwrap()
+    pub fn f_angle(&self) -> Tensor {
+        self.angle().unwrap()
     }
 
-    pub fn angle_out(&self, out: &Tensor) -> Tensor {
-        self.f_angle_out(out).unwrap()
+    pub fn f_angle_out(&self, out: &Tensor) -> Tensor {
+        self.angle_out(out).unwrap()
     }
 
-    pub fn any(&self) -> Tensor {
-        self.f_any().unwrap()
+    pub fn f_any(&self) -> Tensor {
+        self.any().unwrap()
     }
 
-    pub fn any_all_out(&self, out: &Tensor) -> Tensor {
-        self.f_any_all_out(out).unwrap()
+    pub fn f_any_all_out(&self, out: &Tensor) -> Tensor {
+        self.any_all_out(out).unwrap()
     }
 
-    pub fn any_dim(&self, dim: i64, keepdim: bool) -> Tensor {
-        self.f_any_dim(dim, keepdim).unwrap()
+    pub fn f_any_dim(&self, dim: i64, keepdim: bool) -> Tensor {
+        self.any_dim(dim, keepdim).unwrap()
     }
 
-    pub fn any_out(&self, out: &Tensor, dim: i64, keepdim: bool) -> Tensor {
-        self.f_any_out(out, dim, keepdim).unwrap()
+    pub fn f_any_out(&self, out: &Tensor, dim: i64, keepdim: bool) -> Tensor {
+        self.any_out(out, dim, keepdim).unwrap()
     }
 
-    pub fn arange<S: Into<Scalar>>(end: S, options: (Kind, Device)) -> Tensor {
-        Tensor::f_arange(end, options).unwrap()
+    pub fn f_arange<S: Into<Scalar>>(end: S, options: (Kind, Device)) -> Tensor {
+        Tensor::arange(end, options).unwrap()
     }
 
-    pub fn arange_start<S: Into<Scalar>>(start: S, end: S, options: (Kind, Device)) -> Tensor {
-        Tensor::f_arange_start(start, end, options).unwrap()
+    pub fn f_arange_start<S: Into<Scalar>>(start: S, end: S, options: (Kind, Device)) -> Tensor {
+        Tensor::arange_start(start, end, options).unwrap()
     }
 
-    pub fn arange_start_step<S: Into<Scalar>>(
+    pub fn f_arange_start_step<S: Into<Scalar>>(
         start: S,
         end: S,
         step: S,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_arange_start_step(start, end, step, options).unwrap()
+        Tensor::arange_start_step(start, end, step, options).unwrap()
     }
 
-    pub fn arccos(&self) -> Tensor {
-        self.f_arccos().unwrap()
+    pub fn f_arccos(&self) -> Tensor {
+        self.arccos().unwrap()
     }
 
-    pub fn arccos_(&mut self) -> Tensor {
-        self.f_arccos_().unwrap()
+    pub fn f_arccos_(&mut self) -> Tensor {
+        self.arccos_().unwrap()
     }
 
-    pub fn arccos_out(&self, out: &Tensor) -> Tensor {
-        self.f_arccos_out(out).unwrap()
+    pub fn f_arccos_out(&self, out: &Tensor) -> Tensor {
+        self.arccos_out(out).unwrap()
     }
 
-    pub fn arccosh(&self) -> Tensor {
-        self.f_arccosh().unwrap()
+    pub fn f_arccosh(&self) -> Tensor {
+        self.arccosh().unwrap()
     }
 
-    pub fn arccosh_(&mut self) -> Tensor {
-        self.f_arccosh_().unwrap()
+    pub fn f_arccosh_(&mut self) -> Tensor {
+        self.arccosh_().unwrap()
     }
 
-    pub fn arccosh_out(&self, out: &Tensor) -> Tensor {
-        self.f_arccosh_out(out).unwrap()
+    pub fn f_arccosh_out(&self, out: &Tensor) -> Tensor {
+        self.arccosh_out(out).unwrap()
     }
 
-    pub fn arcsin(&self) -> Tensor {
-        self.f_arcsin().unwrap()
+    pub fn f_arcsin(&self) -> Tensor {
+        self.arcsin().unwrap()
     }
 
-    pub fn arcsin_(&mut self) -> Tensor {
-        self.f_arcsin_().unwrap()
+    pub fn f_arcsin_(&mut self) -> Tensor {
+        self.arcsin_().unwrap()
     }
 
-    pub fn arcsin_out(&self, out: &Tensor) -> Tensor {
-        self.f_arcsin_out(out).unwrap()
+    pub fn f_arcsin_out(&self, out: &Tensor) -> Tensor {
+        self.arcsin_out(out).unwrap()
     }
 
-    pub fn arcsinh(&self) -> Tensor {
-        self.f_arcsinh().unwrap()
+    pub fn f_arcsinh(&self) -> Tensor {
+        self.arcsinh().unwrap()
     }
 
-    pub fn arcsinh_(&mut self) -> Tensor {
-        self.f_arcsinh_().unwrap()
+    pub fn f_arcsinh_(&mut self) -> Tensor {
+        self.arcsinh_().unwrap()
     }
 
-    pub fn arcsinh_out(&self, out: &Tensor) -> Tensor {
-        self.f_arcsinh_out(out).unwrap()
+    pub fn f_arcsinh_out(&self, out: &Tensor) -> Tensor {
+        self.arcsinh_out(out).unwrap()
     }
 
-    pub fn arctan(&self) -> Tensor {
-        self.f_arctan().unwrap()
+    pub fn f_arctan(&self) -> Tensor {
+        self.arctan().unwrap()
     }
 
-    pub fn arctan2(&self, other: &Tensor) -> Tensor {
-        self.f_arctan2(other).unwrap()
+    pub fn f_arctan2(&self, other: &Tensor) -> Tensor {
+        self.arctan2(other).unwrap()
     }
 
-    pub fn arctan2_(&mut self, other: &Tensor) -> Tensor {
-        self.f_arctan2_(other).unwrap()
+    pub fn f_arctan2_(&mut self, other: &Tensor) -> Tensor {
+        self.arctan2_(other).unwrap()
     }
 
-    pub fn arctan2_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_arctan2_out(out, other).unwrap()
+    pub fn f_arctan2_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.arctan2_out(out, other).unwrap()
     }
 
-    pub fn arctan_(&mut self) -> Tensor {
-        self.f_arctan_().unwrap()
+    pub fn f_arctan_(&mut self) -> Tensor {
+        self.arctan_().unwrap()
     }
 
-    pub fn arctan_out(&self, out: &Tensor) -> Tensor {
-        self.f_arctan_out(out).unwrap()
+    pub fn f_arctan_out(&self, out: &Tensor) -> Tensor {
+        self.arctan_out(out).unwrap()
     }
 
-    pub fn arctanh(&self) -> Tensor {
-        self.f_arctanh().unwrap()
+    pub fn f_arctanh(&self) -> Tensor {
+        self.arctanh().unwrap()
     }
 
-    pub fn arctanh_(&mut self) -> Tensor {
-        self.f_arctanh_().unwrap()
+    pub fn f_arctanh_(&mut self) -> Tensor {
+        self.arctanh_().unwrap()
     }
 
-    pub fn arctanh_out(&self, out: &Tensor) -> Tensor {
-        self.f_arctanh_out(out).unwrap()
+    pub fn f_arctanh_out(&self, out: &Tensor) -> Tensor {
+        self.arctanh_out(out).unwrap()
     }
 
-    pub fn argmax(&self, dim: impl Into<Option<i64>>, keepdim: bool) -> Tensor {
-        self.f_argmax(dim, keepdim).unwrap()
+    pub fn f_argmax(&self, dim: impl Into<Option<i64>>, keepdim: bool) -> Tensor {
+        self.argmax(dim, keepdim).unwrap()
     }
 
-    pub fn argmax_out(&self, out: &Tensor, dim: impl Into<Option<i64>>, keepdim: bool) -> Tensor {
-        self.f_argmax_out(out, dim, keepdim).unwrap()
+    pub fn f_argmax_out(&self, out: &Tensor, dim: impl Into<Option<i64>>, keepdim: bool) -> Tensor {
+        self.argmax_out(out, dim, keepdim).unwrap()
     }
 
-    pub fn argmin(&self, dim: impl Into<Option<i64>>, keepdim: bool) -> Tensor {
-        self.f_argmin(dim, keepdim).unwrap()
+    pub fn f_argmin(&self, dim: impl Into<Option<i64>>, keepdim: bool) -> Tensor {
+        self.argmin(dim, keepdim).unwrap()
     }
 
-    pub fn argmin_out(&self, out: &Tensor, dim: impl Into<Option<i64>>, keepdim: bool) -> Tensor {
-        self.f_argmin_out(out, dim, keepdim).unwrap()
+    pub fn f_argmin_out(&self, out: &Tensor, dim: impl Into<Option<i64>>, keepdim: bool) -> Tensor {
+        self.argmin_out(out, dim, keepdim).unwrap()
     }
 
-    pub fn argsort(&self, dim: i64, descending: bool) -> Tensor {
-        self.f_argsort(dim, descending).unwrap()
+    pub fn f_argsort(&self, dim: i64, descending: bool) -> Tensor {
+        self.argsort(dim, descending).unwrap()
     }
 
-    pub fn argsort_stable(&self, stable: bool, dim: i64, descending: bool) -> Tensor {
-        self.f_argsort_stable(stable, dim, descending).unwrap()
+    pub fn f_argsort_stable(&self, stable: bool, dim: i64, descending: bool) -> Tensor {
+        self.argsort_stable(stable, dim, descending).unwrap()
     }
 
-    pub fn argsort_stable_out(
+    pub fn f_argsort_stable_out(
         &self,
         out: &Tensor,
         stable: bool,
         dim: i64,
         descending: bool,
     ) -> Tensor {
-        self.f_argsort_stable_out(out, stable, dim, descending).unwrap()
+        self.argsort_stable_out(out, stable, dim, descending).unwrap()
     }
 
-    pub fn argwhere(&self) -> Tensor {
-        self.f_argwhere().unwrap()
+    pub fn f_argwhere(&self) -> Tensor {
+        self.argwhere().unwrap()
     }
 
-    pub fn as_strided(
+    pub fn f_as_strided(
         &self,
         size: impl IntList,
         stride: impl IntList,
         storage_offset: impl Into<Option<i64>>,
     ) -> Tensor {
-        self.f_as_strided(size, stride, storage_offset).unwrap()
+        self.as_strided(size, stride, storage_offset).unwrap()
     }
 
-    pub fn as_strided_(
+    pub fn f_as_strided_(
         &mut self,
         size: impl IntList,
         stride: impl IntList,
         storage_offset: impl Into<Option<i64>>,
     ) -> Tensor {
-        self.f_as_strided_(size, stride, storage_offset).unwrap()
+        self.as_strided_(size, stride, storage_offset).unwrap()
     }
 
-    pub fn as_strided_copy(
+    pub fn f_as_strided_copy(
         &self,
         size: impl IntList,
         stride: impl IntList,
         storage_offset: impl Into<Option<i64>>,
     ) -> Tensor {
-        self.f_as_strided_copy(size, stride, storage_offset).unwrap()
+        self.as_strided_copy(size, stride, storage_offset).unwrap()
     }
 
-    pub fn as_strided_copy_out(
+    pub fn f_as_strided_copy_out(
         &self,
         out: &Tensor,
         size: impl IntList,
         stride: impl IntList,
         storage_offset: impl Into<Option<i64>>,
     ) -> Tensor {
-        self.f_as_strided_copy_out(out, size, stride, storage_offset).unwrap()
+        self.as_strided_copy_out(out, size, stride, storage_offset).unwrap()
     }
 
-    pub fn as_strided_scatter(
+    pub fn f_as_strided_scatter(
         &self,
         src: &Tensor,
         size: impl IntList,
         stride: impl IntList,
         storage_offset: impl Into<Option<i64>>,
     ) -> Tensor {
-        self.f_as_strided_scatter(src, size, stride, storage_offset).unwrap()
+        self.as_strided_scatter(src, size, stride, storage_offset).unwrap()
     }
 
-    pub fn as_strided_scatter_out(
+    pub fn f_as_strided_scatter_out(
         &self,
         out: &Tensor,
         src: &Tensor,
@@ -5197,94 +5195,94 @@ impl Tensor {
         stride: impl IntList,
         storage_offset: impl Into<Option<i64>>,
     ) -> Tensor {
-        self.f_as_strided_scatter_out(out, src, size, stride, storage_offset).unwrap()
+        self.as_strided_scatter_out(out, src, size, stride, storage_offset).unwrap()
     }
 
-    pub fn asin(&self) -> Tensor {
-        self.f_asin().unwrap()
+    pub fn f_asin(&self) -> Tensor {
+        self.asin().unwrap()
     }
 
-    pub fn asin_(&mut self) -> Tensor {
-        self.f_asin_().unwrap()
+    pub fn f_asin_(&mut self) -> Tensor {
+        self.asin_().unwrap()
     }
 
-    pub fn asin_out(&self, out: &Tensor) -> Tensor {
-        self.f_asin_out(out).unwrap()
+    pub fn f_asin_out(&self, out: &Tensor) -> Tensor {
+        self.asin_out(out).unwrap()
     }
 
-    pub fn asinh(&self) -> Tensor {
-        self.f_asinh().unwrap()
+    pub fn f_asinh(&self) -> Tensor {
+        self.asinh().unwrap()
     }
 
-    pub fn asinh_(&mut self) -> Tensor {
-        self.f_asinh_().unwrap()
+    pub fn f_asinh_(&mut self) -> Tensor {
+        self.asinh_().unwrap()
     }
 
-    pub fn asinh_out(&self, out: &Tensor) -> Tensor {
-        self.f_asinh_out(out).unwrap()
+    pub fn f_asinh_out(&self, out: &Tensor) -> Tensor {
+        self.asinh_out(out).unwrap()
     }
 
-    pub fn atan(&self) -> Tensor {
-        self.f_atan().unwrap()
+    pub fn f_atan(&self) -> Tensor {
+        self.atan().unwrap()
     }
 
-    pub fn atan2(&self, other: &Tensor) -> Tensor {
-        self.f_atan2(other).unwrap()
+    pub fn f_atan2(&self, other: &Tensor) -> Tensor {
+        self.atan2(other).unwrap()
     }
 
-    pub fn atan2_(&mut self, other: &Tensor) -> Tensor {
-        self.f_atan2_(other).unwrap()
+    pub fn f_atan2_(&mut self, other: &Tensor) -> Tensor {
+        self.atan2_(other).unwrap()
     }
 
-    pub fn atan2_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_atan2_out(out, other).unwrap()
+    pub fn f_atan2_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.atan2_out(out, other).unwrap()
     }
 
-    pub fn atan_(&mut self) -> Tensor {
-        self.f_atan_().unwrap()
+    pub fn f_atan_(&mut self) -> Tensor {
+        self.atan_().unwrap()
     }
 
-    pub fn atan_out(&self, out: &Tensor) -> Tensor {
-        self.f_atan_out(out).unwrap()
+    pub fn f_atan_out(&self, out: &Tensor) -> Tensor {
+        self.atan_out(out).unwrap()
     }
 
-    pub fn atanh(&self) -> Tensor {
-        self.f_atanh().unwrap()
+    pub fn f_atanh(&self) -> Tensor {
+        self.atanh().unwrap()
     }
 
-    pub fn atanh_(&mut self) -> Tensor {
-        self.f_atanh_().unwrap()
+    pub fn f_atanh_(&mut self) -> Tensor {
+        self.atanh_().unwrap()
     }
 
-    pub fn atanh_out(&self, out: &Tensor) -> Tensor {
-        self.f_atanh_out(out).unwrap()
+    pub fn f_atanh_out(&self, out: &Tensor) -> Tensor {
+        self.atanh_out(out).unwrap()
     }
 
-    pub fn atleast_1d(&self) -> Tensor {
-        self.f_atleast_1d().unwrap()
+    pub fn f_atleast_1d(&self) -> Tensor {
+        self.atleast_1d().unwrap()
     }
 
-    pub fn atleast_1d_sequence<T: Borrow<Tensor>>(tensors: &[T]) -> Vec<Tensor> {
-        Tensor::f_atleast_1d_sequence(tensors).unwrap()
+    pub fn f_atleast_1d_sequence<T: Borrow<Tensor>>(tensors: &[T]) -> Vec<Tensor> {
+        Tensor::atleast_1d_sequence(tensors).unwrap()
     }
 
-    pub fn atleast_2d(&self) -> Tensor {
-        self.f_atleast_2d().unwrap()
+    pub fn f_atleast_2d(&self) -> Tensor {
+        self.atleast_2d().unwrap()
     }
 
-    pub fn atleast_2d_sequence<T: Borrow<Tensor>>(tensors: &[T]) -> Vec<Tensor> {
-        Tensor::f_atleast_2d_sequence(tensors).unwrap()
+    pub fn f_atleast_2d_sequence<T: Borrow<Tensor>>(tensors: &[T]) -> Vec<Tensor> {
+        Tensor::atleast_2d_sequence(tensors).unwrap()
     }
 
-    pub fn atleast_3d(&self) -> Tensor {
-        self.f_atleast_3d().unwrap()
+    pub fn f_atleast_3d(&self) -> Tensor {
+        self.atleast_3d().unwrap()
     }
 
-    pub fn atleast_3d_sequence<T: Borrow<Tensor>>(tensors: &[T]) -> Vec<Tensor> {
-        Tensor::f_atleast_3d_sequence(tensors).unwrap()
+    pub fn f_atleast_3d_sequence<T: Borrow<Tensor>>(tensors: &[T]) -> Vec<Tensor> {
+        Tensor::atleast_3d_sequence(tensors).unwrap()
     }
 
-    pub fn avg_pool1d(
+    pub fn f_avg_pool1d(
         &self,
         kernel_size: impl IntList,
         stride: impl IntList,
@@ -5292,10 +5290,10 @@ impl Tensor {
         ceil_mode: bool,
         count_include_pad: bool,
     ) -> Tensor {
-        self.f_avg_pool1d(kernel_size, stride, padding, ceil_mode, count_include_pad).unwrap()
+        self.avg_pool1d(kernel_size, stride, padding, ceil_mode, count_include_pad).unwrap()
     }
 
-    pub fn avg_pool2d(
+    pub fn f_avg_pool2d(
         &self,
         kernel_size: impl IntList,
         stride: impl IntList,
@@ -5304,7 +5302,7 @@ impl Tensor {
         count_include_pad: bool,
         divisor_override: impl Into<Option<i64>>,
     ) -> Tensor {
-        self.f_avg_pool2d(
+        self.avg_pool2d(
             kernel_size,
             stride,
             padding,
@@ -5315,7 +5313,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn avg_pool2d_backward(
+    pub fn f_avg_pool2d_backward(
         &self,
         grad_output: &Tensor,
         kernel_size: impl IntList,
@@ -5325,7 +5323,7 @@ impl Tensor {
         count_include_pad: bool,
         divisor_override: impl Into<Option<i64>>,
     ) -> Tensor {
-        self.f_avg_pool2d_backward(
+        self.avg_pool2d_backward(
             grad_output,
             kernel_size,
             stride,
@@ -5337,7 +5335,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn avg_pool2d_backward_grad_input(
+    pub fn f_avg_pool2d_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -5348,7 +5346,7 @@ impl Tensor {
         count_include_pad: bool,
         divisor_override: impl Into<Option<i64>>,
     ) -> Tensor {
-        self.f_avg_pool2d_backward_grad_input(
+        self.avg_pool2d_backward_grad_input(
             grad_input,
             grad_output,
             kernel_size,
@@ -5361,7 +5359,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn avg_pool2d_out(
+    pub fn f_avg_pool2d_out(
         &self,
         out: &Tensor,
         kernel_size: impl IntList,
@@ -5371,7 +5369,7 @@ impl Tensor {
         count_include_pad: bool,
         divisor_override: impl Into<Option<i64>>,
     ) -> Tensor {
-        self.f_avg_pool2d_out(
+        self.avg_pool2d_out(
             out,
             kernel_size,
             stride,
@@ -5383,7 +5381,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn avg_pool3d(
+    pub fn f_avg_pool3d(
         &self,
         kernel_size: impl IntList,
         stride: impl IntList,
@@ -5392,7 +5390,7 @@ impl Tensor {
         count_include_pad: bool,
         divisor_override: impl Into<Option<i64>>,
     ) -> Tensor {
-        self.f_avg_pool3d(
+        self.avg_pool3d(
             kernel_size,
             stride,
             padding,
@@ -5403,7 +5401,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn avg_pool3d_backward(
+    pub fn f_avg_pool3d_backward(
         &self,
         grad_output: &Tensor,
         kernel_size: impl IntList,
@@ -5413,7 +5411,7 @@ impl Tensor {
         count_include_pad: bool,
         divisor_override: impl Into<Option<i64>>,
     ) -> Tensor {
-        self.f_avg_pool3d_backward(
+        self.avg_pool3d_backward(
             grad_output,
             kernel_size,
             stride,
@@ -5425,7 +5423,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn avg_pool3d_backward_grad_input(
+    pub fn f_avg_pool3d_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -5436,7 +5434,7 @@ impl Tensor {
         count_include_pad: bool,
         divisor_override: impl Into<Option<i64>>,
     ) -> Tensor {
-        self.f_avg_pool3d_backward_grad_input(
+        self.avg_pool3d_backward_grad_input(
             grad_input,
             grad_output,
             kernel_size,
@@ -5449,7 +5447,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn avg_pool3d_out(
+    pub fn f_avg_pool3d_out(
         &self,
         out: &Tensor,
         kernel_size: impl IntList,
@@ -5459,7 +5457,7 @@ impl Tensor {
         count_include_pad: bool,
         divisor_override: impl Into<Option<i64>>,
     ) -> Tensor {
-        self.f_avg_pool3d_out(
+        self.avg_pool3d_out(
             out,
             kernel_size,
             stride,
@@ -5471,49 +5469,49 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn baddbmm<S: Into<Scalar>>(
+    pub fn f_baddbmm<S: Into<Scalar>>(
         &self,
         batch1: &Tensor,
         batch2: &Tensor,
         beta: S,
         alpha: S,
     ) -> Tensor {
-        self.f_baddbmm(batch1, batch2, beta, alpha).unwrap()
+        self.baddbmm(batch1, batch2, beta, alpha).unwrap()
     }
 
-    pub fn baddbmm_(&mut self, batch1: &Tensor, batch2: &Tensor) -> Tensor {
-        self.f_baddbmm_(batch1, batch2).unwrap()
+    pub fn f_baddbmm_(&mut self, batch1: &Tensor, batch2: &Tensor) -> Tensor {
+        self.baddbmm_(batch1, batch2).unwrap()
     }
 
-    pub fn baddbmm_out(&self, out: &Tensor, batch1: &Tensor, batch2: &Tensor) -> Tensor {
-        self.f_baddbmm_out(out, batch1, batch2).unwrap()
+    pub fn f_baddbmm_out(&self, out: &Tensor, batch1: &Tensor, batch2: &Tensor) -> Tensor {
+        self.baddbmm_out(out, batch1, batch2).unwrap()
     }
 
-    pub fn bartlett_window(window_length: i64, options: (Kind, Device)) -> Tensor {
-        Tensor::f_bartlett_window(window_length, options).unwrap()
+    pub fn f_bartlett_window(window_length: i64, options: (Kind, Device)) -> Tensor {
+        Tensor::bartlett_window(window_length, options).unwrap()
     }
 
-    pub fn bartlett_window_out(out: &Tensor, window_length: i64) -> Tensor {
-        Tensor::f_bartlett_window_out(out, window_length).unwrap()
+    pub fn f_bartlett_window_out(out: &Tensor, window_length: i64) -> Tensor {
+        Tensor::bartlett_window_out(out, window_length).unwrap()
     }
 
-    pub fn bartlett_window_periodic(
+    pub fn f_bartlett_window_periodic(
         window_length: i64,
         periodic: bool,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_bartlett_window_periodic(window_length, periodic, options).unwrap()
+        Tensor::bartlett_window_periodic(window_length, periodic, options).unwrap()
     }
 
-    pub fn bartlett_window_periodic_out(
+    pub fn f_bartlett_window_periodic_out(
         out: &Tensor,
         window_length: i64,
         periodic: bool,
     ) -> Tensor {
-        Tensor::f_bartlett_window_periodic_out(out, window_length, periodic).unwrap()
+        Tensor::bartlett_window_periodic_out(out, window_length, periodic).unwrap()
     }
 
-    pub fn batch_norm<T: Borrow<Tensor>>(
+    pub fn f_batch_norm<T: Borrow<Tensor>>(
         &self,
         weight: Option<T>,
         bias: Option<T>,
@@ -5524,7 +5522,7 @@ impl Tensor {
         eps: f64,
         cudnn_enabled: bool,
     ) -> Tensor {
-        self.f_batch_norm(
+        self.batch_norm(
             weight,
             bias,
             running_mean,
@@ -5537,7 +5535,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn batch_norm_backward_elemt<T: Borrow<Tensor>>(
+    pub fn f_batch_norm_backward_elemt<T: Borrow<Tensor>>(
         &self,
         grad_out: &Tensor,
         mean: &Tensor,
@@ -5547,19 +5545,11 @@ impl Tensor {
         mean_dy_xmu: &Tensor,
         count: &Tensor,
     ) -> Tensor {
-        self.f_batch_norm_backward_elemt(
-            grad_out,
-            mean,
-            invstd,
-            weight,
-            mean_dy,
-            mean_dy_xmu,
-            count,
-        )
-        .unwrap()
+        self.batch_norm_backward_elemt(grad_out, mean, invstd, weight, mean_dy, mean_dy_xmu, count)
+            .unwrap()
     }
 
-    pub fn batch_norm_backward_elemt_out<T: Borrow<Tensor>>(
+    pub fn f_batch_norm_backward_elemt_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         grad_out: &Tensor,
@@ -5570,7 +5560,7 @@ impl Tensor {
         mean_dy_xmu: &Tensor,
         count: &Tensor,
     ) -> Tensor {
-        self.f_batch_norm_backward_elemt_out(
+        self.batch_norm_backward_elemt_out(
             out,
             grad_out,
             mean,
@@ -5583,7 +5573,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn batch_norm_backward_reduce<T: Borrow<Tensor>>(
+    pub fn f_batch_norm_backward_reduce<T: Borrow<Tensor>>(
         &self,
         grad_out: &Tensor,
         mean: &Tensor,
@@ -5593,11 +5583,11 @@ impl Tensor {
         weight_g: bool,
         bias_g: bool,
     ) -> (Tensor, Tensor, Tensor, Tensor) {
-        self.f_batch_norm_backward_reduce(grad_out, mean, invstd, weight, input_g, weight_g, bias_g)
+        self.batch_norm_backward_reduce(grad_out, mean, invstd, weight, input_g, weight_g, bias_g)
             .unwrap()
     }
 
-    pub fn batch_norm_backward_reduce_out<T: Borrow<Tensor>>(
+    pub fn f_batch_norm_backward_reduce_out<T: Borrow<Tensor>>(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -5611,13 +5601,13 @@ impl Tensor {
         weight_g: bool,
         bias_g: bool,
     ) -> (Tensor, Tensor, Tensor, Tensor) {
-        self.f_batch_norm_backward_reduce_out(
+        self.batch_norm_backward_reduce_out(
             out0, out1, out2, out3, grad_out, mean, invstd, weight, input_g, weight_g, bias_g,
         )
         .unwrap()
     }
 
-    pub fn batch_norm_elemt<T: Borrow<Tensor>>(
+    pub fn f_batch_norm_elemt<T: Borrow<Tensor>>(
         &self,
         weight: Option<T>,
         bias: Option<T>,
@@ -5625,10 +5615,10 @@ impl Tensor {
         invstd: &Tensor,
         eps: f64,
     ) -> Tensor {
-        self.f_batch_norm_elemt(weight, bias, mean, invstd, eps).unwrap()
+        self.batch_norm_elemt(weight, bias, mean, invstd, eps).unwrap()
     }
 
-    pub fn batch_norm_elemt_out<T: Borrow<Tensor>>(
+    pub fn f_batch_norm_elemt_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: Option<T>,
@@ -5637,10 +5627,10 @@ impl Tensor {
         invstd: &Tensor,
         eps: f64,
     ) -> Tensor {
-        self.f_batch_norm_elemt_out(out, weight, bias, mean, invstd, eps).unwrap()
+        self.batch_norm_elemt_out(out, weight, bias, mean, invstd, eps).unwrap()
     }
 
-    pub fn batch_norm_gather_stats<T: Borrow<Tensor>>(
+    pub fn f_batch_norm_gather_stats<T: Borrow<Tensor>>(
         &self,
         mean: &Tensor,
         invstd: &Tensor,
@@ -5650,19 +5640,11 @@ impl Tensor {
         eps: f64,
         count: i64,
     ) -> (Tensor, Tensor) {
-        self.f_batch_norm_gather_stats(
-            mean,
-            invstd,
-            running_mean,
-            running_var,
-            momentum,
-            eps,
-            count,
-        )
-        .unwrap()
+        self.batch_norm_gather_stats(mean, invstd, running_mean, running_var, momentum, eps, count)
+            .unwrap()
     }
 
-    pub fn batch_norm_gather_stats_out<T: Borrow<Tensor>>(
+    pub fn f_batch_norm_gather_stats_out<T: Borrow<Tensor>>(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -5674,7 +5656,7 @@ impl Tensor {
         eps: f64,
         count: i64,
     ) -> (Tensor, Tensor) {
-        self.f_batch_norm_gather_stats_out(
+        self.batch_norm_gather_stats_out(
             out0,
             out1,
             mean,
@@ -5688,7 +5670,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn batch_norm_gather_stats_with_counts<T: Borrow<Tensor>>(
+    pub fn f_batch_norm_gather_stats_with_counts<T: Borrow<Tensor>>(
         &self,
         mean: &Tensor,
         invstd: &Tensor,
@@ -5698,7 +5680,7 @@ impl Tensor {
         eps: f64,
         counts: &Tensor,
     ) -> (Tensor, Tensor) {
-        self.f_batch_norm_gather_stats_with_counts(
+        self.batch_norm_gather_stats_with_counts(
             mean,
             invstd,
             running_mean,
@@ -5710,7 +5692,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn batch_norm_gather_stats_with_counts_out<T: Borrow<Tensor>>(
+    pub fn f_batch_norm_gather_stats_with_counts_out<T: Borrow<Tensor>>(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -5722,7 +5704,7 @@ impl Tensor {
         eps: f64,
         counts: &Tensor,
     ) -> (Tensor, Tensor) {
-        self.f_batch_norm_gather_stats_with_counts_out(
+        self.batch_norm_gather_stats_with_counts_out(
             out0,
             out1,
             mean,
@@ -5736,24 +5718,29 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn batch_norm_stats(&self, eps: f64) -> (Tensor, Tensor) {
-        self.f_batch_norm_stats(eps).unwrap()
+    pub fn f_batch_norm_stats(&self, eps: f64) -> (Tensor, Tensor) {
+        self.batch_norm_stats(eps).unwrap()
     }
 
-    pub fn batch_norm_stats_out(&self, out0: &Tensor, out1: &Tensor, eps: f64) -> (Tensor, Tensor) {
-        self.f_batch_norm_stats_out(out0, out1, eps).unwrap()
+    pub fn f_batch_norm_stats_out(
+        &self,
+        out0: &Tensor,
+        out1: &Tensor,
+        eps: f64,
+    ) -> (Tensor, Tensor) {
+        self.batch_norm_stats_out(out0, out1, eps).unwrap()
     }
 
-    pub fn batch_norm_update_stats<T: Borrow<Tensor>>(
+    pub fn f_batch_norm_update_stats<T: Borrow<Tensor>>(
         &self,
         running_mean: Option<T>,
         running_var: Option<T>,
         momentum: f64,
     ) -> (Tensor, Tensor) {
-        self.f_batch_norm_update_stats(running_mean, running_var, momentum).unwrap()
+        self.batch_norm_update_stats(running_mean, running_var, momentum).unwrap()
     }
 
-    pub fn batch_norm_update_stats_out<T: Borrow<Tensor>>(
+    pub fn f_batch_norm_update_stats_out<T: Borrow<Tensor>>(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -5761,58 +5748,58 @@ impl Tensor {
         running_var: Option<T>,
         momentum: f64,
     ) -> (Tensor, Tensor) {
-        self.f_batch_norm_update_stats_out(out0, out1, running_mean, running_var, momentum).unwrap()
+        self.batch_norm_update_stats_out(out0, out1, running_mean, running_var, momentum).unwrap()
     }
 
-    pub fn bernoulli(&self) -> Tensor {
-        self.f_bernoulli().unwrap()
+    pub fn f_bernoulli(&self) -> Tensor {
+        self.bernoulli().unwrap()
     }
 
-    pub fn bernoulli_(&mut self, p: &Tensor) -> Tensor {
-        self.f_bernoulli_(p).unwrap()
+    pub fn f_bernoulli_(&mut self, p: &Tensor) -> Tensor {
+        self.bernoulli_(p).unwrap()
     }
 
-    pub fn bernoulli_float_(&mut self, p: f64) -> Tensor {
-        self.f_bernoulli_float_(p).unwrap()
+    pub fn f_bernoulli_float_(&mut self, p: f64) -> Tensor {
+        self.bernoulli_float_(p).unwrap()
     }
 
-    pub fn bernoulli_p(&self, p: f64) -> Tensor {
-        self.f_bernoulli_p(p).unwrap()
+    pub fn f_bernoulli_p(&self, p: f64) -> Tensor {
+        self.bernoulli_p(p).unwrap()
     }
 
-    pub fn bernoulli_tensor(&self, p: &Tensor) -> Tensor {
-        self.f_bernoulli_tensor(p).unwrap()
+    pub fn f_bernoulli_tensor(&self, p: &Tensor) -> Tensor {
+        self.bernoulli_tensor(p).unwrap()
     }
 
-    pub fn bilinear<T: Borrow<Tensor>>(
+    pub fn f_bilinear<T: Borrow<Tensor>>(
         input1: &Tensor,
         input2: &Tensor,
         weight: &Tensor,
         bias: Option<T>,
     ) -> Tensor {
-        Tensor::f_bilinear(input1, input2, weight, bias).unwrap()
+        Tensor::bilinear(input1, input2, weight, bias).unwrap()
     }
 
-    pub fn binary_cross_entropy<T: Borrow<Tensor>>(
+    pub fn f_binary_cross_entropy<T: Borrow<Tensor>>(
         &self,
         target: &Tensor,
         weight: Option<T>,
         reduction: crate::Reduction,
     ) -> Tensor {
-        self.f_binary_cross_entropy(target, weight, reduction).unwrap()
+        self.binary_cross_entropy(target, weight, reduction).unwrap()
     }
 
-    pub fn binary_cross_entropy_backward<T: Borrow<Tensor>>(
+    pub fn f_binary_cross_entropy_backward<T: Borrow<Tensor>>(
         &self,
         grad_output: &Tensor,
         target: &Tensor,
         weight: Option<T>,
         reduction: crate::Reduction,
     ) -> Tensor {
-        self.f_binary_cross_entropy_backward(grad_output, target, weight, reduction).unwrap()
+        self.binary_cross_entropy_backward(grad_output, target, weight, reduction).unwrap()
     }
 
-    pub fn binary_cross_entropy_backward_grad_input<T: Borrow<Tensor>>(
+    pub fn f_binary_cross_entropy_backward_grad_input<T: Borrow<Tensor>>(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -5820,7 +5807,7 @@ impl Tensor {
         weight: Option<T>,
         reduction: crate::Reduction,
     ) -> Tensor {
-        self.f_binary_cross_entropy_backward_grad_input(
+        self.binary_cross_entropy_backward_grad_input(
             grad_input,
             grad_output,
             target,
@@ -5830,27 +5817,27 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn binary_cross_entropy_out<T: Borrow<Tensor>>(
+    pub fn f_binary_cross_entropy_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         target: &Tensor,
         weight: Option<T>,
         reduction: crate::Reduction,
     ) -> Tensor {
-        self.f_binary_cross_entropy_out(out, target, weight, reduction).unwrap()
+        self.binary_cross_entropy_out(out, target, weight, reduction).unwrap()
     }
 
-    pub fn binary_cross_entropy_with_logits<T: Borrow<Tensor>>(
+    pub fn f_binary_cross_entropy_with_logits<T: Borrow<Tensor>>(
         &self,
         target: &Tensor,
         weight: Option<T>,
         pos_weight: Option<T>,
         reduction: crate::Reduction,
     ) -> Tensor {
-        self.f_binary_cross_entropy_with_logits(target, weight, pos_weight, reduction).unwrap()
+        self.binary_cross_entropy_with_logits(target, weight, pos_weight, reduction).unwrap()
     }
 
-    pub fn binary_cross_entropy_with_logits_out<T: Borrow<Tensor>>(
+    pub fn f_binary_cross_entropy_with_logits_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         target: &Tensor,
@@ -5858,559 +5845,564 @@ impl Tensor {
         pos_weight: Option<T>,
         reduction: crate::Reduction,
     ) -> Tensor {
-        self.f_binary_cross_entropy_with_logits_out(out, target, weight, pos_weight, reduction)
+        self.binary_cross_entropy_with_logits_out(out, target, weight, pos_weight, reduction)
             .unwrap()
     }
 
-    pub fn bincount<T: Borrow<Tensor>>(&self, weights: Option<T>, minlength: i64) -> Tensor {
-        self.f_bincount(weights, minlength).unwrap()
+    pub fn f_bincount<T: Borrow<Tensor>>(&self, weights: Option<T>, minlength: i64) -> Tensor {
+        self.bincount(weights, minlength).unwrap()
     }
 
-    pub fn bincount_out<T: Borrow<Tensor>>(
+    pub fn f_bincount_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weights: Option<T>,
         minlength: i64,
     ) -> Tensor {
-        self.f_bincount_out(out, weights, minlength).unwrap()
+        self.bincount_out(out, weights, minlength).unwrap()
     }
 
-    pub fn binomial(count: &Tensor, prob: &Tensor) -> Tensor {
-        Tensor::f_binomial(count, prob).unwrap()
+    pub fn f_binomial(count: &Tensor, prob: &Tensor) -> Tensor {
+        Tensor::binomial(count, prob).unwrap()
     }
 
-    pub fn binomial_out(out: &Tensor, count: &Tensor, prob: &Tensor) -> Tensor {
-        Tensor::f_binomial_out(out, count, prob).unwrap()
+    pub fn f_binomial_out(out: &Tensor, count: &Tensor, prob: &Tensor) -> Tensor {
+        Tensor::binomial_out(out, count, prob).unwrap()
     }
 
-    pub fn bitwise_and<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_bitwise_and(other).unwrap()
+    pub fn f_bitwise_and<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.bitwise_and(other).unwrap()
     }
 
-    pub fn bitwise_and_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_bitwise_and_(other).unwrap()
+    pub fn f_bitwise_and_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.bitwise_and_(other).unwrap()
     }
 
-    pub fn bitwise_and_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
-        self.f_bitwise_and_scalar_out(out, other).unwrap()
+    pub fn f_bitwise_and_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
+        self.bitwise_and_scalar_out(out, other).unwrap()
     }
 
-    pub fn bitwise_and_scalar_tensor<S: Into<Scalar>>(self_scalar: S, other: &Tensor) -> Tensor {
-        Tensor::f_bitwise_and_scalar_tensor(self_scalar, other).unwrap()
+    pub fn f_bitwise_and_scalar_tensor<S: Into<Scalar>>(self_scalar: S, other: &Tensor) -> Tensor {
+        Tensor::bitwise_and_scalar_tensor(self_scalar, other).unwrap()
     }
 
-    pub fn bitwise_and_scalar_tensor_out<S: Into<Scalar>>(
+    pub fn f_bitwise_and_scalar_tensor_out<S: Into<Scalar>>(
         out: &Tensor,
         self_scalar: S,
         other: &Tensor,
     ) -> Tensor {
-        Tensor::f_bitwise_and_scalar_tensor_out(out, self_scalar, other).unwrap()
+        Tensor::bitwise_and_scalar_tensor_out(out, self_scalar, other).unwrap()
     }
 
-    pub fn bitwise_and_tensor(&self, other: &Tensor) -> Tensor {
-        self.f_bitwise_and_tensor(other).unwrap()
+    pub fn f_bitwise_and_tensor(&self, other: &Tensor) -> Tensor {
+        self.bitwise_and_tensor(other).unwrap()
     }
 
-    pub fn bitwise_and_tensor_(&mut self, other: &Tensor) -> Tensor {
-        self.f_bitwise_and_tensor_(other).unwrap()
+    pub fn f_bitwise_and_tensor_(&mut self, other: &Tensor) -> Tensor {
+        self.bitwise_and_tensor_(other).unwrap()
     }
 
-    pub fn bitwise_and_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_bitwise_and_tensor_out(out, other).unwrap()
+    pub fn f_bitwise_and_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.bitwise_and_tensor_out(out, other).unwrap()
     }
 
-    pub fn bitwise_left_shift(&self, other: &Tensor) -> Tensor {
-        self.f_bitwise_left_shift(other).unwrap()
+    pub fn f_bitwise_left_shift(&self, other: &Tensor) -> Tensor {
+        self.bitwise_left_shift(other).unwrap()
     }
 
-    pub fn bitwise_left_shift_(&mut self, other: &Tensor) -> Tensor {
-        self.f_bitwise_left_shift_(other).unwrap()
+    pub fn f_bitwise_left_shift_(&mut self, other: &Tensor) -> Tensor {
+        self.bitwise_left_shift_(other).unwrap()
     }
 
-    pub fn bitwise_left_shift_scalar_tensor<S: Into<Scalar>>(
+    pub fn f_bitwise_left_shift_scalar_tensor<S: Into<Scalar>>(
         self_scalar: S,
         other: &Tensor,
     ) -> Tensor {
-        Tensor::f_bitwise_left_shift_scalar_tensor(self_scalar, other).unwrap()
+        Tensor::bitwise_left_shift_scalar_tensor(self_scalar, other).unwrap()
     }
 
-    pub fn bitwise_left_shift_scalar_tensor_out<S: Into<Scalar>>(
+    pub fn f_bitwise_left_shift_scalar_tensor_out<S: Into<Scalar>>(
         out: &Tensor,
         self_scalar: S,
         other: &Tensor,
     ) -> Tensor {
-        Tensor::f_bitwise_left_shift_scalar_tensor_out(out, self_scalar, other).unwrap()
+        Tensor::bitwise_left_shift_scalar_tensor_out(out, self_scalar, other).unwrap()
     }
 
-    pub fn bitwise_left_shift_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_bitwise_left_shift_tensor_out(out, other).unwrap()
+    pub fn f_bitwise_left_shift_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.bitwise_left_shift_tensor_out(out, other).unwrap()
     }
 
-    pub fn bitwise_left_shift_tensor_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_bitwise_left_shift_tensor_scalar(other).unwrap()
+    pub fn f_bitwise_left_shift_tensor_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.bitwise_left_shift_tensor_scalar(other).unwrap()
     }
 
-    pub fn bitwise_left_shift_tensor_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_bitwise_left_shift_tensor_scalar_(other).unwrap()
+    pub fn f_bitwise_left_shift_tensor_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.bitwise_left_shift_tensor_scalar_(other).unwrap()
     }
 
-    pub fn bitwise_left_shift_tensor_scalar_out<S: Into<Scalar>>(
+    pub fn f_bitwise_left_shift_tensor_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
     ) -> Tensor {
-        self.f_bitwise_left_shift_tensor_scalar_out(out, other).unwrap()
+        self.bitwise_left_shift_tensor_scalar_out(out, other).unwrap()
     }
 
-    pub fn bitwise_not(&self) -> Tensor {
-        self.f_bitwise_not().unwrap()
+    pub fn f_bitwise_not(&self) -> Tensor {
+        self.bitwise_not().unwrap()
     }
 
-    pub fn bitwise_not_(&mut self) -> Tensor {
-        self.f_bitwise_not_().unwrap()
+    pub fn f_bitwise_not_(&mut self) -> Tensor {
+        self.bitwise_not_().unwrap()
     }
 
-    pub fn bitwise_not_out(&self, out: &Tensor) -> Tensor {
-        self.f_bitwise_not_out(out).unwrap()
+    pub fn f_bitwise_not_out(&self, out: &Tensor) -> Tensor {
+        self.bitwise_not_out(out).unwrap()
     }
 
-    pub fn bitwise_or<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_bitwise_or(other).unwrap()
+    pub fn f_bitwise_or<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.bitwise_or(other).unwrap()
     }
 
-    pub fn bitwise_or_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_bitwise_or_(other).unwrap()
+    pub fn f_bitwise_or_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.bitwise_or_(other).unwrap()
     }
 
-    pub fn bitwise_or_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
-        self.f_bitwise_or_scalar_out(out, other).unwrap()
+    pub fn f_bitwise_or_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
+        self.bitwise_or_scalar_out(out, other).unwrap()
     }
 
-    pub fn bitwise_or_scalar_tensor<S: Into<Scalar>>(self_scalar: S, other: &Tensor) -> Tensor {
-        Tensor::f_bitwise_or_scalar_tensor(self_scalar, other).unwrap()
+    pub fn f_bitwise_or_scalar_tensor<S: Into<Scalar>>(self_scalar: S, other: &Tensor) -> Tensor {
+        Tensor::bitwise_or_scalar_tensor(self_scalar, other).unwrap()
     }
 
-    pub fn bitwise_or_scalar_tensor_out<S: Into<Scalar>>(
+    pub fn f_bitwise_or_scalar_tensor_out<S: Into<Scalar>>(
         out: &Tensor,
         self_scalar: S,
         other: &Tensor,
     ) -> Tensor {
-        Tensor::f_bitwise_or_scalar_tensor_out(out, self_scalar, other).unwrap()
+        Tensor::bitwise_or_scalar_tensor_out(out, self_scalar, other).unwrap()
     }
 
-    pub fn bitwise_or_tensor(&self, other: &Tensor) -> Tensor {
-        self.f_bitwise_or_tensor(other).unwrap()
+    pub fn f_bitwise_or_tensor(&self, other: &Tensor) -> Tensor {
+        self.bitwise_or_tensor(other).unwrap()
     }
 
-    pub fn bitwise_or_tensor_(&mut self, other: &Tensor) -> Tensor {
-        self.f_bitwise_or_tensor_(other).unwrap()
+    pub fn f_bitwise_or_tensor_(&mut self, other: &Tensor) -> Tensor {
+        self.bitwise_or_tensor_(other).unwrap()
     }
 
-    pub fn bitwise_or_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_bitwise_or_tensor_out(out, other).unwrap()
+    pub fn f_bitwise_or_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.bitwise_or_tensor_out(out, other).unwrap()
     }
 
-    pub fn bitwise_right_shift(&self, other: &Tensor) -> Tensor {
-        self.f_bitwise_right_shift(other).unwrap()
+    pub fn f_bitwise_right_shift(&self, other: &Tensor) -> Tensor {
+        self.bitwise_right_shift(other).unwrap()
     }
 
-    pub fn bitwise_right_shift_(&mut self, other: &Tensor) -> Tensor {
-        self.f_bitwise_right_shift_(other).unwrap()
+    pub fn f_bitwise_right_shift_(&mut self, other: &Tensor) -> Tensor {
+        self.bitwise_right_shift_(other).unwrap()
     }
 
-    pub fn bitwise_right_shift_scalar_tensor<S: Into<Scalar>>(
+    pub fn f_bitwise_right_shift_scalar_tensor<S: Into<Scalar>>(
         self_scalar: S,
         other: &Tensor,
     ) -> Tensor {
-        Tensor::f_bitwise_right_shift_scalar_tensor(self_scalar, other).unwrap()
+        Tensor::bitwise_right_shift_scalar_tensor(self_scalar, other).unwrap()
     }
 
-    pub fn bitwise_right_shift_scalar_tensor_out<S: Into<Scalar>>(
+    pub fn f_bitwise_right_shift_scalar_tensor_out<S: Into<Scalar>>(
         out: &Tensor,
         self_scalar: S,
         other: &Tensor,
     ) -> Tensor {
-        Tensor::f_bitwise_right_shift_scalar_tensor_out(out, self_scalar, other).unwrap()
+        Tensor::bitwise_right_shift_scalar_tensor_out(out, self_scalar, other).unwrap()
     }
 
-    pub fn bitwise_right_shift_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_bitwise_right_shift_tensor_out(out, other).unwrap()
+    pub fn f_bitwise_right_shift_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.bitwise_right_shift_tensor_out(out, other).unwrap()
     }
 
-    pub fn bitwise_right_shift_tensor_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_bitwise_right_shift_tensor_scalar(other).unwrap()
+    pub fn f_bitwise_right_shift_tensor_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.bitwise_right_shift_tensor_scalar(other).unwrap()
     }
 
-    pub fn bitwise_right_shift_tensor_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_bitwise_right_shift_tensor_scalar_(other).unwrap()
+    pub fn f_bitwise_right_shift_tensor_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.bitwise_right_shift_tensor_scalar_(other).unwrap()
     }
 
-    pub fn bitwise_right_shift_tensor_scalar_out<S: Into<Scalar>>(
+    pub fn f_bitwise_right_shift_tensor_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
     ) -> Tensor {
-        self.f_bitwise_right_shift_tensor_scalar_out(out, other).unwrap()
+        self.bitwise_right_shift_tensor_scalar_out(out, other).unwrap()
     }
 
-    pub fn bitwise_xor<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_bitwise_xor(other).unwrap()
+    pub fn f_bitwise_xor<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.bitwise_xor(other).unwrap()
     }
 
-    pub fn bitwise_xor_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_bitwise_xor_(other).unwrap()
+    pub fn f_bitwise_xor_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.bitwise_xor_(other).unwrap()
     }
 
-    pub fn bitwise_xor_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
-        self.f_bitwise_xor_scalar_out(out, other).unwrap()
+    pub fn f_bitwise_xor_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
+        self.bitwise_xor_scalar_out(out, other).unwrap()
     }
 
-    pub fn bitwise_xor_scalar_tensor<S: Into<Scalar>>(self_scalar: S, other: &Tensor) -> Tensor {
-        Tensor::f_bitwise_xor_scalar_tensor(self_scalar, other).unwrap()
+    pub fn f_bitwise_xor_scalar_tensor<S: Into<Scalar>>(self_scalar: S, other: &Tensor) -> Tensor {
+        Tensor::bitwise_xor_scalar_tensor(self_scalar, other).unwrap()
     }
 
-    pub fn bitwise_xor_scalar_tensor_out<S: Into<Scalar>>(
+    pub fn f_bitwise_xor_scalar_tensor_out<S: Into<Scalar>>(
         out: &Tensor,
         self_scalar: S,
         other: &Tensor,
     ) -> Tensor {
-        Tensor::f_bitwise_xor_scalar_tensor_out(out, self_scalar, other).unwrap()
+        Tensor::bitwise_xor_scalar_tensor_out(out, self_scalar, other).unwrap()
     }
 
-    pub fn bitwise_xor_tensor(&self, other: &Tensor) -> Tensor {
-        self.f_bitwise_xor_tensor(other).unwrap()
+    pub fn f_bitwise_xor_tensor(&self, other: &Tensor) -> Tensor {
+        self.bitwise_xor_tensor(other).unwrap()
     }
 
-    pub fn bitwise_xor_tensor_(&mut self, other: &Tensor) -> Tensor {
-        self.f_bitwise_xor_tensor_(other).unwrap()
+    pub fn f_bitwise_xor_tensor_(&mut self, other: &Tensor) -> Tensor {
+        self.bitwise_xor_tensor_(other).unwrap()
     }
 
-    pub fn bitwise_xor_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_bitwise_xor_tensor_out(out, other).unwrap()
+    pub fn f_bitwise_xor_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.bitwise_xor_tensor_out(out, other).unwrap()
     }
 
-    pub fn blackman_window(window_length: i64, options: (Kind, Device)) -> Tensor {
-        Tensor::f_blackman_window(window_length, options).unwrap()
+    pub fn f_blackman_window(window_length: i64, options: (Kind, Device)) -> Tensor {
+        Tensor::blackman_window(window_length, options).unwrap()
     }
 
-    pub fn blackman_window_out(out: &Tensor, window_length: i64) -> Tensor {
-        Tensor::f_blackman_window_out(out, window_length).unwrap()
+    pub fn f_blackman_window_out(out: &Tensor, window_length: i64) -> Tensor {
+        Tensor::blackman_window_out(out, window_length).unwrap()
     }
 
-    pub fn blackman_window_periodic(
+    pub fn f_blackman_window_periodic(
         window_length: i64,
         periodic: bool,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_blackman_window_periodic(window_length, periodic, options).unwrap()
+        Tensor::blackman_window_periodic(window_length, periodic, options).unwrap()
     }
 
-    pub fn blackman_window_periodic_out(
+    pub fn f_blackman_window_periodic_out(
         out: &Tensor,
         window_length: i64,
         periodic: bool,
     ) -> Tensor {
-        Tensor::f_blackman_window_periodic_out(out, window_length, periodic).unwrap()
+        Tensor::blackman_window_periodic_out(out, window_length, periodic).unwrap()
     }
 
-    pub fn block_diag<T: Borrow<Tensor>>(tensors: &[T]) -> Tensor {
-        Tensor::f_block_diag(tensors).unwrap()
+    pub fn f_block_diag<T: Borrow<Tensor>>(tensors: &[T]) -> Tensor {
+        Tensor::block_diag(tensors).unwrap()
     }
 
-    pub fn block_diag_out<T: Borrow<Tensor>>(out: &Tensor, tensors: &[T]) -> Tensor {
-        Tensor::f_block_diag_out(out, tensors).unwrap()
+    pub fn f_block_diag_out<T: Borrow<Tensor>>(out: &Tensor, tensors: &[T]) -> Tensor {
+        Tensor::block_diag_out(out, tensors).unwrap()
     }
 
-    pub fn bmm(&self, mat2: &Tensor) -> Tensor {
-        self.f_bmm(mat2).unwrap()
+    pub fn f_bmm(&self, mat2: &Tensor) -> Tensor {
+        self.bmm(mat2).unwrap()
     }
 
-    pub fn bmm_out(&self, out: &Tensor, mat2: &Tensor) -> Tensor {
-        self.f_bmm_out(out, mat2).unwrap()
+    pub fn f_bmm_out(&self, out: &Tensor, mat2: &Tensor) -> Tensor {
+        self.bmm_out(out, mat2).unwrap()
     }
 
-    pub fn broadcast_tensors<T: Borrow<Tensor>>(tensors: &[T]) -> Vec<Tensor> {
-        Tensor::f_broadcast_tensors(tensors).unwrap()
+    pub fn f_broadcast_tensors<T: Borrow<Tensor>>(tensors: &[T]) -> Vec<Tensor> {
+        Tensor::broadcast_tensors(tensors).unwrap()
     }
 
-    pub fn broadcast_to(&self, size: impl IntList) -> Tensor {
-        self.f_broadcast_to(size).unwrap()
+    pub fn f_broadcast_to(&self, size: impl IntList) -> Tensor {
+        self.broadcast_to(size).unwrap()
     }
 
-    pub fn bucketize(&self, boundaries: &Tensor, out_int32: bool, right: bool) -> Tensor {
-        self.f_bucketize(boundaries, out_int32, right).unwrap()
+    pub fn f_bucketize(&self, boundaries: &Tensor, out_int32: bool, right: bool) -> Tensor {
+        self.bucketize(boundaries, out_int32, right).unwrap()
     }
 
-    pub fn bucketize_scalar<S: Into<Scalar>>(
+    pub fn f_bucketize_scalar<S: Into<Scalar>>(
         self_scalar: S,
         boundaries: &Tensor,
         out_int32: bool,
         right: bool,
     ) -> Tensor {
-        Tensor::f_bucketize_scalar(self_scalar, boundaries, out_int32, right).unwrap()
+        Tensor::bucketize_scalar(self_scalar, boundaries, out_int32, right).unwrap()
     }
 
-    pub fn bucketize_scalar_out<S: Into<Scalar>>(
+    pub fn f_bucketize_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         self_scalar: S,
         boundaries: &Tensor,
         out_int32: bool,
         right: bool,
     ) -> Tensor {
-        Tensor::f_bucketize_scalar_out(out, self_scalar, boundaries, out_int32, right).unwrap()
+        Tensor::bucketize_scalar_out(out, self_scalar, boundaries, out_int32, right).unwrap()
     }
 
-    pub fn bucketize_tensor_out(
+    pub fn f_bucketize_tensor_out(
         &self,
         out: &Tensor,
         boundaries: &Tensor,
         out_int32: bool,
         right: bool,
     ) -> Tensor {
-        self.f_bucketize_tensor_out(out, boundaries, out_int32, right).unwrap()
+        self.bucketize_tensor_out(out, boundaries, out_int32, right).unwrap()
     }
 
-    pub fn can_cast(from: Kind, to: Kind) -> bool {
-        Tensor::f_can_cast(from, to).unwrap()
+    pub fn f_can_cast(from: Kind, to: Kind) -> bool {
+        Tensor::can_cast(from, to).unwrap()
     }
 
-    pub fn cartesian_prod<T: Borrow<Tensor>>(tensors: &[T]) -> Tensor {
-        Tensor::f_cartesian_prod(tensors).unwrap()
+    pub fn f_cartesian_prod<T: Borrow<Tensor>>(tensors: &[T]) -> Tensor {
+        Tensor::cartesian_prod(tensors).unwrap()
     }
 
-    pub fn cat<T: Borrow<Tensor>>(tensors: &[T], dim: i64) -> Tensor {
-        Tensor::f_cat(tensors, dim).unwrap()
+    pub fn f_cat<T: Borrow<Tensor>>(tensors: &[T], dim: i64) -> Tensor {
+        Tensor::cat(tensors, dim).unwrap()
     }
 
-    pub fn cat_out<T: Borrow<Tensor>>(out: &Tensor, tensors: &[T], dim: i64) -> Tensor {
-        Tensor::f_cat_out(out, tensors, dim).unwrap()
+    pub fn f_cat_out<T: Borrow<Tensor>>(out: &Tensor, tensors: &[T], dim: i64) -> Tensor {
+        Tensor::cat_out(out, tensors, dim).unwrap()
     }
 
-    pub fn cauchy(&self, median: f64, sigma: f64) -> Tensor {
-        self.f_cauchy(median, sigma).unwrap()
+    pub fn f_cauchy(&self, median: f64, sigma: f64) -> Tensor {
+        self.cauchy(median, sigma).unwrap()
     }
 
-    pub fn cauchy_(&mut self, median: f64, sigma: f64) -> Tensor {
-        self.f_cauchy_(median, sigma).unwrap()
+    pub fn f_cauchy_(&mut self, median: f64, sigma: f64) -> Tensor {
+        self.cauchy_(median, sigma).unwrap()
     }
 
-    pub fn cauchy_out(&self, out: &Tensor, median: f64, sigma: f64) -> Tensor {
-        self.f_cauchy_out(out, median, sigma).unwrap()
+    pub fn f_cauchy_out(&self, out: &Tensor, median: f64, sigma: f64) -> Tensor {
+        self.cauchy_out(out, median, sigma).unwrap()
     }
 
-    pub fn ccol_indices(&self) -> Tensor {
-        self.f_ccol_indices().unwrap()
+    pub fn f_ccol_indices(&self) -> Tensor {
+        self.ccol_indices().unwrap()
     }
 
-    pub fn ccol_indices_copy(&self) -> Tensor {
-        self.f_ccol_indices_copy().unwrap()
+    pub fn f_ccol_indices_copy(&self) -> Tensor {
+        self.ccol_indices_copy().unwrap()
     }
 
-    pub fn ccol_indices_copy_out(&self, out: &Tensor) -> Tensor {
-        self.f_ccol_indices_copy_out(out).unwrap()
+    pub fn f_ccol_indices_copy_out(&self, out: &Tensor) -> Tensor {
+        self.ccol_indices_copy_out(out).unwrap()
     }
 
-    pub fn cdist(x1: &Tensor, x2: &Tensor, p: f64, compute_mode: impl Into<Option<i64>>) -> Tensor {
-        Tensor::f_cdist(x1, x2, p, compute_mode).unwrap()
+    pub fn f_cdist(
+        x1: &Tensor,
+        x2: &Tensor,
+        p: f64,
+        compute_mode: impl Into<Option<i64>>,
+    ) -> Tensor {
+        Tensor::cdist(x1, x2, p, compute_mode).unwrap()
     }
 
-    pub fn ceil(&self) -> Tensor {
-        self.f_ceil().unwrap()
+    pub fn f_ceil(&self) -> Tensor {
+        self.ceil().unwrap()
     }
 
-    pub fn ceil_(&mut self) -> Tensor {
-        self.f_ceil_().unwrap()
+    pub fn f_ceil_(&mut self) -> Tensor {
+        self.ceil_().unwrap()
     }
 
-    pub fn ceil_out(&self, out: &Tensor) -> Tensor {
-        self.f_ceil_out(out).unwrap()
+    pub fn f_ceil_out(&self, out: &Tensor) -> Tensor {
+        self.ceil_out(out).unwrap()
     }
 
-    pub fn celu(&self) -> Tensor {
-        self.f_celu().unwrap()
+    pub fn f_celu(&self) -> Tensor {
+        self.celu().unwrap()
     }
 
-    pub fn celu_(&mut self) -> Tensor {
-        self.f_celu_().unwrap()
+    pub fn f_celu_(&mut self) -> Tensor {
+        self.celu_().unwrap()
     }
 
-    pub fn celu_out(&self, out: &Tensor) -> Tensor {
-        self.f_celu_out(out).unwrap()
+    pub fn f_celu_out(&self, out: &Tensor) -> Tensor {
+        self.celu_out(out).unwrap()
     }
 
-    pub fn chain_matmul<T: Borrow<Tensor>>(matrices: &[T]) -> Tensor {
-        Tensor::f_chain_matmul(matrices).unwrap()
+    pub fn f_chain_matmul<T: Borrow<Tensor>>(matrices: &[T]) -> Tensor {
+        Tensor::chain_matmul(matrices).unwrap()
     }
 
-    pub fn chain_matmul_out<T: Borrow<Tensor>>(out: &Tensor, matrices: &[T]) -> Tensor {
-        Tensor::f_chain_matmul_out(out, matrices).unwrap()
+    pub fn f_chain_matmul_out<T: Borrow<Tensor>>(out: &Tensor, matrices: &[T]) -> Tensor {
+        Tensor::chain_matmul_out(out, matrices).unwrap()
     }
 
-    pub fn chalf(&self) -> Tensor {
-        self.f_chalf().unwrap()
+    pub fn f_chalf(&self) -> Tensor {
+        self.chalf().unwrap()
     }
 
-    pub fn channel_shuffle(&self, groups: i64) -> Tensor {
-        self.f_channel_shuffle(groups).unwrap()
+    pub fn f_channel_shuffle(&self, groups: i64) -> Tensor {
+        self.channel_shuffle(groups).unwrap()
     }
 
-    pub fn channel_shuffle_out(&self, out: &Tensor, groups: i64) -> Tensor {
-        self.f_channel_shuffle_out(out, groups).unwrap()
+    pub fn f_channel_shuffle_out(&self, out: &Tensor, groups: i64) -> Tensor {
+        self.channel_shuffle_out(out, groups).unwrap()
     }
 
-    pub fn cholesky(&self, upper: bool) -> Tensor {
-        self.f_cholesky(upper).unwrap()
+    pub fn f_cholesky(&self, upper: bool) -> Tensor {
+        self.cholesky(upper).unwrap()
     }
 
-    pub fn cholesky_inverse(&self, upper: bool) -> Tensor {
-        self.f_cholesky_inverse(upper).unwrap()
+    pub fn f_cholesky_inverse(&self, upper: bool) -> Tensor {
+        self.cholesky_inverse(upper).unwrap()
     }
 
-    pub fn cholesky_inverse_out(&self, out: &Tensor, upper: bool) -> Tensor {
-        self.f_cholesky_inverse_out(out, upper).unwrap()
+    pub fn f_cholesky_inverse_out(&self, out: &Tensor, upper: bool) -> Tensor {
+        self.cholesky_inverse_out(out, upper).unwrap()
     }
 
-    pub fn cholesky_out(&self, out: &Tensor, upper: bool) -> Tensor {
-        self.f_cholesky_out(out, upper).unwrap()
+    pub fn f_cholesky_out(&self, out: &Tensor, upper: bool) -> Tensor {
+        self.cholesky_out(out, upper).unwrap()
     }
 
-    pub fn cholesky_solve(&self, input2: &Tensor, upper: bool) -> Tensor {
-        self.f_cholesky_solve(input2, upper).unwrap()
+    pub fn f_cholesky_solve(&self, input2: &Tensor, upper: bool) -> Tensor {
+        self.cholesky_solve(input2, upper).unwrap()
     }
 
-    pub fn cholesky_solve_out(&self, out: &Tensor, input2: &Tensor, upper: bool) -> Tensor {
-        self.f_cholesky_solve_out(out, input2, upper).unwrap()
+    pub fn f_cholesky_solve_out(&self, out: &Tensor, input2: &Tensor, upper: bool) -> Tensor {
+        self.cholesky_solve_out(out, input2, upper).unwrap()
     }
 
-    pub fn choose_qparams_optimized(
+    pub fn f_choose_qparams_optimized(
         &self,
         numel: i64,
         n_bins: i64,
         ratio: f64,
         bit_width: i64,
     ) -> (Tensor, Tensor) {
-        self.f_choose_qparams_optimized(numel, n_bins, ratio, bit_width).unwrap()
+        self.choose_qparams_optimized(numel, n_bins, ratio, bit_width).unwrap()
     }
 
-    pub fn chunk(&self, chunks: i64, dim: i64) -> Vec<Tensor> {
-        self.f_chunk(chunks, dim).unwrap()
+    pub fn f_chunk(&self, chunks: i64, dim: i64) -> Vec<Tensor> {
+        self.chunk(chunks, dim).unwrap()
     }
 
-    pub fn clamp<S: Into<Scalar>>(&self, min: S, max: S) -> Tensor {
-        self.f_clamp(min, max).unwrap()
+    pub fn f_clamp<S: Into<Scalar>>(&self, min: S, max: S) -> Tensor {
+        self.clamp(min, max).unwrap()
     }
 
-    pub fn clamp_<S: Into<Scalar>>(&mut self, min: S, max: S) -> Tensor {
-        self.f_clamp_(min, max).unwrap()
+    pub fn f_clamp_<S: Into<Scalar>>(&mut self, min: S, max: S) -> Tensor {
+        self.clamp_(min, max).unwrap()
     }
 
-    pub fn clamp_max<S: Into<Scalar>>(&self, max: S) -> Tensor {
-        self.f_clamp_max(max).unwrap()
+    pub fn f_clamp_max<S: Into<Scalar>>(&self, max: S) -> Tensor {
+        self.clamp_max(max).unwrap()
     }
 
-    pub fn clamp_max_<S: Into<Scalar>>(&mut self, max: S) -> Tensor {
-        self.f_clamp_max_(max).unwrap()
+    pub fn f_clamp_max_<S: Into<Scalar>>(&mut self, max: S) -> Tensor {
+        self.clamp_max_(max).unwrap()
     }
 
-    pub fn clamp_max_out<S: Into<Scalar>>(&self, out: &Tensor, max: S) -> Tensor {
-        self.f_clamp_max_out(out, max).unwrap()
+    pub fn f_clamp_max_out<S: Into<Scalar>>(&self, out: &Tensor, max: S) -> Tensor {
+        self.clamp_max_out(out, max).unwrap()
     }
 
-    pub fn clamp_max_tensor(&self, max: &Tensor) -> Tensor {
-        self.f_clamp_max_tensor(max).unwrap()
+    pub fn f_clamp_max_tensor(&self, max: &Tensor) -> Tensor {
+        self.clamp_max_tensor(max).unwrap()
     }
 
-    pub fn clamp_max_tensor_(&mut self, max: &Tensor) -> Tensor {
-        self.f_clamp_max_tensor_(max).unwrap()
+    pub fn f_clamp_max_tensor_(&mut self, max: &Tensor) -> Tensor {
+        self.clamp_max_tensor_(max).unwrap()
     }
 
-    pub fn clamp_max_tensor_out(&self, out: &Tensor, max: &Tensor) -> Tensor {
-        self.f_clamp_max_tensor_out(out, max).unwrap()
+    pub fn f_clamp_max_tensor_out(&self, out: &Tensor, max: &Tensor) -> Tensor {
+        self.clamp_max_tensor_out(out, max).unwrap()
     }
 
-    pub fn clamp_min<S: Into<Scalar>>(&self, min: S) -> Tensor {
-        self.f_clamp_min(min).unwrap()
+    pub fn f_clamp_min<S: Into<Scalar>>(&self, min: S) -> Tensor {
+        self.clamp_min(min).unwrap()
     }
 
-    pub fn clamp_min_<S: Into<Scalar>>(&mut self, min: S) -> Tensor {
-        self.f_clamp_min_(min).unwrap()
+    pub fn f_clamp_min_<S: Into<Scalar>>(&mut self, min: S) -> Tensor {
+        self.clamp_min_(min).unwrap()
     }
 
-    pub fn clamp_min_out<S: Into<Scalar>>(&self, out: &Tensor, min: S) -> Tensor {
-        self.f_clamp_min_out(out, min).unwrap()
+    pub fn f_clamp_min_out<S: Into<Scalar>>(&self, out: &Tensor, min: S) -> Tensor {
+        self.clamp_min_out(out, min).unwrap()
     }
 
-    pub fn clamp_min_tensor(&self, min: &Tensor) -> Tensor {
-        self.f_clamp_min_tensor(min).unwrap()
+    pub fn f_clamp_min_tensor(&self, min: &Tensor) -> Tensor {
+        self.clamp_min_tensor(min).unwrap()
     }
 
-    pub fn clamp_min_tensor_(&mut self, min: &Tensor) -> Tensor {
-        self.f_clamp_min_tensor_(min).unwrap()
+    pub fn f_clamp_min_tensor_(&mut self, min: &Tensor) -> Tensor {
+        self.clamp_min_tensor_(min).unwrap()
     }
 
-    pub fn clamp_min_tensor_out(&self, out: &Tensor, min: &Tensor) -> Tensor {
-        self.f_clamp_min_tensor_out(out, min).unwrap()
+    pub fn f_clamp_min_tensor_out(&self, out: &Tensor, min: &Tensor) -> Tensor {
+        self.clamp_min_tensor_out(out, min).unwrap()
     }
 
-    pub fn clamp_out<S: Into<Scalar>>(&self, out: &Tensor, min: S, max: S) -> Tensor {
-        self.f_clamp_out(out, min, max).unwrap()
+    pub fn f_clamp_out<S: Into<Scalar>>(&self, out: &Tensor, min: S, max: S) -> Tensor {
+        self.clamp_out(out, min, max).unwrap()
     }
 
-    pub fn clamp_tensor<T: Borrow<Tensor>>(&self, min: Option<T>, max: Option<T>) -> Tensor {
-        self.f_clamp_tensor(min, max).unwrap()
+    pub fn f_clamp_tensor<T: Borrow<Tensor>>(&self, min: Option<T>, max: Option<T>) -> Tensor {
+        self.clamp_tensor(min, max).unwrap()
     }
 
-    pub fn clamp_tensor_<T: Borrow<Tensor>>(&mut self, min: Option<T>, max: Option<T>) -> Tensor {
-        self.f_clamp_tensor_(min, max).unwrap()
+    pub fn f_clamp_tensor_<T: Borrow<Tensor>>(&mut self, min: Option<T>, max: Option<T>) -> Tensor {
+        self.clamp_tensor_(min, max).unwrap()
     }
 
-    pub fn clamp_tensor_out<T: Borrow<Tensor>>(
+    pub fn f_clamp_tensor_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         min: Option<T>,
         max: Option<T>,
     ) -> Tensor {
-        self.f_clamp_tensor_out(out, min, max).unwrap()
+        self.clamp_tensor_out(out, min, max).unwrap()
     }
 
-    pub fn clip<S: Into<Scalar>>(&self, min: S, max: S) -> Tensor {
-        self.f_clip(min, max).unwrap()
+    pub fn f_clip<S: Into<Scalar>>(&self, min: S, max: S) -> Tensor {
+        self.clip(min, max).unwrap()
     }
 
-    pub fn clip_<S: Into<Scalar>>(&mut self, min: S, max: S) -> Tensor {
-        self.f_clip_(min, max).unwrap()
+    pub fn f_clip_<S: Into<Scalar>>(&mut self, min: S, max: S) -> Tensor {
+        self.clip_(min, max).unwrap()
     }
 
-    pub fn clip_out<S: Into<Scalar>>(&self, out: &Tensor, min: S, max: S) -> Tensor {
-        self.f_clip_out(out, min, max).unwrap()
+    pub fn f_clip_out<S: Into<Scalar>>(&self, out: &Tensor, min: S, max: S) -> Tensor {
+        self.clip_out(out, min, max).unwrap()
     }
 
-    pub fn clip_tensor<T: Borrow<Tensor>>(&self, min: Option<T>, max: Option<T>) -> Tensor {
-        self.f_clip_tensor(min, max).unwrap()
+    pub fn f_clip_tensor<T: Borrow<Tensor>>(&self, min: Option<T>, max: Option<T>) -> Tensor {
+        self.clip_tensor(min, max).unwrap()
     }
 
-    pub fn clip_tensor_<T: Borrow<Tensor>>(&mut self, min: Option<T>, max: Option<T>) -> Tensor {
-        self.f_clip_tensor_(min, max).unwrap()
+    pub fn f_clip_tensor_<T: Borrow<Tensor>>(&mut self, min: Option<T>, max: Option<T>) -> Tensor {
+        self.clip_tensor_(min, max).unwrap()
     }
 
-    pub fn clip_tensor_out<T: Borrow<Tensor>>(
+    pub fn f_clip_tensor_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         min: Option<T>,
         max: Option<T>,
     ) -> Tensor {
-        self.f_clip_tensor_out(out, min, max).unwrap()
+        self.clip_tensor_out(out, min, max).unwrap()
     }
 
-    pub fn clone(&self, out: &Tensor) -> Tensor {
-        self.f_clone(out).unwrap()
+    pub fn f_clone(&self, out: &Tensor) -> Tensor {
+        self.clone(out).unwrap()
     }
 
-    pub fn coalesce(&self) -> Tensor {
-        self.f_coalesce().unwrap()
+    pub fn f_coalesce(&self) -> Tensor {
+        self.coalesce().unwrap()
     }
 
-    pub fn col2im(
+    pub fn f_col2im(
         &self,
         output_size: impl IntList,
         kernel_size: impl IntList,
@@ -6418,10 +6410,10 @@ impl Tensor {
         padding: impl IntList,
         stride: impl IntList,
     ) -> Tensor {
-        self.f_col2im(output_size, kernel_size, dilation, padding, stride).unwrap()
+        self.col2im(output_size, kernel_size, dilation, padding, stride).unwrap()
     }
 
-    pub fn col2im_out(
+    pub fn f_col2im_out(
         &self,
         out: &Tensor,
         output_size: impl IntList,
@@ -6430,86 +6422,86 @@ impl Tensor {
         padding: impl IntList,
         stride: impl IntList,
     ) -> Tensor {
-        self.f_col2im_out(out, output_size, kernel_size, dilation, padding, stride).unwrap()
+        self.col2im_out(out, output_size, kernel_size, dilation, padding, stride).unwrap()
     }
 
-    pub fn col_indices(&self) -> Tensor {
-        self.f_col_indices().unwrap()
+    pub fn f_col_indices(&self) -> Tensor {
+        self.col_indices().unwrap()
     }
 
-    pub fn col_indices_copy(&self) -> Tensor {
-        self.f_col_indices_copy().unwrap()
+    pub fn f_col_indices_copy(&self) -> Tensor {
+        self.col_indices_copy().unwrap()
     }
 
-    pub fn col_indices_copy_out(&self, out: &Tensor) -> Tensor {
-        self.f_col_indices_copy_out(out).unwrap()
+    pub fn f_col_indices_copy_out(&self, out: &Tensor) -> Tensor {
+        self.col_indices_copy_out(out).unwrap()
     }
 
-    pub fn column_stack<T: Borrow<Tensor>>(tensors: &[T]) -> Tensor {
-        Tensor::f_column_stack(tensors).unwrap()
+    pub fn f_column_stack<T: Borrow<Tensor>>(tensors: &[T]) -> Tensor {
+        Tensor::column_stack(tensors).unwrap()
     }
 
-    pub fn column_stack_out<T: Borrow<Tensor>>(out: &Tensor, tensors: &[T]) -> Tensor {
-        Tensor::f_column_stack_out(out, tensors).unwrap()
+    pub fn f_column_stack_out<T: Borrow<Tensor>>(out: &Tensor, tensors: &[T]) -> Tensor {
+        Tensor::column_stack_out(out, tensors).unwrap()
     }
 
-    pub fn combinations(&self, r: i64, with_replacement: bool) -> Tensor {
-        self.f_combinations(r, with_replacement).unwrap()
+    pub fn f_combinations(&self, r: i64, with_replacement: bool) -> Tensor {
+        self.combinations(r, with_replacement).unwrap()
     }
 
-    pub fn complex(real: &Tensor, imag: &Tensor) -> Tensor {
-        Tensor::f_complex(real, imag).unwrap()
+    pub fn f_complex(real: &Tensor, imag: &Tensor) -> Tensor {
+        Tensor::complex(real, imag).unwrap()
     }
 
-    pub fn complex_out(out: &Tensor, real: &Tensor, imag: &Tensor) -> Tensor {
-        Tensor::f_complex_out(out, real, imag).unwrap()
+    pub fn f_complex_out(out: &Tensor, real: &Tensor, imag: &Tensor) -> Tensor {
+        Tensor::complex_out(out, real, imag).unwrap()
     }
 
-    pub fn concat<T: Borrow<Tensor>>(tensors: &[T], dim: i64) -> Tensor {
-        Tensor::f_concat(tensors, dim).unwrap()
+    pub fn f_concat<T: Borrow<Tensor>>(tensors: &[T], dim: i64) -> Tensor {
+        Tensor::concat(tensors, dim).unwrap()
     }
 
-    pub fn concat_out<T: Borrow<Tensor>>(out: &Tensor, tensors: &[T], dim: i64) -> Tensor {
-        Tensor::f_concat_out(out, tensors, dim).unwrap()
+    pub fn f_concat_out<T: Borrow<Tensor>>(out: &Tensor, tensors: &[T], dim: i64) -> Tensor {
+        Tensor::concat_out(out, tensors, dim).unwrap()
     }
 
-    pub fn concatenate<T: Borrow<Tensor>>(tensors: &[T], dim: i64) -> Tensor {
-        Tensor::f_concatenate(tensors, dim).unwrap()
+    pub fn f_concatenate<T: Borrow<Tensor>>(tensors: &[T], dim: i64) -> Tensor {
+        Tensor::concatenate(tensors, dim).unwrap()
     }
 
-    pub fn concatenate_out<T: Borrow<Tensor>>(out: &Tensor, tensors: &[T], dim: i64) -> Tensor {
-        Tensor::f_concatenate_out(out, tensors, dim).unwrap()
+    pub fn f_concatenate_out<T: Borrow<Tensor>>(out: &Tensor, tensors: &[T], dim: i64) -> Tensor {
+        Tensor::concatenate_out(out, tensors, dim).unwrap()
     }
 
-    pub fn conj(&self) -> Tensor {
-        self.f_conj().unwrap()
+    pub fn f_conj(&self) -> Tensor {
+        self.conj().unwrap()
     }
 
-    pub fn conj_physical(&self) -> Tensor {
-        self.f_conj_physical().unwrap()
+    pub fn f_conj_physical(&self) -> Tensor {
+        self.conj_physical().unwrap()
     }
 
-    pub fn conj_physical_(&mut self) -> Tensor {
-        self.f_conj_physical_().unwrap()
+    pub fn f_conj_physical_(&mut self) -> Tensor {
+        self.conj_physical_().unwrap()
     }
 
-    pub fn conj_physical_out(&self, out: &Tensor) -> Tensor {
-        self.f_conj_physical_out(out).unwrap()
+    pub fn f_conj_physical_out(&self, out: &Tensor) -> Tensor {
+        self.conj_physical_out(out).unwrap()
     }
 
-    pub fn constant_pad_nd(&self, pad: impl IntList) -> Tensor {
-        self.f_constant_pad_nd(pad).unwrap()
+    pub fn f_constant_pad_nd(&self, pad: impl IntList) -> Tensor {
+        self.constant_pad_nd(pad).unwrap()
     }
 
-    pub fn constant_pad_nd_out(&self, out: &Tensor, pad: impl IntList) -> Tensor {
-        self.f_constant_pad_nd_out(out, pad).unwrap()
+    pub fn f_constant_pad_nd_out(&self, out: &Tensor, pad: impl IntList) -> Tensor {
+        self.constant_pad_nd_out(out, pad).unwrap()
     }
 
-    pub fn contiguous(&self) -> Tensor {
-        self.f_contiguous().unwrap()
+    pub fn f_contiguous(&self) -> Tensor {
+        self.contiguous().unwrap()
     }
 
-    pub fn conv1d<T: Borrow<Tensor>>(
+    pub fn f_conv1d<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -6518,10 +6510,10 @@ impl Tensor {
         dilation: impl IntList,
         groups: i64,
     ) -> Tensor {
-        self.f_conv1d(weight, bias, stride, padding, dilation, groups).unwrap()
+        self.conv1d(weight, bias, stride, padding, dilation, groups).unwrap()
     }
 
-    pub fn conv1d_padding<T: Borrow<Tensor>>(
+    pub fn f_conv1d_padding<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -6530,10 +6522,10 @@ impl Tensor {
         dilation: impl IntList,
         groups: i64,
     ) -> Tensor {
-        self.f_conv1d_padding(weight, bias, stride, padding, dilation, groups).unwrap()
+        self.conv1d_padding(weight, bias, stride, padding, dilation, groups).unwrap()
     }
 
-    pub fn conv2d<T: Borrow<Tensor>>(
+    pub fn f_conv2d<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -6542,10 +6534,10 @@ impl Tensor {
         dilation: impl IntList,
         groups: i64,
     ) -> Tensor {
-        self.f_conv2d(weight, bias, stride, padding, dilation, groups).unwrap()
+        self.conv2d(weight, bias, stride, padding, dilation, groups).unwrap()
     }
 
-    pub fn conv2d_padding<T: Borrow<Tensor>>(
+    pub fn f_conv2d_padding<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -6554,10 +6546,10 @@ impl Tensor {
         dilation: impl IntList,
         groups: i64,
     ) -> Tensor {
-        self.f_conv2d_padding(weight, bias, stride, padding, dilation, groups).unwrap()
+        self.conv2d_padding(weight, bias, stride, padding, dilation, groups).unwrap()
     }
 
-    pub fn conv3d<T: Borrow<Tensor>>(
+    pub fn f_conv3d<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -6566,10 +6558,10 @@ impl Tensor {
         dilation: impl IntList,
         groups: i64,
     ) -> Tensor {
-        self.f_conv3d(weight, bias, stride, padding, dilation, groups).unwrap()
+        self.conv3d(weight, bias, stride, padding, dilation, groups).unwrap()
     }
 
-    pub fn conv3d_padding<T: Borrow<Tensor>>(
+    pub fn f_conv3d_padding<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -6578,10 +6570,10 @@ impl Tensor {
         dilation: impl IntList,
         groups: i64,
     ) -> Tensor {
-        self.f_conv3d_padding(weight, bias, stride, padding, dilation, groups).unwrap()
+        self.conv3d_padding(weight, bias, stride, padding, dilation, groups).unwrap()
     }
 
-    pub fn conv_depthwise3d<T: Borrow<Tensor>>(
+    pub fn f_conv_depthwise3d<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         kernel_size: impl IntList,
@@ -6590,10 +6582,10 @@ impl Tensor {
         padding: impl IntList,
         dilation: impl IntList,
     ) -> Tensor {
-        self.f_conv_depthwise3d(weight, kernel_size, bias, stride, padding, dilation).unwrap()
+        self.conv_depthwise3d(weight, kernel_size, bias, stride, padding, dilation).unwrap()
     }
 
-    pub fn conv_depthwise3d_out<T: Borrow<Tensor>>(
+    pub fn f_conv_depthwise3d_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -6603,29 +6595,29 @@ impl Tensor {
         padding: impl IntList,
         dilation: impl IntList,
     ) -> Tensor {
-        self.f_conv_depthwise3d_out(out, weight, kernel_size, bias, stride, padding, dilation)
+        self.conv_depthwise3d_out(out, weight, kernel_size, bias, stride, padding, dilation)
             .unwrap()
     }
 
-    pub fn conv_tbc(&self, weight: &Tensor, bias: &Tensor, pad: i64) -> Tensor {
-        self.f_conv_tbc(weight, bias, pad).unwrap()
+    pub fn f_conv_tbc(&self, weight: &Tensor, bias: &Tensor, pad: i64) -> Tensor {
+        self.conv_tbc(weight, bias, pad).unwrap()
     }
 
-    pub fn conv_tbc_backward(
+    pub fn f_conv_tbc_backward(
         &self,
         input: &Tensor,
         weight: &Tensor,
         bias: &Tensor,
         pad: i64,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_conv_tbc_backward(input, weight, bias, pad).unwrap()
+        self.conv_tbc_backward(input, weight, bias, pad).unwrap()
     }
 
-    pub fn conv_tbc_out(&self, out: &Tensor, weight: &Tensor, bias: &Tensor, pad: i64) -> Tensor {
-        self.f_conv_tbc_out(out, weight, bias, pad).unwrap()
+    pub fn f_conv_tbc_out(&self, out: &Tensor, weight: &Tensor, bias: &Tensor, pad: i64) -> Tensor {
+        self.conv_tbc_out(out, weight, bias, pad).unwrap()
     }
 
-    pub fn conv_transpose1d<T: Borrow<Tensor>>(
+    pub fn f_conv_transpose1d<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -6635,11 +6627,11 @@ impl Tensor {
         groups: i64,
         dilation: impl IntList,
     ) -> Tensor {
-        self.f_conv_transpose1d(weight, bias, stride, padding, output_padding, groups, dilation)
+        self.conv_transpose1d(weight, bias, stride, padding, output_padding, groups, dilation)
             .unwrap()
     }
 
-    pub fn conv_transpose2d<T: Borrow<Tensor>>(
+    pub fn f_conv_transpose2d<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -6649,11 +6641,11 @@ impl Tensor {
         groups: i64,
         dilation: impl IntList,
     ) -> Tensor {
-        self.f_conv_transpose2d(weight, bias, stride, padding, output_padding, groups, dilation)
+        self.conv_transpose2d(weight, bias, stride, padding, output_padding, groups, dilation)
             .unwrap()
     }
 
-    pub fn conv_transpose3d<T: Borrow<Tensor>>(
+    pub fn f_conv_transpose3d<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -6663,11 +6655,11 @@ impl Tensor {
         groups: i64,
         dilation: impl IntList,
     ) -> Tensor {
-        self.f_conv_transpose3d(weight, bias, stride, padding, output_padding, groups, dilation)
+        self.conv_transpose3d(weight, bias, stride, padding, output_padding, groups, dilation)
             .unwrap()
     }
 
-    pub fn convolution<T: Borrow<Tensor>>(
+    pub fn f_convolution<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -6678,7 +6670,7 @@ impl Tensor {
         output_padding: impl IntList,
         groups: i64,
     ) -> Tensor {
-        self.f_convolution(
+        self.convolution(
             weight,
             bias,
             stride,
@@ -6691,7 +6683,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn convolution_out<T: Borrow<Tensor>>(
+    pub fn f_convolution_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -6703,7 +6695,7 @@ impl Tensor {
         output_padding: impl IntList,
         groups: i64,
     ) -> Tensor {
-        self.f_convolution_out(
+        self.convolution_out(
             out,
             weight,
             bias,
@@ -6717,7 +6709,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn convolution_overrideable<T: Borrow<Tensor>>(
+    pub fn f_convolution_overrideable<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -6728,7 +6720,7 @@ impl Tensor {
         output_padding: impl IntList,
         groups: i64,
     ) -> Tensor {
-        self.f_convolution_overrideable(
+        self.convolution_overrideable(
             weight,
             bias,
             stride,
@@ -6741,7 +6733,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn convolution_overrideable_out<T: Borrow<Tensor>>(
+    pub fn f_convolution_overrideable_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -6753,7 +6745,7 @@ impl Tensor {
         output_padding: impl IntList,
         groups: i64,
     ) -> Tensor {
-        self.f_convolution_overrideable_out(
+        self.convolution_overrideable_out(
             out,
             weight,
             bias,
@@ -6767,119 +6759,119 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn copy_sparse_to_sparse(&self, src: &Tensor, non_blocking: bool) -> Tensor {
-        self.f_copy_sparse_to_sparse(src, non_blocking).unwrap()
+    pub fn f_copy_sparse_to_sparse(&self, src: &Tensor, non_blocking: bool) -> Tensor {
+        self.copy_sparse_to_sparse(src, non_blocking).unwrap()
     }
 
-    pub fn copy_sparse_to_sparse_(&mut self, src: &Tensor, non_blocking: bool) -> Tensor {
-        self.f_copy_sparse_to_sparse_(src, non_blocking).unwrap()
+    pub fn f_copy_sparse_to_sparse_(&mut self, src: &Tensor, non_blocking: bool) -> Tensor {
+        self.copy_sparse_to_sparse_(src, non_blocking).unwrap()
     }
 
-    pub fn copy_sparse_to_sparse_out(
+    pub fn f_copy_sparse_to_sparse_out(
         &self,
         out: &Tensor,
         src: &Tensor,
         non_blocking: bool,
     ) -> Tensor {
-        self.f_copy_sparse_to_sparse_out(out, src, non_blocking).unwrap()
+        self.copy_sparse_to_sparse_out(out, src, non_blocking).unwrap()
     }
 
-    pub fn copysign(&self, other: &Tensor) -> Tensor {
-        self.f_copysign(other).unwrap()
+    pub fn f_copysign(&self, other: &Tensor) -> Tensor {
+        self.copysign(other).unwrap()
     }
 
-    pub fn copysign_(&mut self, other: &Tensor) -> Tensor {
-        self.f_copysign_(other).unwrap()
+    pub fn f_copysign_(&mut self, other: &Tensor) -> Tensor {
+        self.copysign_(other).unwrap()
     }
 
-    pub fn copysign_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_copysign_out(out, other).unwrap()
+    pub fn f_copysign_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.copysign_out(out, other).unwrap()
     }
 
-    pub fn copysign_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_copysign_scalar(other).unwrap()
+    pub fn f_copysign_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.copysign_scalar(other).unwrap()
     }
 
-    pub fn copysign_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_copysign_scalar_(other).unwrap()
+    pub fn f_copysign_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.copysign_scalar_(other).unwrap()
     }
 
-    pub fn copysign_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
-        self.f_copysign_scalar_out(out, other).unwrap()
+    pub fn f_copysign_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
+        self.copysign_scalar_out(out, other).unwrap()
     }
 
-    pub fn corrcoef(&self) -> Tensor {
-        self.f_corrcoef().unwrap()
+    pub fn f_corrcoef(&self) -> Tensor {
+        self.corrcoef().unwrap()
     }
 
-    pub fn cos(&self) -> Tensor {
-        self.f_cos().unwrap()
+    pub fn f_cos(&self) -> Tensor {
+        self.cos().unwrap()
     }
 
-    pub fn cos_(&mut self) -> Tensor {
-        self.f_cos_().unwrap()
+    pub fn f_cos_(&mut self) -> Tensor {
+        self.cos_().unwrap()
     }
 
-    pub fn cos_out(&self, out: &Tensor) -> Tensor {
-        self.f_cos_out(out).unwrap()
+    pub fn f_cos_out(&self, out: &Tensor) -> Tensor {
+        self.cos_out(out).unwrap()
     }
 
-    pub fn cosh(&self) -> Tensor {
-        self.f_cosh().unwrap()
+    pub fn f_cosh(&self) -> Tensor {
+        self.cosh().unwrap()
     }
 
-    pub fn cosh_(&mut self) -> Tensor {
-        self.f_cosh_().unwrap()
+    pub fn f_cosh_(&mut self) -> Tensor {
+        self.cosh_().unwrap()
     }
 
-    pub fn cosh_out(&self, out: &Tensor) -> Tensor {
-        self.f_cosh_out(out).unwrap()
+    pub fn f_cosh_out(&self, out: &Tensor) -> Tensor {
+        self.cosh_out(out).unwrap()
     }
 
-    pub fn cosine_embedding_loss(
+    pub fn f_cosine_embedding_loss(
         input1: &Tensor,
         input2: &Tensor,
         target: &Tensor,
         margin: f64,
         reduction: crate::Reduction,
     ) -> Tensor {
-        Tensor::f_cosine_embedding_loss(input1, input2, target, margin, reduction).unwrap()
+        Tensor::cosine_embedding_loss(input1, input2, target, margin, reduction).unwrap()
     }
 
-    pub fn cosine_similarity(x1: &Tensor, x2: &Tensor, dim: i64, eps: f64) -> Tensor {
-        Tensor::f_cosine_similarity(x1, x2, dim, eps).unwrap()
+    pub fn f_cosine_similarity(x1: &Tensor, x2: &Tensor, dim: i64, eps: f64) -> Tensor {
+        Tensor::cosine_similarity(x1, x2, dim, eps).unwrap()
     }
 
-    pub fn count_nonzero(&self, dim: impl Into<Option<i64>>) -> Tensor {
-        self.f_count_nonzero(dim).unwrap()
+    pub fn f_count_nonzero(&self, dim: impl Into<Option<i64>>) -> Tensor {
+        self.count_nonzero(dim).unwrap()
     }
 
-    pub fn count_nonzero_dim_intlist(&self, dim: impl IntList) -> Tensor {
-        self.f_count_nonzero_dim_intlist(dim).unwrap()
+    pub fn f_count_nonzero_dim_intlist(&self, dim: impl IntList) -> Tensor {
+        self.count_nonzero_dim_intlist(dim).unwrap()
     }
 
-    pub fn count_nonzero_dim_intlist_out(&self, out: &Tensor, dim: impl IntList) -> Tensor {
-        self.f_count_nonzero_dim_intlist_out(out, dim).unwrap()
+    pub fn f_count_nonzero_dim_intlist_out(&self, out: &Tensor, dim: impl IntList) -> Tensor {
+        self.count_nonzero_dim_intlist_out(out, dim).unwrap()
     }
 
-    pub fn count_nonzero_out(&self, out: &Tensor, dim: impl Into<Option<i64>>) -> Tensor {
-        self.f_count_nonzero_out(out, dim).unwrap()
+    pub fn f_count_nonzero_out(&self, out: &Tensor, dim: impl Into<Option<i64>>) -> Tensor {
+        self.count_nonzero_out(out, dim).unwrap()
     }
 
-    pub fn cov<T: Borrow<Tensor>>(
+    pub fn f_cov<T: Borrow<Tensor>>(
         &self,
         correction: i64,
         fweights: Option<T>,
         aweights: Option<T>,
     ) -> Tensor {
-        self.f_cov(correction, fweights, aweights).unwrap()
+        self.cov(correction, fweights, aweights).unwrap()
     }
 
-    pub fn cross(&self, other: &Tensor, dim: impl Into<Option<i64>>) -> Tensor {
-        self.f_cross(other, dim).unwrap()
+    pub fn f_cross(&self, other: &Tensor, dim: impl Into<Option<i64>>) -> Tensor {
+        self.cross(other, dim).unwrap()
     }
 
-    pub fn cross_entropy_loss<T: Borrow<Tensor>>(
+    pub fn f_cross_entropy_loss<T: Borrow<Tensor>>(
         &self,
         target: &Tensor,
         weight: Option<T>,
@@ -6887,26 +6879,26 @@ impl Tensor {
         ignore_index: i64,
         label_smoothing: f64,
     ) -> Tensor {
-        self.f_cross_entropy_loss(target, weight, reduction, ignore_index, label_smoothing).unwrap()
+        self.cross_entropy_loss(target, weight, reduction, ignore_index, label_smoothing).unwrap()
     }
 
-    pub fn cross_out(&self, out: &Tensor, other: &Tensor, dim: impl Into<Option<i64>>) -> Tensor {
-        self.f_cross_out(out, other, dim).unwrap()
+    pub fn f_cross_out(&self, out: &Tensor, other: &Tensor, dim: impl Into<Option<i64>>) -> Tensor {
+        self.cross_out(out, other, dim).unwrap()
     }
 
-    pub fn crow_indices(&self) -> Tensor {
-        self.f_crow_indices().unwrap()
+    pub fn f_crow_indices(&self) -> Tensor {
+        self.crow_indices().unwrap()
     }
 
-    pub fn crow_indices_copy(&self) -> Tensor {
-        self.f_crow_indices_copy().unwrap()
+    pub fn f_crow_indices_copy(&self) -> Tensor {
+        self.crow_indices_copy().unwrap()
     }
 
-    pub fn crow_indices_copy_out(&self, out: &Tensor) -> Tensor {
-        self.f_crow_indices_copy_out(out).unwrap()
+    pub fn f_crow_indices_copy_out(&self, out: &Tensor) -> Tensor {
+        self.crow_indices_copy_out(out).unwrap()
     }
 
-    pub fn ctc_loss(
+    pub fn f_ctc_loss(
         log_probs: &Tensor,
         targets: &Tensor,
         input_lengths: impl IntList,
@@ -6915,7 +6907,7 @@ impl Tensor {
         reduction: crate::Reduction,
         zero_infinity: bool,
     ) -> Tensor {
-        Tensor::f_ctc_loss(
+        Tensor::ctc_loss(
             log_probs,
             targets,
             input_lengths,
@@ -6927,7 +6919,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn ctc_loss_tensor(
+    pub fn f_ctc_loss_tensor(
         log_probs: &Tensor,
         targets: &Tensor,
         input_lengths: &Tensor,
@@ -6936,7 +6928,7 @@ impl Tensor {
         reduction: crate::Reduction,
         zero_infinity: bool,
     ) -> Tensor {
-        Tensor::f_ctc_loss_tensor(
+        Tensor::ctc_loss_tensor(
             log_probs,
             targets,
             input_lengths,
@@ -6948,21 +6940,21 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn cudnn_affine_grid_generator(theta: &Tensor, n: i64, c: i64, h: i64, w: i64) -> Tensor {
-        Tensor::f_cudnn_affine_grid_generator(theta, n, c, h, w).unwrap()
+    pub fn f_cudnn_affine_grid_generator(theta: &Tensor, n: i64, c: i64, h: i64, w: i64) -> Tensor {
+        Tensor::cudnn_affine_grid_generator(theta, n, c, h, w).unwrap()
     }
 
-    pub fn cudnn_affine_grid_generator_backward(
+    pub fn f_cudnn_affine_grid_generator_backward(
         grad: &Tensor,
         n: i64,
         c: i64,
         h: i64,
         w: i64,
     ) -> Tensor {
-        Tensor::f_cudnn_affine_grid_generator_backward(grad, n, c, h, w).unwrap()
+        Tensor::cudnn_affine_grid_generator_backward(grad, n, c, h, w).unwrap()
     }
 
-    pub fn cudnn_affine_grid_generator_backward_out(
+    pub fn f_cudnn_affine_grid_generator_backward_out(
         out: &Tensor,
         grad: &Tensor,
         n: i64,
@@ -6970,10 +6962,10 @@ impl Tensor {
         h: i64,
         w: i64,
     ) -> Tensor {
-        Tensor::f_cudnn_affine_grid_generator_backward_out(out, grad, n, c, h, w).unwrap()
+        Tensor::cudnn_affine_grid_generator_backward_out(out, grad, n, c, h, w).unwrap()
     }
 
-    pub fn cudnn_affine_grid_generator_out(
+    pub fn f_cudnn_affine_grid_generator_out(
         out: &Tensor,
         theta: &Tensor,
         n: i64,
@@ -6981,10 +6973,10 @@ impl Tensor {
         h: i64,
         w: i64,
     ) -> Tensor {
-        Tensor::f_cudnn_affine_grid_generator_out(out, theta, n, c, h, w).unwrap()
+        Tensor::cudnn_affine_grid_generator_out(out, theta, n, c, h, w).unwrap()
     }
 
-    pub fn cudnn_batch_norm<T: Borrow<Tensor>>(
+    pub fn f_cudnn_batch_norm<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -6994,7 +6986,7 @@ impl Tensor {
         exponential_average_factor: f64,
         epsilon: f64,
     ) -> (Tensor, Tensor, Tensor, Tensor) {
-        self.f_cudnn_batch_norm(
+        self.cudnn_batch_norm(
             weight,
             bias,
             running_mean,
@@ -7006,7 +6998,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn cudnn_batch_norm_backward<T: Borrow<Tensor>>(
+    pub fn f_cudnn_batch_norm_backward<T: Borrow<Tensor>>(
         &self,
         grad_output: &Tensor,
         weight: &Tensor,
@@ -7017,7 +7009,7 @@ impl Tensor {
         epsilon: f64,
         reservespace: &Tensor,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_cudnn_batch_norm_backward(
+        self.cudnn_batch_norm_backward(
             grad_output,
             weight,
             running_mean,
@@ -7030,7 +7022,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn cudnn_batch_norm_backward_out<T: Borrow<Tensor>>(
+    pub fn f_cudnn_batch_norm_backward_out<T: Borrow<Tensor>>(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -7044,7 +7036,7 @@ impl Tensor {
         epsilon: f64,
         reservespace: &Tensor,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_cudnn_batch_norm_backward_out(
+        self.cudnn_batch_norm_backward_out(
             out0,
             out1,
             out2,
@@ -7060,7 +7052,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn cudnn_batch_norm_out<T: Borrow<Tensor>>(
+    pub fn f_cudnn_batch_norm_out<T: Borrow<Tensor>>(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -7074,7 +7066,7 @@ impl Tensor {
         exponential_average_factor: f64,
         epsilon: f64,
     ) -> (Tensor, Tensor, Tensor, Tensor) {
-        self.f_cudnn_batch_norm_out(
+        self.cudnn_batch_norm_out(
             out0,
             out1,
             out2,
@@ -7090,7 +7082,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn cudnn_convolution(
+    pub fn f_cudnn_convolution(
         &self,
         weight: &Tensor,
         padding: impl IntList,
@@ -7101,7 +7093,7 @@ impl Tensor {
         deterministic: bool,
         allow_tf32: bool,
     ) -> Tensor {
-        self.f_cudnn_convolution(
+        self.cudnn_convolution(
             weight,
             padding,
             stride,
@@ -7114,7 +7106,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn cudnn_convolution_add_relu<T: Borrow<Tensor>, S: Into<Scalar>>(
+    pub fn f_cudnn_convolution_add_relu<T: Borrow<Tensor>, S: Into<Scalar>>(
         &self,
         weight: &Tensor,
         z: &Tensor,
@@ -7125,11 +7117,11 @@ impl Tensor {
         dilation: impl IntList,
         groups: i64,
     ) -> Tensor {
-        self.f_cudnn_convolution_add_relu(weight, z, alpha, bias, stride, padding, dilation, groups)
+        self.cudnn_convolution_add_relu(weight, z, alpha, bias, stride, padding, dilation, groups)
             .unwrap()
     }
 
-    pub fn cudnn_convolution_add_relu_out<T: Borrow<Tensor>, S: Into<Scalar>>(
+    pub fn f_cudnn_convolution_add_relu_out<T: Borrow<Tensor>, S: Into<Scalar>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -7141,13 +7133,13 @@ impl Tensor {
         dilation: impl IntList,
         groups: i64,
     ) -> Tensor {
-        self.f_cudnn_convolution_add_relu_out(
+        self.cudnn_convolution_add_relu_out(
             out, weight, z, alpha, bias, stride, padding, dilation, groups,
         )
         .unwrap()
     }
 
-    pub fn cudnn_convolution_out(
+    pub fn f_cudnn_convolution_out(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -7159,7 +7151,7 @@ impl Tensor {
         deterministic: bool,
         allow_tf32: bool,
     ) -> Tensor {
-        self.f_cudnn_convolution_out(
+        self.cudnn_convolution_out(
             out,
             weight,
             padding,
@@ -7173,7 +7165,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn cudnn_convolution_relu<T: Borrow<Tensor>>(
+    pub fn f_cudnn_convolution_relu<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -7182,10 +7174,10 @@ impl Tensor {
         dilation: impl IntList,
         groups: i64,
     ) -> Tensor {
-        self.f_cudnn_convolution_relu(weight, bias, stride, padding, dilation, groups).unwrap()
+        self.cudnn_convolution_relu(weight, bias, stride, padding, dilation, groups).unwrap()
     }
 
-    pub fn cudnn_convolution_relu_out<T: Borrow<Tensor>>(
+    pub fn f_cudnn_convolution_relu_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -7195,11 +7187,11 @@ impl Tensor {
         dilation: impl IntList,
         groups: i64,
     ) -> Tensor {
-        self.f_cudnn_convolution_relu_out(out, weight, bias, stride, padding, dilation, groups)
+        self.cudnn_convolution_relu_out(out, weight, bias, stride, padding, dilation, groups)
             .unwrap()
     }
 
-    pub fn cudnn_convolution_transpose(
+    pub fn f_cudnn_convolution_transpose(
         &self,
         weight: &Tensor,
         padding: impl IntList,
@@ -7211,7 +7203,7 @@ impl Tensor {
         deterministic: bool,
         allow_tf32: bool,
     ) -> Tensor {
-        self.f_cudnn_convolution_transpose(
+        self.cudnn_convolution_transpose(
             weight,
             padding,
             output_padding,
@@ -7225,7 +7217,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn cudnn_convolution_transpose_out(
+    pub fn f_cudnn_convolution_transpose_out(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -7238,7 +7230,7 @@ impl Tensor {
         deterministic: bool,
         allow_tf32: bool,
     ) -> Tensor {
-        self.f_cudnn_convolution_transpose_out(
+        self.cudnn_convolution_transpose_out(
             out,
             weight,
             padding,
@@ -7253,183 +7245,183 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn cudnn_grid_sampler(&self, grid: &Tensor) -> Tensor {
-        self.f_cudnn_grid_sampler(grid).unwrap()
+    pub fn f_cudnn_grid_sampler(&self, grid: &Tensor) -> Tensor {
+        self.cudnn_grid_sampler(grid).unwrap()
     }
 
-    pub fn cudnn_grid_sampler_backward(
+    pub fn f_cudnn_grid_sampler_backward(
         &self,
         grid: &Tensor,
         grad_output: &Tensor,
     ) -> (Tensor, Tensor) {
-        self.f_cudnn_grid_sampler_backward(grid, grad_output).unwrap()
+        self.cudnn_grid_sampler_backward(grid, grad_output).unwrap()
     }
 
-    pub fn cudnn_grid_sampler_backward_out(
+    pub fn f_cudnn_grid_sampler_backward_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
         grid: &Tensor,
         grad_output: &Tensor,
     ) -> (Tensor, Tensor) {
-        self.f_cudnn_grid_sampler_backward_out(out0, out1, grid, grad_output).unwrap()
+        self.cudnn_grid_sampler_backward_out(out0, out1, grid, grad_output).unwrap()
     }
 
-    pub fn cudnn_grid_sampler_out(&self, out: &Tensor, grid: &Tensor) -> Tensor {
-        self.f_cudnn_grid_sampler_out(out, grid).unwrap()
+    pub fn f_cudnn_grid_sampler_out(&self, out: &Tensor, grid: &Tensor) -> Tensor {
+        self.cudnn_grid_sampler_out(out, grid).unwrap()
     }
 
-    pub fn cudnn_is_acceptable(&self) -> bool {
-        self.f_cudnn_is_acceptable().unwrap()
+    pub fn f_cudnn_is_acceptable(&self) -> bool {
+        self.cudnn_is_acceptable().unwrap()
     }
 
-    pub fn cummax(&self, dim: i64) -> (Tensor, Tensor) {
-        self.f_cummax(dim).unwrap()
+    pub fn f_cummax(&self, dim: i64) -> (Tensor, Tensor) {
+        self.cummax(dim).unwrap()
     }
 
-    pub fn cummax_out(&self, values: &Tensor, indices: &Tensor, dim: i64) -> (Tensor, Tensor) {
-        self.f_cummax_out(values, indices, dim).unwrap()
+    pub fn f_cummax_out(&self, values: &Tensor, indices: &Tensor, dim: i64) -> (Tensor, Tensor) {
+        self.cummax_out(values, indices, dim).unwrap()
     }
 
-    pub fn cummaxmin_backward(&self, grad: &Tensor, indices: &Tensor, dim: i64) -> Tensor {
-        self.f_cummaxmin_backward(grad, indices, dim).unwrap()
+    pub fn f_cummaxmin_backward(&self, grad: &Tensor, indices: &Tensor, dim: i64) -> Tensor {
+        self.cummaxmin_backward(grad, indices, dim).unwrap()
     }
 
-    pub fn cummin(&self, dim: i64) -> (Tensor, Tensor) {
-        self.f_cummin(dim).unwrap()
+    pub fn f_cummin(&self, dim: i64) -> (Tensor, Tensor) {
+        self.cummin(dim).unwrap()
     }
 
-    pub fn cummin_out(&self, values: &Tensor, indices: &Tensor, dim: i64) -> (Tensor, Tensor) {
-        self.f_cummin_out(values, indices, dim).unwrap()
+    pub fn f_cummin_out(&self, values: &Tensor, indices: &Tensor, dim: i64) -> (Tensor, Tensor) {
+        self.cummin_out(values, indices, dim).unwrap()
     }
 
-    pub fn cumprod(&self, dim: i64, dtype: impl Into<Option<Kind>>) -> Tensor {
-        self.f_cumprod(dim, dtype).unwrap()
+    pub fn f_cumprod(&self, dim: i64, dtype: impl Into<Option<Kind>>) -> Tensor {
+        self.cumprod(dim, dtype).unwrap()
     }
 
-    pub fn cumprod_(&mut self, dim: i64, dtype: impl Into<Option<Kind>>) -> Tensor {
-        self.f_cumprod_(dim, dtype).unwrap()
+    pub fn f_cumprod_(&mut self, dim: i64, dtype: impl Into<Option<Kind>>) -> Tensor {
+        self.cumprod_(dim, dtype).unwrap()
     }
 
-    pub fn cumprod_backward(&self, grad: &Tensor, dim: i64, output: &Tensor) -> Tensor {
-        self.f_cumprod_backward(grad, dim, output).unwrap()
+    pub fn f_cumprod_backward(&self, grad: &Tensor, dim: i64, output: &Tensor) -> Tensor {
+        self.cumprod_backward(grad, dim, output).unwrap()
     }
 
-    pub fn cumprod_out(&self, out: &Tensor, dim: i64, dtype: impl Into<Option<Kind>>) -> Tensor {
-        self.f_cumprod_out(out, dim, dtype).unwrap()
+    pub fn f_cumprod_out(&self, out: &Tensor, dim: i64, dtype: impl Into<Option<Kind>>) -> Tensor {
+        self.cumprod_out(out, dim, dtype).unwrap()
     }
 
-    pub fn cumsum(&self, dim: i64, dtype: impl Into<Option<Kind>>) -> Tensor {
-        self.f_cumsum(dim, dtype).unwrap()
+    pub fn f_cumsum(&self, dim: i64, dtype: impl Into<Option<Kind>>) -> Tensor {
+        self.cumsum(dim, dtype).unwrap()
     }
 
-    pub fn cumsum_(&mut self, dim: i64, dtype: impl Into<Option<Kind>>) -> Tensor {
-        self.f_cumsum_(dim, dtype).unwrap()
+    pub fn f_cumsum_(&mut self, dim: i64, dtype: impl Into<Option<Kind>>) -> Tensor {
+        self.cumsum_(dim, dtype).unwrap()
     }
 
-    pub fn cumsum_out(&self, out: &Tensor, dim: i64, dtype: impl Into<Option<Kind>>) -> Tensor {
-        self.f_cumsum_out(out, dim, dtype).unwrap()
+    pub fn f_cumsum_out(&self, out: &Tensor, dim: i64, dtype: impl Into<Option<Kind>>) -> Tensor {
+        self.cumsum_out(out, dim, dtype).unwrap()
     }
 
-    pub fn cumulative_trapezoid(y: &Tensor, dim: i64) -> Tensor {
-        Tensor::f_cumulative_trapezoid(y, dim).unwrap()
+    pub fn f_cumulative_trapezoid(y: &Tensor, dim: i64) -> Tensor {
+        Tensor::cumulative_trapezoid(y, dim).unwrap()
     }
 
-    pub fn cumulative_trapezoid_x(y: &Tensor, x: &Tensor, dim: i64) -> Tensor {
-        Tensor::f_cumulative_trapezoid_x(y, x, dim).unwrap()
+    pub fn f_cumulative_trapezoid_x(y: &Tensor, x: &Tensor, dim: i64) -> Tensor {
+        Tensor::cumulative_trapezoid_x(y, x, dim).unwrap()
     }
 
-    pub fn data(&self) -> Tensor {
-        self.f_data().unwrap()
+    pub fn f_data(&self) -> Tensor {
+        self.data().unwrap()
     }
 
-    pub fn deg2rad(&self) -> Tensor {
-        self.f_deg2rad().unwrap()
+    pub fn f_deg2rad(&self) -> Tensor {
+        self.deg2rad().unwrap()
     }
 
-    pub fn deg2rad_(&mut self) -> Tensor {
-        self.f_deg2rad_().unwrap()
+    pub fn f_deg2rad_(&mut self) -> Tensor {
+        self.deg2rad_().unwrap()
     }
 
-    pub fn deg2rad_out(&self, out: &Tensor) -> Tensor {
-        self.f_deg2rad_out(out).unwrap()
+    pub fn f_deg2rad_out(&self, out: &Tensor) -> Tensor {
+        self.deg2rad_out(out).unwrap()
     }
 
-    pub fn dense_dim(&self) -> i64 {
-        self.f_dense_dim().unwrap()
+    pub fn f_dense_dim(&self) -> i64 {
+        self.dense_dim().unwrap()
     }
 
-    pub fn dequantize(&self) -> Tensor {
-        self.f_dequantize().unwrap()
+    pub fn f_dequantize(&self) -> Tensor {
+        self.dequantize().unwrap()
     }
 
-    pub fn dequantize_self_out(&self, out: &Tensor) -> Tensor {
-        self.f_dequantize_self_out(out).unwrap()
+    pub fn f_dequantize_self_out(&self, out: &Tensor) -> Tensor {
+        self.dequantize_self_out(out).unwrap()
     }
 
-    pub fn dequantize_tensors<T: Borrow<Tensor>>(tensors: &[T]) -> Vec<Tensor> {
-        Tensor::f_dequantize_tensors(tensors).unwrap()
+    pub fn f_dequantize_tensors<T: Borrow<Tensor>>(tensors: &[T]) -> Vec<Tensor> {
+        Tensor::dequantize_tensors(tensors).unwrap()
     }
 
-    pub fn dequantize_tensors_out<T: Borrow<Tensor>>(out: &[T], tensors: &[T]) {
-        Tensor::f_dequantize_tensors_out(out, tensors).unwrap()
+    pub fn f_dequantize_tensors_out<T: Borrow<Tensor>>(out: &[T], tensors: &[T]) {
+        Tensor::dequantize_tensors_out(out, tensors).unwrap()
     }
 
-    pub fn det(&self) -> Tensor {
-        self.f_det().unwrap()
+    pub fn f_det(&self) -> Tensor {
+        self.det().unwrap()
     }
 
-    pub fn detach(&self) -> Tensor {
-        self.f_detach().unwrap()
+    pub fn f_detach(&self) -> Tensor {
+        self.detach().unwrap()
     }
 
-    pub fn detach_(&mut self) -> Tensor {
-        self.f_detach_().unwrap()
+    pub fn f_detach_(&mut self) -> Tensor {
+        self.detach_().unwrap()
     }
 
-    pub fn detach_copy(&self) -> Tensor {
-        self.f_detach_copy().unwrap()
+    pub fn f_detach_copy(&self) -> Tensor {
+        self.detach_copy().unwrap()
     }
 
-    pub fn detach_copy_out(&self, out: &Tensor) -> Tensor {
-        self.f_detach_copy_out(out).unwrap()
+    pub fn f_detach_copy_out(&self, out: &Tensor) -> Tensor {
+        self.detach_copy_out(out).unwrap()
     }
 
-    pub fn diag(&self, diagonal: i64) -> Tensor {
-        self.f_diag(diagonal).unwrap()
+    pub fn f_diag(&self, diagonal: i64) -> Tensor {
+        self.diag(diagonal).unwrap()
     }
 
-    pub fn diag_embed(&self, offset: i64, dim1: i64, dim2: i64) -> Tensor {
-        self.f_diag_embed(offset, dim1, dim2).unwrap()
+    pub fn f_diag_embed(&self, offset: i64, dim1: i64, dim2: i64) -> Tensor {
+        self.diag_embed(offset, dim1, dim2).unwrap()
     }
 
-    pub fn diag_embed_out(&self, out: &Tensor, offset: i64, dim1: i64, dim2: i64) -> Tensor {
-        self.f_diag_embed_out(out, offset, dim1, dim2).unwrap()
+    pub fn f_diag_embed_out(&self, out: &Tensor, offset: i64, dim1: i64, dim2: i64) -> Tensor {
+        self.diag_embed_out(out, offset, dim1, dim2).unwrap()
     }
 
-    pub fn diag_out(&self, out: &Tensor, diagonal: i64) -> Tensor {
-        self.f_diag_out(out, diagonal).unwrap()
+    pub fn f_diag_out(&self, out: &Tensor, diagonal: i64) -> Tensor {
+        self.diag_out(out, diagonal).unwrap()
     }
 
-    pub fn diagflat(&self, offset: i64) -> Tensor {
-        self.f_diagflat(offset).unwrap()
+    pub fn f_diagflat(&self, offset: i64) -> Tensor {
+        self.diagflat(offset).unwrap()
     }
 
-    pub fn diagonal(&self, offset: i64, dim1: i64, dim2: i64) -> Tensor {
-        self.f_diagonal(offset, dim1, dim2).unwrap()
+    pub fn f_diagonal(&self, offset: i64, dim1: i64, dim2: i64) -> Tensor {
+        self.diagonal(offset, dim1, dim2).unwrap()
     }
 
-    pub fn diagonal_backward(
+    pub fn f_diagonal_backward(
         grad_output: &Tensor,
         input_sizes: impl IntList,
         offset: i64,
         dim1: i64,
         dim2: i64,
     ) -> Tensor {
-        Tensor::f_diagonal_backward(grad_output, input_sizes, offset, dim1, dim2).unwrap()
+        Tensor::diagonal_backward(grad_output, input_sizes, offset, dim1, dim2).unwrap()
     }
 
-    pub fn diagonal_backward_out(
+    pub fn f_diagonal_backward_out(
         out: &Tensor,
         grad_output: &Tensor,
         input_sizes: impl IntList,
@@ -7437,22 +7429,22 @@ impl Tensor {
         dim1: i64,
         dim2: i64,
     ) -> Tensor {
-        Tensor::f_diagonal_backward_out(out, grad_output, input_sizes, offset, dim1, dim2).unwrap()
+        Tensor::diagonal_backward_out(out, grad_output, input_sizes, offset, dim1, dim2).unwrap()
     }
 
-    pub fn diagonal_copy(&self, offset: i64, dim1: i64, dim2: i64) -> Tensor {
-        self.f_diagonal_copy(offset, dim1, dim2).unwrap()
+    pub fn f_diagonal_copy(&self, offset: i64, dim1: i64, dim2: i64) -> Tensor {
+        self.diagonal_copy(offset, dim1, dim2).unwrap()
     }
 
-    pub fn diagonal_copy_out(&self, out: &Tensor, offset: i64, dim1: i64, dim2: i64) -> Tensor {
-        self.f_diagonal_copy_out(out, offset, dim1, dim2).unwrap()
+    pub fn f_diagonal_copy_out(&self, out: &Tensor, offset: i64, dim1: i64, dim2: i64) -> Tensor {
+        self.diagonal_copy_out(out, offset, dim1, dim2).unwrap()
     }
 
-    pub fn diagonal_scatter(&self, src: &Tensor, offset: i64, dim1: i64, dim2: i64) -> Tensor {
-        self.f_diagonal_scatter(src, offset, dim1, dim2).unwrap()
+    pub fn f_diagonal_scatter(&self, src: &Tensor, offset: i64, dim1: i64, dim2: i64) -> Tensor {
+        self.diagonal_scatter(src, offset, dim1, dim2).unwrap()
     }
 
-    pub fn diagonal_scatter_out(
+    pub fn f_diagonal_scatter_out(
         &self,
         out: &Tensor,
         src: &Tensor,
@@ -7460,20 +7452,20 @@ impl Tensor {
         dim1: i64,
         dim2: i64,
     ) -> Tensor {
-        self.f_diagonal_scatter_out(out, src, offset, dim1, dim2).unwrap()
+        self.diagonal_scatter_out(out, src, offset, dim1, dim2).unwrap()
     }
 
-    pub fn diff<T: Borrow<Tensor>>(
+    pub fn f_diff<T: Borrow<Tensor>>(
         &self,
         n: i64,
         dim: i64,
         prepend: Option<T>,
         append: Option<T>,
     ) -> Tensor {
-        self.f_diff(n, dim, prepend, append).unwrap()
+        self.diff(n, dim, prepend, append).unwrap()
     }
 
-    pub fn diff_out<T: Borrow<Tensor>>(
+    pub fn f_diff_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         n: i64,
@@ -7481,175 +7473,175 @@ impl Tensor {
         prepend: Option<T>,
         append: Option<T>,
     ) -> Tensor {
-        self.f_diff_out(out, n, dim, prepend, append).unwrap()
+        self.diff_out(out, n, dim, prepend, append).unwrap()
     }
 
-    pub fn digamma(&self) -> Tensor {
-        self.f_digamma().unwrap()
+    pub fn f_digamma(&self) -> Tensor {
+        self.digamma().unwrap()
     }
 
-    pub fn digamma_(&mut self) -> Tensor {
-        self.f_digamma_().unwrap()
+    pub fn f_digamma_(&mut self) -> Tensor {
+        self.digamma_().unwrap()
     }
 
-    pub fn digamma_out(&self, out: &Tensor) -> Tensor {
-        self.f_digamma_out(out).unwrap()
+    pub fn f_digamma_out(&self, out: &Tensor) -> Tensor {
+        self.digamma_out(out).unwrap()
     }
 
-    pub fn dist(&self, other: &Tensor) -> Tensor {
-        self.f_dist(other).unwrap()
+    pub fn f_dist(&self, other: &Tensor) -> Tensor {
+        self.dist(other).unwrap()
     }
 
-    pub fn dist_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_dist_out(out, other).unwrap()
+    pub fn f_dist_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.dist_out(out, other).unwrap()
     }
 
-    pub fn g_div(&self, other: &Tensor) -> Tensor {
-        self.f_div(other).unwrap()
+    pub fn f_div(&self, other: &Tensor) -> Tensor {
+        self.g_div(other).unwrap()
     }
 
-    pub fn g_div_(&mut self, other: &Tensor) -> Tensor {
-        self.f_div_(other).unwrap()
+    pub fn f_div_(&mut self, other: &Tensor) -> Tensor {
+        self.g_div_(other).unwrap()
     }
 
-    pub fn div_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_div_out(out, other).unwrap()
+    pub fn f_div_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.div_out(out, other).unwrap()
     }
 
-    pub fn div_out_mode(&self, out: &Tensor, other: &Tensor, rounding_mode: &str) -> Tensor {
-        self.f_div_out_mode(out, other, rounding_mode).unwrap()
+    pub fn f_div_out_mode(&self, out: &Tensor, other: &Tensor, rounding_mode: &str) -> Tensor {
+        self.div_out_mode(out, other, rounding_mode).unwrap()
     }
 
-    pub fn g_div_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_div_scalar(other).unwrap()
+    pub fn f_div_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.g_div_scalar(other).unwrap()
     }
 
-    pub fn g_div_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_div_scalar_(other).unwrap()
+    pub fn f_div_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.g_div_scalar_(other).unwrap()
     }
 
-    pub fn g_div_scalar_mode<S: Into<Scalar>>(&self, other: S, rounding_mode: &str) -> Tensor {
-        self.f_div_scalar_mode(other, rounding_mode).unwrap()
+    pub fn f_div_scalar_mode<S: Into<Scalar>>(&self, other: S, rounding_mode: &str) -> Tensor {
+        self.g_div_scalar_mode(other, rounding_mode).unwrap()
     }
 
-    pub fn g_div_scalar_mode_<S: Into<Scalar>>(&mut self, other: S, rounding_mode: &str) -> Tensor {
-        self.f_div_scalar_mode_(other, rounding_mode).unwrap()
+    pub fn f_div_scalar_mode_<S: Into<Scalar>>(&mut self, other: S, rounding_mode: &str) -> Tensor {
+        self.g_div_scalar_mode_(other, rounding_mode).unwrap()
     }
 
-    pub fn div_scalar_mode_out<S: Into<Scalar>>(
+    pub fn f_div_scalar_mode_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
         rounding_mode: &str,
     ) -> Tensor {
-        self.f_div_scalar_mode_out(out, other, rounding_mode).unwrap()
+        self.div_scalar_mode_out(out, other, rounding_mode).unwrap()
     }
 
-    pub fn div_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
-        self.f_div_scalar_out(out, other).unwrap()
+    pub fn f_div_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
+        self.div_scalar_out(out, other).unwrap()
     }
 
-    pub fn g_div_tensor_mode(&self, other: &Tensor, rounding_mode: &str) -> Tensor {
-        self.f_div_tensor_mode(other, rounding_mode).unwrap()
+    pub fn f_div_tensor_mode(&self, other: &Tensor, rounding_mode: &str) -> Tensor {
+        self.g_div_tensor_mode(other, rounding_mode).unwrap()
     }
 
-    pub fn g_div_tensor_mode_(&mut self, other: &Tensor, rounding_mode: &str) -> Tensor {
-        self.f_div_tensor_mode_(other, rounding_mode).unwrap()
+    pub fn f_div_tensor_mode_(&mut self, other: &Tensor, rounding_mode: &str) -> Tensor {
+        self.g_div_tensor_mode_(other, rounding_mode).unwrap()
     }
 
-    pub fn divide(&self, other: &Tensor) -> Tensor {
-        self.f_divide(other).unwrap()
+    pub fn f_divide(&self, other: &Tensor) -> Tensor {
+        self.divide(other).unwrap()
     }
 
-    pub fn divide_(&mut self, other: &Tensor) -> Tensor {
-        self.f_divide_(other).unwrap()
+    pub fn f_divide_(&mut self, other: &Tensor) -> Tensor {
+        self.divide_(other).unwrap()
     }
 
-    pub fn divide_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_divide_out(out, other).unwrap()
+    pub fn f_divide_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.divide_out(out, other).unwrap()
     }
 
-    pub fn divide_out_mode(&self, out: &Tensor, other: &Tensor, rounding_mode: &str) -> Tensor {
-        self.f_divide_out_mode(out, other, rounding_mode).unwrap()
+    pub fn f_divide_out_mode(&self, out: &Tensor, other: &Tensor, rounding_mode: &str) -> Tensor {
+        self.divide_out_mode(out, other, rounding_mode).unwrap()
     }
 
-    pub fn divide_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_divide_scalar(other).unwrap()
+    pub fn f_divide_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.divide_scalar(other).unwrap()
     }
 
-    pub fn divide_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_divide_scalar_(other).unwrap()
+    pub fn f_divide_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.divide_scalar_(other).unwrap()
     }
 
-    pub fn divide_scalar_mode<S: Into<Scalar>>(&self, other: S, rounding_mode: &str) -> Tensor {
-        self.f_divide_scalar_mode(other, rounding_mode).unwrap()
+    pub fn f_divide_scalar_mode<S: Into<Scalar>>(&self, other: S, rounding_mode: &str) -> Tensor {
+        self.divide_scalar_mode(other, rounding_mode).unwrap()
     }
 
-    pub fn divide_scalar_mode_<S: Into<Scalar>>(
+    pub fn f_divide_scalar_mode_<S: Into<Scalar>>(
         &mut self,
         other: S,
         rounding_mode: &str,
     ) -> Tensor {
-        self.f_divide_scalar_mode_(other, rounding_mode).unwrap()
+        self.divide_scalar_mode_(other, rounding_mode).unwrap()
     }
 
-    pub fn divide_tensor_mode(&self, other: &Tensor, rounding_mode: &str) -> Tensor {
-        self.f_divide_tensor_mode(other, rounding_mode).unwrap()
+    pub fn f_divide_tensor_mode(&self, other: &Tensor, rounding_mode: &str) -> Tensor {
+        self.divide_tensor_mode(other, rounding_mode).unwrap()
     }
 
-    pub fn divide_tensor_mode_(&mut self, other: &Tensor, rounding_mode: &str) -> Tensor {
-        self.f_divide_tensor_mode_(other, rounding_mode).unwrap()
+    pub fn f_divide_tensor_mode_(&mut self, other: &Tensor, rounding_mode: &str) -> Tensor {
+        self.divide_tensor_mode_(other, rounding_mode).unwrap()
     }
 
-    pub fn dot(&self, tensor: &Tensor) -> Tensor {
-        self.f_dot(tensor).unwrap()
+    pub fn f_dot(&self, tensor: &Tensor) -> Tensor {
+        self.dot(tensor).unwrap()
     }
 
-    pub fn dot_out(&self, out: &Tensor, tensor: &Tensor) -> Tensor {
-        self.f_dot_out(out, tensor).unwrap()
+    pub fn f_dot_out(&self, out: &Tensor, tensor: &Tensor) -> Tensor {
+        self.dot_out(out, tensor).unwrap()
     }
 
-    pub fn dropout(&self, p: f64, train: bool) -> Tensor {
-        self.f_dropout(p, train).unwrap()
+    pub fn f_dropout(&self, p: f64, train: bool) -> Tensor {
+        self.dropout(p, train).unwrap()
     }
 
-    pub fn dropout_(&mut self, p: f64, train: bool) -> Tensor {
-        self.f_dropout_(p, train).unwrap()
+    pub fn f_dropout_(&mut self, p: f64, train: bool) -> Tensor {
+        self.dropout_(p, train).unwrap()
     }
 
-    pub fn dsplit(&self, sections: i64) -> Vec<Tensor> {
-        self.f_dsplit(sections).unwrap()
+    pub fn f_dsplit(&self, sections: i64) -> Vec<Tensor> {
+        self.dsplit(sections).unwrap()
     }
 
-    pub fn dsplit_array(&self, indices: impl IntList) -> Vec<Tensor> {
-        self.f_dsplit_array(indices).unwrap()
+    pub fn f_dsplit_array(&self, indices: impl IntList) -> Vec<Tensor> {
+        self.dsplit_array(indices).unwrap()
     }
 
-    pub fn dstack<T: Borrow<Tensor>>(tensors: &[T]) -> Tensor {
-        Tensor::f_dstack(tensors).unwrap()
+    pub fn f_dstack<T: Borrow<Tensor>>(tensors: &[T]) -> Tensor {
+        Tensor::dstack(tensors).unwrap()
     }
 
-    pub fn dstack_out<T: Borrow<Tensor>>(out: &Tensor, tensors: &[T]) -> Tensor {
-        Tensor::f_dstack_out(out, tensors).unwrap()
+    pub fn f_dstack_out<T: Borrow<Tensor>>(out: &Tensor, tensors: &[T]) -> Tensor {
+        Tensor::dstack_out(out, tensors).unwrap()
     }
 
-    pub fn einsum<T: Borrow<Tensor>>(
+    pub fn f_einsum<T: Borrow<Tensor>>(
         equation: &str,
         tensors: &[T],
         path: impl IntListOption,
     ) -> Tensor {
-        Tensor::f_einsum(equation, tensors, path).unwrap()
+        Tensor::einsum(equation, tensors, path).unwrap()
     }
 
-    pub fn elu(&self) -> Tensor {
-        self.f_elu().unwrap()
+    pub fn f_elu(&self) -> Tensor {
+        self.elu().unwrap()
     }
 
-    pub fn elu_(&mut self) -> Tensor {
-        self.f_elu_().unwrap()
+    pub fn f_elu_(&mut self) -> Tensor {
+        self.elu_().unwrap()
     }
 
-    pub fn elu_backward<S: Into<Scalar>>(
+    pub fn f_elu_backward<S: Into<Scalar>>(
         grad_output: &Tensor,
         alpha: S,
         scale: S,
@@ -7657,11 +7649,11 @@ impl Tensor {
         is_result: bool,
         self_or_result: &Tensor,
     ) -> Tensor {
-        Tensor::f_elu_backward(grad_output, alpha, scale, input_scale, is_result, self_or_result)
+        Tensor::elu_backward(grad_output, alpha, scale, input_scale, is_result, self_or_result)
             .unwrap()
     }
 
-    pub fn elu_backward_grad_input<S: Into<Scalar>>(
+    pub fn f_elu_backward_grad_input<S: Into<Scalar>>(
         grad_input: &Tensor,
         grad_output: &Tensor,
         alpha: S,
@@ -7670,7 +7662,7 @@ impl Tensor {
         is_result: bool,
         self_or_result: &Tensor,
     ) -> Tensor {
-        Tensor::f_elu_backward_grad_input(
+        Tensor::elu_backward_grad_input(
             grad_input,
             grad_output,
             alpha,
@@ -7682,21 +7674,21 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn elu_out(&self, out: &Tensor) -> Tensor {
-        self.f_elu_out(out).unwrap()
+    pub fn f_elu_out(&self, out: &Tensor) -> Tensor {
+        self.elu_out(out).unwrap()
     }
 
-    pub fn embedding(
+    pub fn f_embedding(
         weight: &Tensor,
         indices: &Tensor,
         padding_idx: i64,
         scale_grad_by_freq: bool,
         sparse: bool,
     ) -> Tensor {
-        Tensor::f_embedding(weight, indices, padding_idx, scale_grad_by_freq, sparse).unwrap()
+        Tensor::embedding(weight, indices, padding_idx, scale_grad_by_freq, sparse).unwrap()
     }
 
-    pub fn embedding_backward(
+    pub fn f_embedding_backward(
         grad: &Tensor,
         indices: &Tensor,
         num_weights: i64,
@@ -7704,7 +7696,7 @@ impl Tensor {
         scale_grad_by_freq: bool,
         sparse: bool,
     ) -> Tensor {
-        Tensor::f_embedding_backward(
+        Tensor::embedding_backward(
             grad,
             indices,
             num_weights,
@@ -7715,7 +7707,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn embedding_bag<T: Borrow<Tensor>>(
+    pub fn f_embedding_bag<T: Borrow<Tensor>>(
         weight: &Tensor,
         indices: &Tensor,
         offsets: &Tensor,
@@ -7725,7 +7717,7 @@ impl Tensor {
         per_sample_weights: Option<T>,
         include_last_offset: bool,
     ) -> (Tensor, Tensor, Tensor, Tensor) {
-        Tensor::f_embedding_bag(
+        Tensor::embedding_bag(
             weight,
             indices,
             offsets,
@@ -7738,7 +7730,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn embedding_bag_padding_idx<T: Borrow<Tensor>>(
+    pub fn f_embedding_bag_padding_idx<T: Borrow<Tensor>>(
         weight: &Tensor,
         indices: &Tensor,
         offsets: &Tensor,
@@ -7749,7 +7741,7 @@ impl Tensor {
         include_last_offset: bool,
         padding_idx: impl Into<Option<i64>>,
     ) -> (Tensor, Tensor, Tensor, Tensor) {
-        Tensor::f_embedding_bag_padding_idx(
+        Tensor::embedding_bag_padding_idx(
             weight,
             indices,
             offsets,
@@ -7763,14 +7755,14 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn embedding_dense_backward(
+    pub fn f_embedding_dense_backward(
         grad_output: &Tensor,
         indices: &Tensor,
         num_weights: i64,
         padding_idx: i64,
         scale_grad_by_freq: bool,
     ) -> Tensor {
-        Tensor::f_embedding_dense_backward(
+        Tensor::embedding_dense_backward(
             grad_output,
             indices,
             num_weights,
@@ -7780,7 +7772,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn embedding_dense_backward_out(
+    pub fn f_embedding_dense_backward_out(
         out: &Tensor,
         grad_output: &Tensor,
         indices: &Tensor,
@@ -7788,7 +7780,7 @@ impl Tensor {
         padding_idx: i64,
         scale_grad_by_freq: bool,
     ) -> Tensor {
-        Tensor::f_embedding_dense_backward_out(
+        Tensor::embedding_dense_backward_out(
             out,
             grad_output,
             indices,
@@ -7799,7 +7791,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn embedding_out(
+    pub fn f_embedding_out(
         out: &Tensor,
         weight: &Tensor,
         indices: &Tensor,
@@ -7807,36 +7799,41 @@ impl Tensor {
         scale_grad_by_freq: bool,
         sparse: bool,
     ) -> Tensor {
-        Tensor::f_embedding_out(out, weight, indices, padding_idx, scale_grad_by_freq, sparse)
+        Tensor::embedding_out(out, weight, indices, padding_idx, scale_grad_by_freq, sparse)
             .unwrap()
     }
 
-    pub fn embedding_renorm(&self, indices: &Tensor, max_norm: f64, norm_type: f64) -> Tensor {
-        self.f_embedding_renorm(indices, max_norm, norm_type).unwrap()
+    pub fn f_embedding_renorm(&self, indices: &Tensor, max_norm: f64, norm_type: f64) -> Tensor {
+        self.embedding_renorm(indices, max_norm, norm_type).unwrap()
     }
 
-    pub fn embedding_renorm_(&mut self, indices: &Tensor, max_norm: f64, norm_type: f64) -> Tensor {
-        self.f_embedding_renorm_(indices, max_norm, norm_type).unwrap()
+    pub fn f_embedding_renorm_(
+        &mut self,
+        indices: &Tensor,
+        max_norm: f64,
+        norm_type: f64,
+    ) -> Tensor {
+        self.embedding_renorm_(indices, max_norm, norm_type).unwrap()
     }
 
-    pub fn embedding_renorm_out(
+    pub fn f_embedding_renorm_out(
         &self,
         out: &Tensor,
         indices: &Tensor,
         max_norm: f64,
         norm_type: f64,
     ) -> Tensor {
-        self.f_embedding_renorm_out(out, indices, max_norm, norm_type).unwrap()
+        self.embedding_renorm_out(out, indices, max_norm, norm_type).unwrap()
     }
 
-    pub fn embedding_sparse_backward(
+    pub fn f_embedding_sparse_backward(
         grad: &Tensor,
         indices: &Tensor,
         num_weights: i64,
         padding_idx: i64,
         scale_grad_by_freq: bool,
     ) -> Tensor {
-        Tensor::f_embedding_sparse_backward(
+        Tensor::embedding_sparse_backward(
             grad,
             indices,
             num_weights,
@@ -7846,191 +7843,191 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn empty(size: impl IntList, options: (Kind, Device)) -> Tensor {
-        Tensor::f_empty(size, options).unwrap()
+    pub fn f_empty(size: impl IntList, options: (Kind, Device)) -> Tensor {
+        Tensor::empty(size, options).unwrap()
     }
 
-    pub fn empty_like(&self) -> Tensor {
-        self.f_empty_like().unwrap()
+    pub fn f_empty_like(&self) -> Tensor {
+        self.empty_like().unwrap()
     }
 
-    pub fn empty_like_out(&self, out: &Tensor) -> Tensor {
-        self.f_empty_like_out(out).unwrap()
+    pub fn f_empty_like_out(&self, out: &Tensor) -> Tensor {
+        self.empty_like_out(out).unwrap()
     }
 
-    pub fn empty_out(out: &Tensor, size: impl IntList) -> Tensor {
-        Tensor::f_empty_out(out, size).unwrap()
+    pub fn f_empty_out(out: &Tensor, size: impl IntList) -> Tensor {
+        Tensor::empty_out(out, size).unwrap()
     }
 
-    pub fn empty_quantized(
+    pub fn f_empty_quantized(
         size: impl IntList,
         qtensor: &Tensor,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_empty_quantized(size, qtensor, options).unwrap()
+        Tensor::empty_quantized(size, qtensor, options).unwrap()
     }
 
-    pub fn empty_quantized_out(out: &Tensor, size: impl IntList, qtensor: &Tensor) -> Tensor {
-        Tensor::f_empty_quantized_out(out, size, qtensor).unwrap()
+    pub fn f_empty_quantized_out(out: &Tensor, size: impl IntList, qtensor: &Tensor) -> Tensor {
+        Tensor::empty_quantized_out(out, size, qtensor).unwrap()
     }
 
-    pub fn empty_strided(
+    pub fn f_empty_strided(
         size: impl IntList,
         stride: impl IntList,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_empty_strided(size, stride, options).unwrap()
+        Tensor::empty_strided(size, stride, options).unwrap()
     }
 
-    pub fn empty_strided_out(out: &Tensor, size: impl IntList, stride: impl IntList) -> Tensor {
-        Tensor::f_empty_strided_out(out, size, stride).unwrap()
+    pub fn f_empty_strided_out(out: &Tensor, size: impl IntList, stride: impl IntList) -> Tensor {
+        Tensor::empty_strided_out(out, size, stride).unwrap()
     }
 
-    pub fn eq<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_eq(other).unwrap()
+    pub fn f_eq<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.eq(other).unwrap()
     }
 
-    pub fn eq_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_eq_(other).unwrap()
+    pub fn f_eq_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.eq_(other).unwrap()
     }
 
-    pub fn eq_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
-        self.f_eq_scalar_out(out, other).unwrap()
+    pub fn f_eq_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
+        self.eq_scalar_out(out, other).unwrap()
     }
 
-    pub fn eq_tensor(&self, other: &Tensor) -> Tensor {
-        self.f_eq_tensor(other).unwrap()
+    pub fn f_eq_tensor(&self, other: &Tensor) -> Tensor {
+        self.eq_tensor(other).unwrap()
     }
 
-    pub fn eq_tensor_(&mut self, other: &Tensor) -> Tensor {
-        self.f_eq_tensor_(other).unwrap()
+    pub fn f_eq_tensor_(&mut self, other: &Tensor) -> Tensor {
+        self.eq_tensor_(other).unwrap()
     }
 
-    pub fn eq_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_eq_tensor_out(out, other).unwrap()
+    pub fn f_eq_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.eq_tensor_out(out, other).unwrap()
     }
 
-    pub fn equal(&self, other: &Tensor) -> bool {
-        self.f_equal(other).unwrap()
+    pub fn f_equal(&self, other: &Tensor) -> bool {
+        self.equal(other).unwrap()
     }
 
-    pub fn erf(&self) -> Tensor {
-        self.f_erf().unwrap()
+    pub fn f_erf(&self) -> Tensor {
+        self.erf().unwrap()
     }
 
-    pub fn erf_(&mut self) -> Tensor {
-        self.f_erf_().unwrap()
+    pub fn f_erf_(&mut self) -> Tensor {
+        self.erf_().unwrap()
     }
 
-    pub fn erf_out(&self, out: &Tensor) -> Tensor {
-        self.f_erf_out(out).unwrap()
+    pub fn f_erf_out(&self, out: &Tensor) -> Tensor {
+        self.erf_out(out).unwrap()
     }
 
-    pub fn erfc(&self) -> Tensor {
-        self.f_erfc().unwrap()
+    pub fn f_erfc(&self) -> Tensor {
+        self.erfc().unwrap()
     }
 
-    pub fn erfc_(&mut self) -> Tensor {
-        self.f_erfc_().unwrap()
+    pub fn f_erfc_(&mut self) -> Tensor {
+        self.erfc_().unwrap()
     }
 
-    pub fn erfc_out(&self, out: &Tensor) -> Tensor {
-        self.f_erfc_out(out).unwrap()
+    pub fn f_erfc_out(&self, out: &Tensor) -> Tensor {
+        self.erfc_out(out).unwrap()
     }
 
-    pub fn erfinv(&self) -> Tensor {
-        self.f_erfinv().unwrap()
+    pub fn f_erfinv(&self) -> Tensor {
+        self.erfinv().unwrap()
     }
 
-    pub fn erfinv_(&mut self) -> Tensor {
-        self.f_erfinv_().unwrap()
+    pub fn f_erfinv_(&mut self) -> Tensor {
+        self.erfinv_().unwrap()
     }
 
-    pub fn erfinv_out(&self, out: &Tensor) -> Tensor {
-        self.f_erfinv_out(out).unwrap()
+    pub fn f_erfinv_out(&self, out: &Tensor) -> Tensor {
+        self.erfinv_out(out).unwrap()
     }
 
-    pub fn exp(&self) -> Tensor {
-        self.f_exp().unwrap()
+    pub fn f_exp(&self) -> Tensor {
+        self.exp().unwrap()
     }
 
-    pub fn exp2(&self) -> Tensor {
-        self.f_exp2().unwrap()
+    pub fn f_exp2(&self) -> Tensor {
+        self.exp2().unwrap()
     }
 
-    pub fn exp2_(&mut self) -> Tensor {
-        self.f_exp2_().unwrap()
+    pub fn f_exp2_(&mut self) -> Tensor {
+        self.exp2_().unwrap()
     }
 
-    pub fn exp2_out(&self, out: &Tensor) -> Tensor {
-        self.f_exp2_out(out).unwrap()
+    pub fn f_exp2_out(&self, out: &Tensor) -> Tensor {
+        self.exp2_out(out).unwrap()
     }
 
-    pub fn exp_(&mut self) -> Tensor {
-        self.f_exp_().unwrap()
+    pub fn f_exp_(&mut self) -> Tensor {
+        self.exp_().unwrap()
     }
 
-    pub fn exp_out(&self, out: &Tensor) -> Tensor {
-        self.f_exp_out(out).unwrap()
+    pub fn f_exp_out(&self, out: &Tensor) -> Tensor {
+        self.exp_out(out).unwrap()
     }
 
-    pub fn expand(&self, size: impl IntList, implicit: bool) -> Tensor {
-        self.f_expand(size, implicit).unwrap()
+    pub fn f_expand(&self, size: impl IntList, implicit: bool) -> Tensor {
+        self.expand(size, implicit).unwrap()
     }
 
-    pub fn expand_as(&self, other: &Tensor) -> Tensor {
-        self.f_expand_as(other).unwrap()
+    pub fn f_expand_as(&self, other: &Tensor) -> Tensor {
+        self.expand_as(other).unwrap()
     }
 
-    pub fn expand_copy(&self, size: impl IntList, implicit: bool) -> Tensor {
-        self.f_expand_copy(size, implicit).unwrap()
+    pub fn f_expand_copy(&self, size: impl IntList, implicit: bool) -> Tensor {
+        self.expand_copy(size, implicit).unwrap()
     }
 
-    pub fn expand_copy_out(&self, out: &Tensor, size: impl IntList, implicit: bool) -> Tensor {
-        self.f_expand_copy_out(out, size, implicit).unwrap()
+    pub fn f_expand_copy_out(&self, out: &Tensor, size: impl IntList, implicit: bool) -> Tensor {
+        self.expand_copy_out(out, size, implicit).unwrap()
     }
 
-    pub fn expm1(&self) -> Tensor {
-        self.f_expm1().unwrap()
+    pub fn f_expm1(&self) -> Tensor {
+        self.expm1().unwrap()
     }
 
-    pub fn expm1_(&mut self) -> Tensor {
-        self.f_expm1_().unwrap()
+    pub fn f_expm1_(&mut self) -> Tensor {
+        self.expm1_().unwrap()
     }
 
-    pub fn expm1_out(&self, out: &Tensor) -> Tensor {
-        self.f_expm1_out(out).unwrap()
+    pub fn f_expm1_out(&self, out: &Tensor) -> Tensor {
+        self.expm1_out(out).unwrap()
     }
 
-    pub fn exponential(&self, lambd: f64) -> Tensor {
-        self.f_exponential(lambd).unwrap()
+    pub fn f_exponential(&self, lambd: f64) -> Tensor {
+        self.exponential(lambd).unwrap()
     }
 
-    pub fn exponential_(&mut self, lambd: f64) -> Tensor {
-        self.f_exponential_(lambd).unwrap()
+    pub fn f_exponential_(&mut self, lambd: f64) -> Tensor {
+        self.exponential_(lambd).unwrap()
     }
 
-    pub fn exponential_out(&self, out: &Tensor, lambd: f64) -> Tensor {
-        self.f_exponential_out(out, lambd).unwrap()
+    pub fn f_exponential_out(&self, out: &Tensor, lambd: f64) -> Tensor {
+        self.exponential_out(out, lambd).unwrap()
     }
 
-    pub fn eye(n: i64, options: (Kind, Device)) -> Tensor {
-        Tensor::f_eye(n, options).unwrap()
+    pub fn f_eye(n: i64, options: (Kind, Device)) -> Tensor {
+        Tensor::eye(n, options).unwrap()
     }
 
-    pub fn eye_m(n: i64, m: i64, options: (Kind, Device)) -> Tensor {
-        Tensor::f_eye_m(n, m, options).unwrap()
+    pub fn f_eye_m(n: i64, m: i64, options: (Kind, Device)) -> Tensor {
+        Tensor::eye_m(n, m, options).unwrap()
     }
 
-    pub fn eye_m_out(out: &Tensor, n: i64, m: i64) -> Tensor {
-        Tensor::f_eye_m_out(out, n, m).unwrap()
+    pub fn f_eye_m_out(out: &Tensor, n: i64, m: i64) -> Tensor {
+        Tensor::eye_m_out(out, n, m).unwrap()
     }
 
-    pub fn eye_out(out: &Tensor, n: i64) -> Tensor {
-        Tensor::f_eye_out(out, n).unwrap()
+    pub fn f_eye_out(out: &Tensor, n: i64) -> Tensor {
+        Tensor::eye_out(out, n).unwrap()
     }
 
-    pub fn fake_quantize_per_channel_affine(
+    pub fn f_fake_quantize_per_channel_affine(
         &self,
         scale: &Tensor,
         zero_point: &Tensor,
@@ -8038,11 +8035,11 @@ impl Tensor {
         quant_min: i64,
         quant_max: i64,
     ) -> Tensor {
-        self.f_fake_quantize_per_channel_affine(scale, zero_point, axis, quant_min, quant_max)
+        self.fake_quantize_per_channel_affine(scale, zero_point, axis, quant_min, quant_max)
             .unwrap()
     }
 
-    pub fn fake_quantize_per_channel_affine_cachemask(
+    pub fn f_fake_quantize_per_channel_affine_cachemask(
         &self,
         scale: &Tensor,
         zero_point: &Tensor,
@@ -8050,20 +8047,20 @@ impl Tensor {
         quant_min: i64,
         quant_max: i64,
     ) -> (Tensor, Tensor) {
-        self.f_fake_quantize_per_channel_affine_cachemask(
+        self.fake_quantize_per_channel_affine_cachemask(
             scale, zero_point, axis, quant_min, quant_max,
         )
         .unwrap()
     }
 
-    pub fn fake_quantize_per_channel_affine_cachemask_backward(
+    pub fn f_fake_quantize_per_channel_affine_cachemask_backward(
         grad: &Tensor,
         mask: &Tensor,
     ) -> Tensor {
-        Tensor::f_fake_quantize_per_channel_affine_cachemask_backward(grad, mask).unwrap()
+        Tensor::fake_quantize_per_channel_affine_cachemask_backward(grad, mask).unwrap()
     }
 
-    pub fn fake_quantize_per_channel_affine_cachemask_out(
+    pub fn f_fake_quantize_per_channel_affine_cachemask_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -8073,41 +8070,41 @@ impl Tensor {
         quant_min: i64,
         quant_max: i64,
     ) -> (Tensor, Tensor) {
-        self.f_fake_quantize_per_channel_affine_cachemask_out(
+        self.fake_quantize_per_channel_affine_cachemask_out(
             out0, out1, scale, zero_point, axis, quant_min, quant_max,
         )
         .unwrap()
     }
 
-    pub fn fake_quantize_per_tensor_affine(
+    pub fn f_fake_quantize_per_tensor_affine(
         &self,
         scale: f64,
         zero_point: i64,
         quant_min: i64,
         quant_max: i64,
     ) -> Tensor {
-        self.f_fake_quantize_per_tensor_affine(scale, zero_point, quant_min, quant_max).unwrap()
+        self.fake_quantize_per_tensor_affine(scale, zero_point, quant_min, quant_max).unwrap()
     }
 
-    pub fn fake_quantize_per_tensor_affine_cachemask(
+    pub fn f_fake_quantize_per_tensor_affine_cachemask(
         &self,
         scale: f64,
         zero_point: i64,
         quant_min: i64,
         quant_max: i64,
     ) -> (Tensor, Tensor) {
-        self.f_fake_quantize_per_tensor_affine_cachemask(scale, zero_point, quant_min, quant_max)
+        self.fake_quantize_per_tensor_affine_cachemask(scale, zero_point, quant_min, quant_max)
             .unwrap()
     }
 
-    pub fn fake_quantize_per_tensor_affine_cachemask_backward(
+    pub fn f_fake_quantize_per_tensor_affine_cachemask_backward(
         grad: &Tensor,
         mask: &Tensor,
     ) -> Tensor {
-        Tensor::f_fake_quantize_per_tensor_affine_cachemask_backward(grad, mask).unwrap()
+        Tensor::fake_quantize_per_tensor_affine_cachemask_backward(grad, mask).unwrap()
     }
 
-    pub fn fake_quantize_per_tensor_affine_cachemask_out(
+    pub fn f_fake_quantize_per_tensor_affine_cachemask_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -8116,38 +8113,36 @@ impl Tensor {
         quant_min: i64,
         quant_max: i64,
     ) -> (Tensor, Tensor) {
-        self.f_fake_quantize_per_tensor_affine_cachemask_out(
+        self.fake_quantize_per_tensor_affine_cachemask_out(
             out0, out1, scale, zero_point, quant_min, quant_max,
         )
         .unwrap()
     }
 
-    pub fn fake_quantize_per_tensor_affine_tensor_qparams(
+    pub fn f_fake_quantize_per_tensor_affine_tensor_qparams(
         &self,
         scale: &Tensor,
         zero_point: &Tensor,
         quant_min: i64,
         quant_max: i64,
     ) -> Tensor {
-        self.f_fake_quantize_per_tensor_affine_tensor_qparams(
-            scale, zero_point, quant_min, quant_max,
-        )
-        .unwrap()
+        self.fake_quantize_per_tensor_affine_tensor_qparams(scale, zero_point, quant_min, quant_max)
+            .unwrap()
     }
 
-    pub fn fbgemm_linear_fp16_weight(&self, packed_weight: &Tensor, bias: &Tensor) -> Tensor {
-        self.f_fbgemm_linear_fp16_weight(packed_weight, bias).unwrap()
+    pub fn f_fbgemm_linear_fp16_weight(&self, packed_weight: &Tensor, bias: &Tensor) -> Tensor {
+        self.fbgemm_linear_fp16_weight(packed_weight, bias).unwrap()
     }
 
-    pub fn fbgemm_linear_fp16_weight_fp32_activation(
+    pub fn f_fbgemm_linear_fp16_weight_fp32_activation(
         &self,
         packed_weight: &Tensor,
         bias: &Tensor,
     ) -> Tensor {
-        self.f_fbgemm_linear_fp16_weight_fp32_activation(packed_weight, bias).unwrap()
+        self.fbgemm_linear_fp16_weight_fp32_activation(packed_weight, bias).unwrap()
     }
 
-    pub fn fbgemm_linear_int8_weight<S: Into<Scalar>>(
+    pub fn f_fbgemm_linear_int8_weight<S: Into<Scalar>>(
         &self,
         weight: &Tensor,
         packed: &Tensor,
@@ -8156,7 +8151,7 @@ impl Tensor {
         weight_zero_point: S,
         bias: &Tensor,
     ) -> Tensor {
-        self.f_fbgemm_linear_int8_weight(
+        self.fbgemm_linear_int8_weight(
             weight,
             packed,
             col_offsets,
@@ -8167,7 +8162,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn fbgemm_linear_int8_weight_fp32_activation<S: Into<Scalar>>(
+    pub fn f_fbgemm_linear_int8_weight_fp32_activation<S: Into<Scalar>>(
         &self,
         weight: &Tensor,
         packed: &Tensor,
@@ -8176,7 +8171,7 @@ impl Tensor {
         weight_zero_point: S,
         bias: &Tensor,
     ) -> Tensor {
-        self.f_fbgemm_linear_int8_weight_fp32_activation(
+        self.fbgemm_linear_int8_weight_fp32_activation(
             weight,
             packed,
             col_offsets,
@@ -8187,519 +8182,543 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn fbgemm_pack_gemm_matrix_fp16(&self) -> Tensor {
-        self.f_fbgemm_pack_gemm_matrix_fp16().unwrap()
+    pub fn f_fbgemm_pack_gemm_matrix_fp16(&self) -> Tensor {
+        self.fbgemm_pack_gemm_matrix_fp16().unwrap()
     }
 
-    pub fn fbgemm_pack_quantized_matrix(&self) -> Tensor {
-        self.f_fbgemm_pack_quantized_matrix().unwrap()
+    pub fn f_fbgemm_pack_quantized_matrix(&self) -> Tensor {
+        self.fbgemm_pack_quantized_matrix().unwrap()
     }
 
-    pub fn fbgemm_pack_quantized_matrix_kn(&self, k: i64, n: i64) -> Tensor {
-        self.f_fbgemm_pack_quantized_matrix_kn(k, n).unwrap()
+    pub fn f_fbgemm_pack_quantized_matrix_kn(&self, k: i64, n: i64) -> Tensor {
+        self.fbgemm_pack_quantized_matrix_kn(k, n).unwrap()
     }
 
-    pub fn feature_alpha_dropout(&self, p: f64, train: bool) -> Tensor {
-        self.f_feature_alpha_dropout(p, train).unwrap()
+    pub fn f_feature_alpha_dropout(&self, p: f64, train: bool) -> Tensor {
+        self.feature_alpha_dropout(p, train).unwrap()
     }
 
-    pub fn feature_alpha_dropout_(&mut self, p: f64, train: bool) -> Tensor {
-        self.f_feature_alpha_dropout_(p, train).unwrap()
+    pub fn f_feature_alpha_dropout_(&mut self, p: f64, train: bool) -> Tensor {
+        self.feature_alpha_dropout_(p, train).unwrap()
     }
 
-    pub fn feature_dropout(&self, p: f64, train: bool) -> Tensor {
-        self.f_feature_dropout(p, train).unwrap()
+    pub fn f_feature_dropout(&self, p: f64, train: bool) -> Tensor {
+        self.feature_dropout(p, train).unwrap()
     }
 
-    pub fn feature_dropout_(&mut self, p: f64, train: bool) -> Tensor {
-        self.f_feature_dropout_(p, train).unwrap()
+    pub fn f_feature_dropout_(&mut self, p: f64, train: bool) -> Tensor {
+        self.feature_dropout_(p, train).unwrap()
     }
 
-    pub fn fft_fft(&self, n: impl Into<Option<i64>>, dim: i64, norm: &str) -> Tensor {
-        self.f_fft_fft(n, dim, norm).unwrap()
+    pub fn f_fft_fft(&self, n: impl Into<Option<i64>>, dim: i64, norm: &str) -> Tensor {
+        self.fft_fft(n, dim, norm).unwrap()
     }
 
-    pub fn fft_fft2(&self, s: impl IntListOption, dim: impl IntList, norm: &str) -> Tensor {
-        self.f_fft_fft2(s, dim, norm).unwrap()
+    pub fn f_fft_fft2(&self, s: impl IntListOption, dim: impl IntList, norm: &str) -> Tensor {
+        self.fft_fft2(s, dim, norm).unwrap()
     }
 
-    pub fn fft_fft2_out(
+    pub fn f_fft_fft2_out(
         &self,
         out: &Tensor,
         s: impl IntListOption,
         dim: impl IntList,
         norm: &str,
     ) -> Tensor {
-        self.f_fft_fft2_out(out, s, dim, norm).unwrap()
+        self.fft_fft2_out(out, s, dim, norm).unwrap()
     }
 
-    pub fn fft_fft_out(
+    pub fn f_fft_fft_out(
         &self,
         out: &Tensor,
         n: impl Into<Option<i64>>,
         dim: i64,
         norm: &str,
     ) -> Tensor {
-        self.f_fft_fft_out(out, n, dim, norm).unwrap()
+        self.fft_fft_out(out, n, dim, norm).unwrap()
     }
 
-    pub fn fft_fftfreq(n: i64, d: f64, options: (Kind, Device)) -> Tensor {
-        Tensor::f_fft_fftfreq(n, d, options).unwrap()
+    pub fn f_fft_fftfreq(n: i64, d: f64, options: (Kind, Device)) -> Tensor {
+        Tensor::fft_fftfreq(n, d, options).unwrap()
     }
 
-    pub fn fft_fftfreq_out(out: &Tensor, n: i64, d: f64) -> Tensor {
-        Tensor::f_fft_fftfreq_out(out, n, d).unwrap()
+    pub fn f_fft_fftfreq_out(out: &Tensor, n: i64, d: f64) -> Tensor {
+        Tensor::fft_fftfreq_out(out, n, d).unwrap()
     }
 
-    pub fn fft_fftn(&self, s: impl IntListOption, dim: impl IntListOption, norm: &str) -> Tensor {
-        self.f_fft_fftn(s, dim, norm).unwrap()
+    pub fn f_fft_fftn(&self, s: impl IntListOption, dim: impl IntListOption, norm: &str) -> Tensor {
+        self.fft_fftn(s, dim, norm).unwrap()
     }
 
-    pub fn fft_fftn_out(
+    pub fn f_fft_fftn_out(
         &self,
         out: &Tensor,
         s: impl IntListOption,
         dim: impl IntListOption,
         norm: &str,
     ) -> Tensor {
-        self.f_fft_fftn_out(out, s, dim, norm).unwrap()
+        self.fft_fftn_out(out, s, dim, norm).unwrap()
     }
 
-    pub fn fft_fftshift(&self, dim: impl IntListOption) -> Tensor {
-        self.f_fft_fftshift(dim).unwrap()
+    pub fn f_fft_fftshift(&self, dim: impl IntListOption) -> Tensor {
+        self.fft_fftshift(dim).unwrap()
     }
 
-    pub fn fft_hfft(&self, n: impl Into<Option<i64>>, dim: i64, norm: &str) -> Tensor {
-        self.f_fft_hfft(n, dim, norm).unwrap()
+    pub fn f_fft_hfft(&self, n: impl Into<Option<i64>>, dim: i64, norm: &str) -> Tensor {
+        self.fft_hfft(n, dim, norm).unwrap()
     }
 
-    pub fn fft_hfft2(&self, s: impl IntListOption, dim: impl IntList, norm: &str) -> Tensor {
-        self.f_fft_hfft2(s, dim, norm).unwrap()
+    pub fn f_fft_hfft2(&self, s: impl IntListOption, dim: impl IntList, norm: &str) -> Tensor {
+        self.fft_hfft2(s, dim, norm).unwrap()
     }
 
-    pub fn fft_hfft2_out(
+    pub fn f_fft_hfft2_out(
         &self,
         out: &Tensor,
         s: impl IntListOption,
         dim: impl IntList,
         norm: &str,
     ) -> Tensor {
-        self.f_fft_hfft2_out(out, s, dim, norm).unwrap()
+        self.fft_hfft2_out(out, s, dim, norm).unwrap()
     }
 
-    pub fn fft_hfft_out(
+    pub fn f_fft_hfft_out(
         &self,
         out: &Tensor,
         n: impl Into<Option<i64>>,
         dim: i64,
         norm: &str,
     ) -> Tensor {
-        self.f_fft_hfft_out(out, n, dim, norm).unwrap()
+        self.fft_hfft_out(out, n, dim, norm).unwrap()
     }
 
-    pub fn fft_hfftn(&self, s: impl IntListOption, dim: impl IntListOption, norm: &str) -> Tensor {
-        self.f_fft_hfftn(s, dim, norm).unwrap()
+    pub fn f_fft_hfftn(
+        &self,
+        s: impl IntListOption,
+        dim: impl IntListOption,
+        norm: &str,
+    ) -> Tensor {
+        self.fft_hfftn(s, dim, norm).unwrap()
     }
 
-    pub fn fft_hfftn_out(
+    pub fn f_fft_hfftn_out(
         &self,
         out: &Tensor,
         s: impl IntListOption,
         dim: impl IntListOption,
         norm: &str,
     ) -> Tensor {
-        self.f_fft_hfftn_out(out, s, dim, norm).unwrap()
+        self.fft_hfftn_out(out, s, dim, norm).unwrap()
     }
 
-    pub fn fft_ifft(&self, n: impl Into<Option<i64>>, dim: i64, norm: &str) -> Tensor {
-        self.f_fft_ifft(n, dim, norm).unwrap()
+    pub fn f_fft_ifft(&self, n: impl Into<Option<i64>>, dim: i64, norm: &str) -> Tensor {
+        self.fft_ifft(n, dim, norm).unwrap()
     }
 
-    pub fn fft_ifft2(&self, s: impl IntListOption, dim: impl IntList, norm: &str) -> Tensor {
-        self.f_fft_ifft2(s, dim, norm).unwrap()
+    pub fn f_fft_ifft2(&self, s: impl IntListOption, dim: impl IntList, norm: &str) -> Tensor {
+        self.fft_ifft2(s, dim, norm).unwrap()
     }
 
-    pub fn fft_ifft2_out(
+    pub fn f_fft_ifft2_out(
         &self,
         out: &Tensor,
         s: impl IntListOption,
         dim: impl IntList,
         norm: &str,
     ) -> Tensor {
-        self.f_fft_ifft2_out(out, s, dim, norm).unwrap()
+        self.fft_ifft2_out(out, s, dim, norm).unwrap()
     }
 
-    pub fn fft_ifft_out(
+    pub fn f_fft_ifft_out(
         &self,
         out: &Tensor,
         n: impl Into<Option<i64>>,
         dim: i64,
         norm: &str,
     ) -> Tensor {
-        self.f_fft_ifft_out(out, n, dim, norm).unwrap()
+        self.fft_ifft_out(out, n, dim, norm).unwrap()
     }
 
-    pub fn fft_ifftn(&self, s: impl IntListOption, dim: impl IntListOption, norm: &str) -> Tensor {
-        self.f_fft_ifftn(s, dim, norm).unwrap()
+    pub fn f_fft_ifftn(
+        &self,
+        s: impl IntListOption,
+        dim: impl IntListOption,
+        norm: &str,
+    ) -> Tensor {
+        self.fft_ifftn(s, dim, norm).unwrap()
     }
 
-    pub fn fft_ifftn_out(
+    pub fn f_fft_ifftn_out(
         &self,
         out: &Tensor,
         s: impl IntListOption,
         dim: impl IntListOption,
         norm: &str,
     ) -> Tensor {
-        self.f_fft_ifftn_out(out, s, dim, norm).unwrap()
+        self.fft_ifftn_out(out, s, dim, norm).unwrap()
     }
 
-    pub fn fft_ifftshift(&self, dim: impl IntListOption) -> Tensor {
-        self.f_fft_ifftshift(dim).unwrap()
+    pub fn f_fft_ifftshift(&self, dim: impl IntListOption) -> Tensor {
+        self.fft_ifftshift(dim).unwrap()
     }
 
-    pub fn fft_ihfft(&self, n: impl Into<Option<i64>>, dim: i64, norm: &str) -> Tensor {
-        self.f_fft_ihfft(n, dim, norm).unwrap()
+    pub fn f_fft_ihfft(&self, n: impl Into<Option<i64>>, dim: i64, norm: &str) -> Tensor {
+        self.fft_ihfft(n, dim, norm).unwrap()
     }
 
-    pub fn fft_ihfft2(&self, s: impl IntListOption, dim: impl IntList, norm: &str) -> Tensor {
-        self.f_fft_ihfft2(s, dim, norm).unwrap()
+    pub fn f_fft_ihfft2(&self, s: impl IntListOption, dim: impl IntList, norm: &str) -> Tensor {
+        self.fft_ihfft2(s, dim, norm).unwrap()
     }
 
-    pub fn fft_ihfft2_out(
+    pub fn f_fft_ihfft2_out(
         &self,
         out: &Tensor,
         s: impl IntListOption,
         dim: impl IntList,
         norm: &str,
     ) -> Tensor {
-        self.f_fft_ihfft2_out(out, s, dim, norm).unwrap()
+        self.fft_ihfft2_out(out, s, dim, norm).unwrap()
     }
 
-    pub fn fft_ihfft_out(
+    pub fn f_fft_ihfft_out(
         &self,
         out: &Tensor,
         n: impl Into<Option<i64>>,
         dim: i64,
         norm: &str,
     ) -> Tensor {
-        self.f_fft_ihfft_out(out, n, dim, norm).unwrap()
+        self.fft_ihfft_out(out, n, dim, norm).unwrap()
     }
 
-    pub fn fft_ihfftn(&self, s: impl IntListOption, dim: impl IntListOption, norm: &str) -> Tensor {
-        self.f_fft_ihfftn(s, dim, norm).unwrap()
+    pub fn f_fft_ihfftn(
+        &self,
+        s: impl IntListOption,
+        dim: impl IntListOption,
+        norm: &str,
+    ) -> Tensor {
+        self.fft_ihfftn(s, dim, norm).unwrap()
     }
 
-    pub fn fft_ihfftn_out(
+    pub fn f_fft_ihfftn_out(
         &self,
         out: &Tensor,
         s: impl IntListOption,
         dim: impl IntListOption,
         norm: &str,
     ) -> Tensor {
-        self.f_fft_ihfftn_out(out, s, dim, norm).unwrap()
+        self.fft_ihfftn_out(out, s, dim, norm).unwrap()
     }
 
-    pub fn fft_irfft(&self, n: impl Into<Option<i64>>, dim: i64, norm: &str) -> Tensor {
-        self.f_fft_irfft(n, dim, norm).unwrap()
+    pub fn f_fft_irfft(&self, n: impl Into<Option<i64>>, dim: i64, norm: &str) -> Tensor {
+        self.fft_irfft(n, dim, norm).unwrap()
     }
 
-    pub fn fft_irfft2(&self, s: impl IntListOption, dim: impl IntList, norm: &str) -> Tensor {
-        self.f_fft_irfft2(s, dim, norm).unwrap()
+    pub fn f_fft_irfft2(&self, s: impl IntListOption, dim: impl IntList, norm: &str) -> Tensor {
+        self.fft_irfft2(s, dim, norm).unwrap()
     }
 
-    pub fn fft_irfft2_out(
+    pub fn f_fft_irfft2_out(
         &self,
         out: &Tensor,
         s: impl IntListOption,
         dim: impl IntList,
         norm: &str,
     ) -> Tensor {
-        self.f_fft_irfft2_out(out, s, dim, norm).unwrap()
+        self.fft_irfft2_out(out, s, dim, norm).unwrap()
     }
 
-    pub fn fft_irfft_out(
+    pub fn f_fft_irfft_out(
         &self,
         out: &Tensor,
         n: impl Into<Option<i64>>,
         dim: i64,
         norm: &str,
     ) -> Tensor {
-        self.f_fft_irfft_out(out, n, dim, norm).unwrap()
+        self.fft_irfft_out(out, n, dim, norm).unwrap()
     }
 
-    pub fn fft_irfftn(&self, s: impl IntListOption, dim: impl IntListOption, norm: &str) -> Tensor {
-        self.f_fft_irfftn(s, dim, norm).unwrap()
+    pub fn f_fft_irfftn(
+        &self,
+        s: impl IntListOption,
+        dim: impl IntListOption,
+        norm: &str,
+    ) -> Tensor {
+        self.fft_irfftn(s, dim, norm).unwrap()
     }
 
-    pub fn fft_irfftn_out(
+    pub fn f_fft_irfftn_out(
         &self,
         out: &Tensor,
         s: impl IntListOption,
         dim: impl IntListOption,
         norm: &str,
     ) -> Tensor {
-        self.f_fft_irfftn_out(out, s, dim, norm).unwrap()
+        self.fft_irfftn_out(out, s, dim, norm).unwrap()
     }
 
-    pub fn fft_rfft(&self, n: impl Into<Option<i64>>, dim: i64, norm: &str) -> Tensor {
-        self.f_fft_rfft(n, dim, norm).unwrap()
+    pub fn f_fft_rfft(&self, n: impl Into<Option<i64>>, dim: i64, norm: &str) -> Tensor {
+        self.fft_rfft(n, dim, norm).unwrap()
     }
 
-    pub fn fft_rfft2(&self, s: impl IntListOption, dim: impl IntList, norm: &str) -> Tensor {
-        self.f_fft_rfft2(s, dim, norm).unwrap()
+    pub fn f_fft_rfft2(&self, s: impl IntListOption, dim: impl IntList, norm: &str) -> Tensor {
+        self.fft_rfft2(s, dim, norm).unwrap()
     }
 
-    pub fn fft_rfft2_out(
+    pub fn f_fft_rfft2_out(
         &self,
         out: &Tensor,
         s: impl IntListOption,
         dim: impl IntList,
         norm: &str,
     ) -> Tensor {
-        self.f_fft_rfft2_out(out, s, dim, norm).unwrap()
+        self.fft_rfft2_out(out, s, dim, norm).unwrap()
     }
 
-    pub fn fft_rfft_out(
+    pub fn f_fft_rfft_out(
         &self,
         out: &Tensor,
         n: impl Into<Option<i64>>,
         dim: i64,
         norm: &str,
     ) -> Tensor {
-        self.f_fft_rfft_out(out, n, dim, norm).unwrap()
+        self.fft_rfft_out(out, n, dim, norm).unwrap()
     }
 
-    pub fn fft_rfftfreq(n: i64, d: f64, options: (Kind, Device)) -> Tensor {
-        Tensor::f_fft_rfftfreq(n, d, options).unwrap()
+    pub fn f_fft_rfftfreq(n: i64, d: f64, options: (Kind, Device)) -> Tensor {
+        Tensor::fft_rfftfreq(n, d, options).unwrap()
     }
 
-    pub fn fft_rfftfreq_out(out: &Tensor, n: i64, d: f64) -> Tensor {
-        Tensor::f_fft_rfftfreq_out(out, n, d).unwrap()
+    pub fn f_fft_rfftfreq_out(out: &Tensor, n: i64, d: f64) -> Tensor {
+        Tensor::fft_rfftfreq_out(out, n, d).unwrap()
     }
 
-    pub fn fft_rfftn(&self, s: impl IntListOption, dim: impl IntListOption, norm: &str) -> Tensor {
-        self.f_fft_rfftn(s, dim, norm).unwrap()
+    pub fn f_fft_rfftn(
+        &self,
+        s: impl IntListOption,
+        dim: impl IntListOption,
+        norm: &str,
+    ) -> Tensor {
+        self.fft_rfftn(s, dim, norm).unwrap()
     }
 
-    pub fn fft_rfftn_out(
+    pub fn f_fft_rfftn_out(
         &self,
         out: &Tensor,
         s: impl IntListOption,
         dim: impl IntListOption,
         norm: &str,
     ) -> Tensor {
-        self.f_fft_rfftn_out(out, s, dim, norm).unwrap()
+        self.fft_rfftn_out(out, s, dim, norm).unwrap()
     }
 
-    pub fn fill<S: Into<Scalar>>(&self, value: S) -> Tensor {
-        self.f_fill(value).unwrap()
+    pub fn f_fill<S: Into<Scalar>>(&self, value: S) -> Tensor {
+        self.fill(value).unwrap()
     }
 
-    pub fn fill_<S: Into<Scalar>>(&mut self, value: S) -> Tensor {
-        self.f_fill_(value).unwrap()
+    pub fn f_fill_<S: Into<Scalar>>(&mut self, value: S) -> Tensor {
+        self.fill_(value).unwrap()
     }
 
-    pub fn fill_diagonal_<S: Into<Scalar>>(&mut self, fill_value: S, wrap: bool) -> Tensor {
-        self.f_fill_diagonal_(fill_value, wrap).unwrap()
+    pub fn f_fill_diagonal_<S: Into<Scalar>>(&mut self, fill_value: S, wrap: bool) -> Tensor {
+        self.fill_diagonal_(fill_value, wrap).unwrap()
     }
 
-    pub fn fill_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, value: S) -> Tensor {
-        self.f_fill_scalar_out(out, value).unwrap()
+    pub fn f_fill_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, value: S) -> Tensor {
+        self.fill_scalar_out(out, value).unwrap()
     }
 
-    pub fn fill_tensor(&self, value: &Tensor) -> Tensor {
-        self.f_fill_tensor(value).unwrap()
+    pub fn f_fill_tensor(&self, value: &Tensor) -> Tensor {
+        self.fill_tensor(value).unwrap()
     }
 
-    pub fn fill_tensor_(&mut self, value: &Tensor) -> Tensor {
-        self.f_fill_tensor_(value).unwrap()
+    pub fn f_fill_tensor_(&mut self, value: &Tensor) -> Tensor {
+        self.fill_tensor_(value).unwrap()
     }
 
-    pub fn fill_tensor_out(&self, out: &Tensor, value: &Tensor) -> Tensor {
-        self.f_fill_tensor_out(out, value).unwrap()
+    pub fn f_fill_tensor_out(&self, out: &Tensor, value: &Tensor) -> Tensor {
+        self.fill_tensor_out(out, value).unwrap()
     }
 
-    pub fn fix(&self) -> Tensor {
-        self.f_fix().unwrap()
+    pub fn f_fix(&self) -> Tensor {
+        self.fix().unwrap()
     }
 
-    pub fn fix_(&mut self) -> Tensor {
-        self.f_fix_().unwrap()
+    pub fn f_fix_(&mut self) -> Tensor {
+        self.fix_().unwrap()
     }
 
-    pub fn fix_out(&self, out: &Tensor) -> Tensor {
-        self.f_fix_out(out).unwrap()
+    pub fn f_fix_out(&self, out: &Tensor) -> Tensor {
+        self.fix_out(out).unwrap()
     }
 
-    pub fn flatten(&self, start_dim: i64, end_dim: i64) -> Tensor {
-        self.f_flatten(start_dim, end_dim).unwrap()
+    pub fn f_flatten(&self, start_dim: i64, end_dim: i64) -> Tensor {
+        self.flatten(start_dim, end_dim).unwrap()
     }
 
-    pub fn flatten_dense_tensors<T: Borrow<Tensor>>(tensors: &[T]) -> Tensor {
-        Tensor::f_flatten_dense_tensors(tensors).unwrap()
+    pub fn f_flatten_dense_tensors<T: Borrow<Tensor>>(tensors: &[T]) -> Tensor {
+        Tensor::flatten_dense_tensors(tensors).unwrap()
     }
 
-    pub fn flip(&self, dims: impl IntList) -> Tensor {
-        self.f_flip(dims).unwrap()
+    pub fn f_flip(&self, dims: impl IntList) -> Tensor {
+        self.flip(dims).unwrap()
     }
 
-    pub fn flip_out(&self, out: &Tensor, dims: impl IntList) -> Tensor {
-        self.f_flip_out(out, dims).unwrap()
+    pub fn f_flip_out(&self, out: &Tensor, dims: impl IntList) -> Tensor {
+        self.flip_out(out, dims).unwrap()
     }
 
-    pub fn fliplr(&self) -> Tensor {
-        self.f_fliplr().unwrap()
+    pub fn f_fliplr(&self) -> Tensor {
+        self.fliplr().unwrap()
     }
 
-    pub fn flipud(&self) -> Tensor {
-        self.f_flipud().unwrap()
+    pub fn f_flipud(&self) -> Tensor {
+        self.flipud().unwrap()
     }
 
-    pub fn float_power(&self, exponent: &Tensor) -> Tensor {
-        self.f_float_power(exponent).unwrap()
+    pub fn f_float_power(&self, exponent: &Tensor) -> Tensor {
+        self.float_power(exponent).unwrap()
     }
 
-    pub fn float_power_<S: Into<Scalar>>(&mut self, exponent: S) -> Tensor {
-        self.f_float_power_(exponent).unwrap()
+    pub fn f_float_power_<S: Into<Scalar>>(&mut self, exponent: S) -> Tensor {
+        self.float_power_(exponent).unwrap()
     }
 
-    pub fn float_power_scalar<S: Into<Scalar>>(self_scalar: S, exponent: &Tensor) -> Tensor {
-        Tensor::f_float_power_scalar(self_scalar, exponent).unwrap()
+    pub fn f_float_power_scalar<S: Into<Scalar>>(self_scalar: S, exponent: &Tensor) -> Tensor {
+        Tensor::float_power_scalar(self_scalar, exponent).unwrap()
     }
 
-    pub fn float_power_scalar_out<S: Into<Scalar>>(
+    pub fn f_float_power_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         self_scalar: S,
         exponent: &Tensor,
     ) -> Tensor {
-        Tensor::f_float_power_scalar_out(out, self_scalar, exponent).unwrap()
+        Tensor::float_power_scalar_out(out, self_scalar, exponent).unwrap()
     }
 
-    pub fn float_power_tensor_(&mut self, exponent: &Tensor) -> Tensor {
-        self.f_float_power_tensor_(exponent).unwrap()
+    pub fn f_float_power_tensor_(&mut self, exponent: &Tensor) -> Tensor {
+        self.float_power_tensor_(exponent).unwrap()
     }
 
-    pub fn float_power_tensor_scalar<S: Into<Scalar>>(&self, exponent: S) -> Tensor {
-        self.f_float_power_tensor_scalar(exponent).unwrap()
+    pub fn f_float_power_tensor_scalar<S: Into<Scalar>>(&self, exponent: S) -> Tensor {
+        self.float_power_tensor_scalar(exponent).unwrap()
     }
 
-    pub fn float_power_tensor_scalar_out<S: Into<Scalar>>(
+    pub fn f_float_power_tensor_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         exponent: S,
     ) -> Tensor {
-        self.f_float_power_tensor_scalar_out(out, exponent).unwrap()
+        self.float_power_tensor_scalar_out(out, exponent).unwrap()
     }
 
-    pub fn float_power_tensor_tensor_out(&self, out: &Tensor, exponent: &Tensor) -> Tensor {
-        self.f_float_power_tensor_tensor_out(out, exponent).unwrap()
+    pub fn f_float_power_tensor_tensor_out(&self, out: &Tensor, exponent: &Tensor) -> Tensor {
+        self.float_power_tensor_tensor_out(out, exponent).unwrap()
     }
 
-    pub fn floor(&self) -> Tensor {
-        self.f_floor().unwrap()
+    pub fn f_floor(&self) -> Tensor {
+        self.floor().unwrap()
     }
 
-    pub fn floor_(&mut self) -> Tensor {
-        self.f_floor_().unwrap()
+    pub fn f_floor_(&mut self) -> Tensor {
+        self.floor_().unwrap()
     }
 
-    pub fn floor_divide(&self, other: &Tensor) -> Tensor {
-        self.f_floor_divide(other).unwrap()
+    pub fn f_floor_divide(&self, other: &Tensor) -> Tensor {
+        self.floor_divide(other).unwrap()
     }
 
-    pub fn floor_divide_(&mut self, other: &Tensor) -> Tensor {
-        self.f_floor_divide_(other).unwrap()
+    pub fn f_floor_divide_(&mut self, other: &Tensor) -> Tensor {
+        self.floor_divide_(other).unwrap()
     }
 
-    pub fn floor_divide_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_floor_divide_out(out, other).unwrap()
+    pub fn f_floor_divide_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.floor_divide_out(out, other).unwrap()
     }
 
-    pub fn floor_divide_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_floor_divide_scalar(other).unwrap()
+    pub fn f_floor_divide_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.floor_divide_scalar(other).unwrap()
     }
 
-    pub fn floor_divide_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_floor_divide_scalar_(other).unwrap()
+    pub fn f_floor_divide_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.floor_divide_scalar_(other).unwrap()
     }
 
-    pub fn floor_out(&self, out: &Tensor) -> Tensor {
-        self.f_floor_out(out).unwrap()
+    pub fn f_floor_out(&self, out: &Tensor) -> Tensor {
+        self.floor_out(out).unwrap()
     }
 
-    pub fn fmax(&self, other: &Tensor) -> Tensor {
-        self.f_fmax(other).unwrap()
+    pub fn f_fmax(&self, other: &Tensor) -> Tensor {
+        self.fmax(other).unwrap()
     }
 
-    pub fn fmax_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_fmax_out(out, other).unwrap()
+    pub fn f_fmax_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.fmax_out(out, other).unwrap()
     }
 
-    pub fn fmin(&self, other: &Tensor) -> Tensor {
-        self.f_fmin(other).unwrap()
+    pub fn f_fmin(&self, other: &Tensor) -> Tensor {
+        self.fmin(other).unwrap()
     }
 
-    pub fn fmin_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_fmin_out(out, other).unwrap()
+    pub fn f_fmin_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.fmin_out(out, other).unwrap()
     }
 
-    pub fn fmod<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_fmod(other).unwrap()
+    pub fn f_fmod<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.fmod(other).unwrap()
     }
 
-    pub fn fmod_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_fmod_(other).unwrap()
+    pub fn f_fmod_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.fmod_(other).unwrap()
     }
 
-    pub fn fmod_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
-        self.f_fmod_scalar_out(out, other).unwrap()
+    pub fn f_fmod_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
+        self.fmod_scalar_out(out, other).unwrap()
     }
 
-    pub fn fmod_tensor(&self, other: &Tensor) -> Tensor {
-        self.f_fmod_tensor(other).unwrap()
+    pub fn f_fmod_tensor(&self, other: &Tensor) -> Tensor {
+        self.fmod_tensor(other).unwrap()
     }
 
-    pub fn fmod_tensor_(&mut self, other: &Tensor) -> Tensor {
-        self.f_fmod_tensor_(other).unwrap()
+    pub fn f_fmod_tensor_(&mut self, other: &Tensor) -> Tensor {
+        self.fmod_tensor_(other).unwrap()
     }
 
-    pub fn fmod_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_fmod_tensor_out(out, other).unwrap()
+    pub fn f_fmod_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.fmod_tensor_out(out, other).unwrap()
     }
 
-    pub fn frac(&self) -> Tensor {
-        self.f_frac().unwrap()
+    pub fn f_frac(&self) -> Tensor {
+        self.frac().unwrap()
     }
 
-    pub fn frac_(&mut self) -> Tensor {
-        self.f_frac_().unwrap()
+    pub fn f_frac_(&mut self) -> Tensor {
+        self.frac_().unwrap()
     }
 
-    pub fn frac_out(&self, out: &Tensor) -> Tensor {
-        self.f_frac_out(out).unwrap()
+    pub fn f_frac_out(&self, out: &Tensor) -> Tensor {
+        self.frac_out(out).unwrap()
     }
 
-    pub fn fractional_max_pool2d(
+    pub fn f_fractional_max_pool2d(
         &self,
         kernel_size: impl IntList,
         output_size: impl IntList,
         random_samples: &Tensor,
     ) -> (Tensor, Tensor) {
-        self.f_fractional_max_pool2d(kernel_size, output_size, random_samples).unwrap()
+        self.fractional_max_pool2d(kernel_size, output_size, random_samples).unwrap()
     }
 
-    pub fn fractional_max_pool2d_backward(
+    pub fn f_fractional_max_pool2d_backward(
         &self,
         grad_output: &Tensor,
         kernel_size: impl IntList,
         output_size: impl IntList,
         indices: &Tensor,
     ) -> Tensor {
-        self.f_fractional_max_pool2d_backward(grad_output, kernel_size, output_size, indices)
-            .unwrap()
+        self.fractional_max_pool2d_backward(grad_output, kernel_size, output_size, indices).unwrap()
     }
 
-    pub fn fractional_max_pool2d_backward_grad_input(
+    pub fn f_fractional_max_pool2d_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -8707,7 +8726,7 @@ impl Tensor {
         output_size: impl IntList,
         indices: &Tensor,
     ) -> Tensor {
-        self.f_fractional_max_pool2d_backward_grad_input(
+        self.fractional_max_pool2d_backward_grad_input(
             grad_input,
             grad_output,
             kernel_size,
@@ -8717,7 +8736,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn fractional_max_pool2d_output(
+    pub fn f_fractional_max_pool2d_output(
         &self,
         output: &Tensor,
         indices: &Tensor,
@@ -8725,37 +8744,30 @@ impl Tensor {
         output_size: impl IntList,
         random_samples: &Tensor,
     ) -> (Tensor, Tensor) {
-        self.f_fractional_max_pool2d_output(
-            output,
-            indices,
-            kernel_size,
-            output_size,
-            random_samples,
-        )
-        .unwrap()
+        self.fractional_max_pool2d_output(output, indices, kernel_size, output_size, random_samples)
+            .unwrap()
     }
 
-    pub fn fractional_max_pool3d(
+    pub fn f_fractional_max_pool3d(
         &self,
         kernel_size: impl IntList,
         output_size: impl IntList,
         random_samples: &Tensor,
     ) -> (Tensor, Tensor) {
-        self.f_fractional_max_pool3d(kernel_size, output_size, random_samples).unwrap()
+        self.fractional_max_pool3d(kernel_size, output_size, random_samples).unwrap()
     }
 
-    pub fn fractional_max_pool3d_backward(
+    pub fn f_fractional_max_pool3d_backward(
         &self,
         grad_output: &Tensor,
         kernel_size: impl IntList,
         output_size: impl IntList,
         indices: &Tensor,
     ) -> Tensor {
-        self.f_fractional_max_pool3d_backward(grad_output, kernel_size, output_size, indices)
-            .unwrap()
+        self.fractional_max_pool3d_backward(grad_output, kernel_size, output_size, indices).unwrap()
     }
 
-    pub fn fractional_max_pool3d_backward_grad_input(
+    pub fn f_fractional_max_pool3d_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -8763,7 +8775,7 @@ impl Tensor {
         output_size: impl IntList,
         indices: &Tensor,
     ) -> Tensor {
-        self.f_fractional_max_pool3d_backward_grad_input(
+        self.fractional_max_pool3d_backward_grad_input(
             grad_input,
             grad_output,
             kernel_size,
@@ -8773,7 +8785,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn fractional_max_pool3d_output(
+    pub fn f_fractional_max_pool3d_output(
         &self,
         output: &Tensor,
         indices: &Tensor,
@@ -8781,71 +8793,65 @@ impl Tensor {
         output_size: impl IntList,
         random_samples: &Tensor,
     ) -> (Tensor, Tensor) {
-        self.f_fractional_max_pool3d_output(
-            output,
-            indices,
-            kernel_size,
-            output_size,
-            random_samples,
-        )
-        .unwrap()
+        self.fractional_max_pool3d_output(output, indices, kernel_size, output_size, random_samples)
+            .unwrap()
     }
 
-    pub fn frexp(&self) -> (Tensor, Tensor) {
-        self.f_frexp().unwrap()
+    pub fn f_frexp(&self) -> (Tensor, Tensor) {
+        self.frexp().unwrap()
     }
 
-    pub fn frexp_tensor_out(&self, mantissa: &Tensor, exponent: &Tensor) -> (Tensor, Tensor) {
-        self.f_frexp_tensor_out(mantissa, exponent).unwrap()
+    pub fn f_frexp_tensor_out(&self, mantissa: &Tensor, exponent: &Tensor) -> (Tensor, Tensor) {
+        self.frexp_tensor_out(mantissa, exponent).unwrap()
     }
 
-    pub fn frobenius_norm(&self, dim: impl IntList, keepdim: bool) -> Tensor {
-        self.f_frobenius_norm(dim, keepdim).unwrap()
+    pub fn f_frobenius_norm(&self, dim: impl IntList, keepdim: bool) -> Tensor {
+        self.frobenius_norm(dim, keepdim).unwrap()
     }
 
-    pub fn frobenius_norm_out(&self, out: &Tensor, dim: impl IntList, keepdim: bool) -> Tensor {
-        self.f_frobenius_norm_out(out, dim, keepdim).unwrap()
+    pub fn f_frobenius_norm_out(&self, out: &Tensor, dim: impl IntList, keepdim: bool) -> Tensor {
+        self.frobenius_norm_out(out, dim, keepdim).unwrap()
     }
 
-    pub fn from_file(
+    pub fn f_from_file(
         filename: &str,
         shared: bool,
         size: impl Into<Option<i64>>,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_from_file(filename, shared, size, options).unwrap()
+        Tensor::from_file(filename, shared, size, options).unwrap()
     }
 
-    pub fn from_file_out(
+    pub fn f_from_file_out(
         out: &Tensor,
         filename: &str,
         shared: bool,
         size: impl Into<Option<i64>>,
     ) -> Tensor {
-        Tensor::f_from_file_out(out, filename, shared, size).unwrap()
+        Tensor::from_file_out(out, filename, shared, size).unwrap()
     }
 
-    pub fn full<S: Into<Scalar>>(
+    pub fn f_full<S: Into<Scalar>>(
         size: impl IntList,
         fill_value: S,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_full(size, fill_value, options).unwrap()
+        Tensor::full(size, fill_value, options).unwrap()
     }
 
-    pub fn full_like<S: Into<Scalar>>(&self, fill_value: S) -> Tensor {
-        self.f_full_like(fill_value).unwrap()
+    pub fn f_full_like<S: Into<Scalar>>(&self, fill_value: S) -> Tensor {
+        self.full_like(fill_value).unwrap()
     }
 
-    pub fn full_like_out<S: Into<Scalar>>(&self, out: &Tensor, fill_value: S) -> Tensor {
-        self.f_full_like_out(out, fill_value).unwrap()
+    pub fn f_full_like_out<S: Into<Scalar>>(&self, out: &Tensor, fill_value: S) -> Tensor {
+        self.full_like_out(out, fill_value).unwrap()
     }
 
-    pub fn full_out<S: Into<Scalar>>(out: &Tensor, size: impl IntList, fill_value: S) -> Tensor {
-        Tensor::f_full_out(out, size, fill_value).unwrap()
+    pub fn f_full_out<S: Into<Scalar>>(out: &Tensor, size: impl IntList, fill_value: S) -> Tensor {
+        Tensor::full_out(out, size, fill_value).unwrap()
     }
 
-    pub fn fused_moving_avg_obs_fake_quant(
+    pub fn f_fused_moving_avg_obs_fake_quant(
         &self,
         observer_on: &Tensor,
         fake_quant_on: &Tensor,
@@ -8860,7 +8866,7 @@ impl Tensor {
         per_row_fake_quant: bool,
         symmetric_quant: bool,
     ) -> Tensor {
-        self.f_fused_moving_avg_obs_fake_quant(
+        self.fused_moving_avg_obs_fake_quant(
             observer_on,
             fake_quant_on,
             running_min,
@@ -8877,131 +8883,137 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn gather(&self, dim: i64, index: &Tensor, sparse_grad: bool) -> Tensor {
-        self.f_gather(dim, index, sparse_grad).unwrap()
+    pub fn f_gather(&self, dim: i64, index: &Tensor, sparse_grad: bool) -> Tensor {
+        self.gather(dim, index, sparse_grad).unwrap()
     }
 
-    pub fn gather_backward(
+    pub fn f_gather_backward(
         &self,
         grad: &Tensor,
         dim: i64,
         index: &Tensor,
         sparse_grad: bool,
     ) -> Tensor {
-        self.f_gather_backward(grad, dim, index, sparse_grad).unwrap()
+        self.gather_backward(grad, dim, index, sparse_grad).unwrap()
     }
 
-    pub fn gather_out(&self, out: &Tensor, dim: i64, index: &Tensor, sparse_grad: bool) -> Tensor {
-        self.f_gather_out(out, dim, index, sparse_grad).unwrap()
+    pub fn f_gather_out(
+        &self,
+        out: &Tensor,
+        dim: i64,
+        index: &Tensor,
+        sparse_grad: bool,
+    ) -> Tensor {
+        self.gather_out(out, dim, index, sparse_grad).unwrap()
     }
 
-    pub fn gcd(&self, other: &Tensor) -> Tensor {
-        self.f_gcd(other).unwrap()
+    pub fn f_gcd(&self, other: &Tensor) -> Tensor {
+        self.gcd(other).unwrap()
     }
 
-    pub fn gcd_(&mut self, other: &Tensor) -> Tensor {
-        self.f_gcd_(other).unwrap()
+    pub fn f_gcd_(&mut self, other: &Tensor) -> Tensor {
+        self.gcd_(other).unwrap()
     }
 
-    pub fn gcd_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_gcd_out(out, other).unwrap()
+    pub fn f_gcd_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.gcd_out(out, other).unwrap()
     }
 
-    pub fn ge<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_ge(other).unwrap()
+    pub fn f_ge<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.ge(other).unwrap()
     }
 
-    pub fn ge_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_ge_(other).unwrap()
+    pub fn f_ge_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.ge_(other).unwrap()
     }
 
-    pub fn ge_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
-        self.f_ge_scalar_out(out, other).unwrap()
+    pub fn f_ge_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
+        self.ge_scalar_out(out, other).unwrap()
     }
 
-    pub fn ge_tensor(&self, other: &Tensor) -> Tensor {
-        self.f_ge_tensor(other).unwrap()
+    pub fn f_ge_tensor(&self, other: &Tensor) -> Tensor {
+        self.ge_tensor(other).unwrap()
     }
 
-    pub fn ge_tensor_(&mut self, other: &Tensor) -> Tensor {
-        self.f_ge_tensor_(other).unwrap()
+    pub fn f_ge_tensor_(&mut self, other: &Tensor) -> Tensor {
+        self.ge_tensor_(other).unwrap()
     }
 
-    pub fn ge_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_ge_tensor_out(out, other).unwrap()
+    pub fn f_ge_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.ge_tensor_out(out, other).unwrap()
     }
 
-    pub fn gelu(&self, approximate: &str) -> Tensor {
-        self.f_gelu(approximate).unwrap()
+    pub fn f_gelu(&self, approximate: &str) -> Tensor {
+        self.gelu(approximate).unwrap()
     }
 
-    pub fn gelu_(&mut self, approximate: &str) -> Tensor {
-        self.f_gelu_(approximate).unwrap()
+    pub fn f_gelu_(&mut self, approximate: &str) -> Tensor {
+        self.gelu_(approximate).unwrap()
     }
 
-    pub fn gelu_backward(&self, grad_output: &Tensor, approximate: &str) -> Tensor {
-        self.f_gelu_backward(grad_output, approximate).unwrap()
+    pub fn f_gelu_backward(&self, grad_output: &Tensor, approximate: &str) -> Tensor {
+        self.gelu_backward(grad_output, approximate).unwrap()
     }
 
-    pub fn gelu_backward_grad_input(
+    pub fn f_gelu_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
         approximate: &str,
     ) -> Tensor {
-        self.f_gelu_backward_grad_input(grad_input, grad_output, approximate).unwrap()
+        self.gelu_backward_grad_input(grad_input, grad_output, approximate).unwrap()
     }
 
-    pub fn gelu_out(&self, out: &Tensor, approximate: &str) -> Tensor {
-        self.f_gelu_out(out, approximate).unwrap()
+    pub fn f_gelu_out(&self, out: &Tensor, approximate: &str) -> Tensor {
+        self.gelu_out(out, approximate).unwrap()
     }
 
-    pub fn geometric(&self, p: f64) -> Tensor {
-        self.f_geometric(p).unwrap()
+    pub fn f_geometric(&self, p: f64) -> Tensor {
+        self.geometric(p).unwrap()
     }
 
-    pub fn geometric_(&mut self, p: f64) -> Tensor {
-        self.f_geometric_(p).unwrap()
+    pub fn f_geometric_(&mut self, p: f64) -> Tensor {
+        self.geometric_(p).unwrap()
     }
 
-    pub fn geometric_out(&self, out: &Tensor, p: f64) -> Tensor {
-        self.f_geometric_out(out, p).unwrap()
+    pub fn f_geometric_out(&self, out: &Tensor, p: f64) -> Tensor {
+        self.geometric_out(out, p).unwrap()
     }
 
-    pub fn geqrf(&self) -> (Tensor, Tensor) {
-        self.f_geqrf().unwrap()
+    pub fn f_geqrf(&self) -> (Tensor, Tensor) {
+        self.geqrf().unwrap()
     }
 
-    pub fn geqrf_a(&self, a: &Tensor, tau: &Tensor) -> (Tensor, Tensor) {
-        self.f_geqrf_a(a, tau).unwrap()
+    pub fn f_geqrf_a(&self, a: &Tensor, tau: &Tensor) -> (Tensor, Tensor) {
+        self.geqrf_a(a, tau).unwrap()
     }
 
-    pub fn ger(&self, vec2: &Tensor) -> Tensor {
-        self.f_ger(vec2).unwrap()
+    pub fn f_ger(&self, vec2: &Tensor) -> Tensor {
+        self.ger(vec2).unwrap()
     }
 
-    pub fn ger_out(&self, out: &Tensor, vec2: &Tensor) -> Tensor {
-        self.f_ger_out(out, vec2).unwrap()
+    pub fn f_ger_out(&self, out: &Tensor, vec2: &Tensor) -> Tensor {
+        self.ger_out(out, vec2).unwrap()
     }
 
-    pub fn glu(&self, dim: i64) -> Tensor {
-        self.f_glu(dim).unwrap()
+    pub fn f_glu(&self, dim: i64) -> Tensor {
+        self.glu(dim).unwrap()
     }
 
-    pub fn glu_backward(&self, grad_output: &Tensor, dim: i64) -> Tensor {
-        self.f_glu_backward(grad_output, dim).unwrap()
+    pub fn f_glu_backward(&self, grad_output: &Tensor, dim: i64) -> Tensor {
+        self.glu_backward(grad_output, dim).unwrap()
     }
 
-    pub fn glu_backward_grad_input(
+    pub fn f_glu_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
         dim: i64,
     ) -> Tensor {
-        self.f_glu_backward_grad_input(grad_input, grad_output, dim).unwrap()
+        self.glu_backward_grad_input(grad_input, grad_output, dim).unwrap()
     }
 
-    pub fn glu_backward_jvp(
+    pub fn f_glu_backward_jvp(
         grad_x: &Tensor,
         grad_glu: &Tensor,
         x: &Tensor,
@@ -9009,10 +9021,10 @@ impl Tensor {
         dx: &Tensor,
         dim: i64,
     ) -> Tensor {
-        Tensor::f_glu_backward_jvp(grad_x, grad_glu, x, dgrad_glu, dx, dim).unwrap()
+        Tensor::glu_backward_jvp(grad_x, grad_glu, x, dgrad_glu, dx, dim).unwrap()
     }
 
-    pub fn glu_backward_jvp_out(
+    pub fn f_glu_backward_jvp_out(
         out: &Tensor,
         grad_x: &Tensor,
         grad_glu: &Tensor,
@@ -9021,116 +9033,94 @@ impl Tensor {
         dx: &Tensor,
         dim: i64,
     ) -> Tensor {
-        Tensor::f_glu_backward_jvp_out(out, grad_x, grad_glu, x, dgrad_glu, dx, dim).unwrap()
+        Tensor::glu_backward_jvp_out(out, grad_x, grad_glu, x, dgrad_glu, dx, dim).unwrap()
     }
 
-    pub fn glu_jvp(glu: &Tensor, x: &Tensor, dx: &Tensor, dim: i64) -> Tensor {
-        Tensor::f_glu_jvp(glu, x, dx, dim).unwrap()
+    pub fn f_glu_jvp(glu: &Tensor, x: &Tensor, dx: &Tensor, dim: i64) -> Tensor {
+        Tensor::glu_jvp(glu, x, dx, dim).unwrap()
     }
 
-    pub fn glu_jvp_out(out: &Tensor, glu: &Tensor, x: &Tensor, dx: &Tensor, dim: i64) -> Tensor {
-        Tensor::f_glu_jvp_out(out, glu, x, dx, dim).unwrap()
+    pub fn f_glu_jvp_out(out: &Tensor, glu: &Tensor, x: &Tensor, dx: &Tensor, dim: i64) -> Tensor {
+        Tensor::glu_jvp_out(out, glu, x, dx, dim).unwrap()
     }
 
-    pub fn glu_out(&self, out: &Tensor, dim: i64) -> Tensor {
-        self.f_glu_out(out, dim).unwrap()
+    pub fn f_glu_out(&self, out: &Tensor, dim: i64) -> Tensor {
+        self.glu_out(out, dim).unwrap()
     }
 
-    pub fn grad(&self) -> Tensor {
-        self.f_grad().unwrap()
+    pub fn f_grad(&self) -> Tensor {
+        self.grad().unwrap()
     }
 
-    pub fn greater<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_greater(other).unwrap()
+    pub fn f_greater<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.greater(other).unwrap()
     }
 
-    pub fn greater_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_greater_(other).unwrap()
+    pub fn f_greater_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.greater_(other).unwrap()
     }
 
-    pub fn greater_equal<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_greater_equal(other).unwrap()
+    pub fn f_greater_equal<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.greater_equal(other).unwrap()
     }
 
-    pub fn greater_equal_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_greater_equal_(other).unwrap()
+    pub fn f_greater_equal_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.greater_equal_(other).unwrap()
     }
 
-    pub fn greater_equal_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
-        self.f_greater_equal_scalar_out(out, other).unwrap()
+    pub fn f_greater_equal_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
+        self.greater_equal_scalar_out(out, other).unwrap()
     }
 
-    pub fn greater_equal_tensor(&self, other: &Tensor) -> Tensor {
-        self.f_greater_equal_tensor(other).unwrap()
+    pub fn f_greater_equal_tensor(&self, other: &Tensor) -> Tensor {
+        self.greater_equal_tensor(other).unwrap()
     }
 
-    pub fn greater_equal_tensor_(&mut self, other: &Tensor) -> Tensor {
-        self.f_greater_equal_tensor_(other).unwrap()
+    pub fn f_greater_equal_tensor_(&mut self, other: &Tensor) -> Tensor {
+        self.greater_equal_tensor_(other).unwrap()
     }
 
-    pub fn greater_equal_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_greater_equal_tensor_out(out, other).unwrap()
+    pub fn f_greater_equal_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.greater_equal_tensor_out(out, other).unwrap()
     }
 
-    pub fn greater_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
-        self.f_greater_scalar_out(out, other).unwrap()
+    pub fn f_greater_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
+        self.greater_scalar_out(out, other).unwrap()
     }
 
-    pub fn greater_tensor(&self, other: &Tensor) -> Tensor {
-        self.f_greater_tensor(other).unwrap()
+    pub fn f_greater_tensor(&self, other: &Tensor) -> Tensor {
+        self.greater_tensor(other).unwrap()
     }
 
-    pub fn greater_tensor_(&mut self, other: &Tensor) -> Tensor {
-        self.f_greater_tensor_(other).unwrap()
+    pub fn f_greater_tensor_(&mut self, other: &Tensor) -> Tensor {
+        self.greater_tensor_(other).unwrap()
     }
 
-    pub fn greater_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_greater_tensor_out(out, other).unwrap()
+    pub fn f_greater_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.greater_tensor_out(out, other).unwrap()
     }
 
-    pub fn grid_sampler(
+    pub fn f_grid_sampler(
         &self,
         grid: &Tensor,
         interpolation_mode: i64,
         padding_mode: i64,
         align_corners: bool,
     ) -> Tensor {
-        self.f_grid_sampler(grid, interpolation_mode, padding_mode, align_corners).unwrap()
+        self.grid_sampler(grid, interpolation_mode, padding_mode, align_corners).unwrap()
     }
 
-    pub fn grid_sampler_2d(
+    pub fn f_grid_sampler_2d(
         &self,
         grid: &Tensor,
         interpolation_mode: i64,
         padding_mode: i64,
         align_corners: bool,
     ) -> Tensor {
-        self.f_grid_sampler_2d(grid, interpolation_mode, padding_mode, align_corners).unwrap()
+        self.grid_sampler_2d(grid, interpolation_mode, padding_mode, align_corners).unwrap()
     }
 
-    pub fn grid_sampler_2d_out(
-        &self,
-        out: &Tensor,
-        grid: &Tensor,
-        interpolation_mode: i64,
-        padding_mode: i64,
-        align_corners: bool,
-    ) -> Tensor {
-        self.f_grid_sampler_2d_out(out, grid, interpolation_mode, padding_mode, align_corners)
-            .unwrap()
-    }
-
-    pub fn grid_sampler_3d(
-        &self,
-        grid: &Tensor,
-        interpolation_mode: i64,
-        padding_mode: i64,
-        align_corners: bool,
-    ) -> Tensor {
-        self.f_grid_sampler_3d(grid, interpolation_mode, padding_mode, align_corners).unwrap()
-    }
-
-    pub fn grid_sampler_3d_out(
+    pub fn f_grid_sampler_2d_out(
         &self,
         out: &Tensor,
         grid: &Tensor,
@@ -9138,11 +9128,33 @@ impl Tensor {
         padding_mode: i64,
         align_corners: bool,
     ) -> Tensor {
-        self.f_grid_sampler_3d_out(out, grid, interpolation_mode, padding_mode, align_corners)
+        self.grid_sampler_2d_out(out, grid, interpolation_mode, padding_mode, align_corners)
             .unwrap()
     }
 
-    pub fn group_norm<T: Borrow<Tensor>>(
+    pub fn f_grid_sampler_3d(
+        &self,
+        grid: &Tensor,
+        interpolation_mode: i64,
+        padding_mode: i64,
+        align_corners: bool,
+    ) -> Tensor {
+        self.grid_sampler_3d(grid, interpolation_mode, padding_mode, align_corners).unwrap()
+    }
+
+    pub fn f_grid_sampler_3d_out(
+        &self,
+        out: &Tensor,
+        grid: &Tensor,
+        interpolation_mode: i64,
+        padding_mode: i64,
+        align_corners: bool,
+    ) -> Tensor {
+        self.grid_sampler_3d_out(out, grid, interpolation_mode, padding_mode, align_corners)
+            .unwrap()
+    }
+
+    pub fn f_group_norm<T: Borrow<Tensor>>(
         &self,
         num_groups: i64,
         weight: Option<T>,
@@ -9150,10 +9162,10 @@ impl Tensor {
         eps: f64,
         cudnn_enabled: bool,
     ) -> Tensor {
-        self.f_group_norm(num_groups, weight, bias, eps, cudnn_enabled).unwrap()
+        self.group_norm(num_groups, weight, bias, eps, cudnn_enabled).unwrap()
     }
 
-    pub fn gru<T: Borrow<Tensor>>(
+    pub fn f_gru<T: Borrow<Tensor>>(
         &self,
         hx: &Tensor,
         params: &[T],
@@ -9164,11 +9176,11 @@ impl Tensor {
         bidirectional: bool,
         batch_first: bool,
     ) -> (Tensor, Tensor) {
-        self.f_gru(hx, params, has_biases, num_layers, dropout, train, bidirectional, batch_first)
+        self.gru(hx, params, has_biases, num_layers, dropout, train, bidirectional, batch_first)
             .unwrap()
     }
 
-    pub fn gru_cell<T: Borrow<Tensor>>(
+    pub fn f_gru_cell<T: Borrow<Tensor>>(
         &self,
         hx: &Tensor,
         w_ih: &Tensor,
@@ -9176,10 +9188,10 @@ impl Tensor {
         b_ih: Option<T>,
         b_hh: Option<T>,
     ) -> Tensor {
-        self.f_gru_cell(hx, w_ih, w_hh, b_ih, b_hh).unwrap()
+        self.gru_cell(hx, w_ih, w_hh, b_ih, b_hh).unwrap()
     }
 
-    pub fn gru_data<T: Borrow<Tensor>>(
+    pub fn f_gru_data<T: Borrow<Tensor>>(
         data: &Tensor,
         batch_sizes: &Tensor,
         hx: &Tensor,
@@ -9190,7 +9202,7 @@ impl Tensor {
         train: bool,
         bidirectional: bool,
     ) -> (Tensor, Tensor) {
-        Tensor::f_gru_data(
+        Tensor::gru_data(
             data,
             batch_sizes,
             hx,
@@ -9204,255 +9216,259 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn gt<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_gt(other).unwrap()
+    pub fn f_gt<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.gt(other).unwrap()
     }
 
-    pub fn gt_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_gt_(other).unwrap()
+    pub fn f_gt_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.gt_(other).unwrap()
     }
 
-    pub fn gt_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
-        self.f_gt_scalar_out(out, other).unwrap()
+    pub fn f_gt_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
+        self.gt_scalar_out(out, other).unwrap()
     }
 
-    pub fn gt_tensor(&self, other: &Tensor) -> Tensor {
-        self.f_gt_tensor(other).unwrap()
+    pub fn f_gt_tensor(&self, other: &Tensor) -> Tensor {
+        self.gt_tensor(other).unwrap()
     }
 
-    pub fn gt_tensor_(&mut self, other: &Tensor) -> Tensor {
-        self.f_gt_tensor_(other).unwrap()
+    pub fn f_gt_tensor_(&mut self, other: &Tensor) -> Tensor {
+        self.gt_tensor_(other).unwrap()
     }
 
-    pub fn gt_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_gt_tensor_out(out, other).unwrap()
+    pub fn f_gt_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.gt_tensor_out(out, other).unwrap()
     }
 
-    pub fn hamming_window(window_length: i64, options: (Kind, Device)) -> Tensor {
-        Tensor::f_hamming_window(window_length, options).unwrap()
+    pub fn f_hamming_window(window_length: i64, options: (Kind, Device)) -> Tensor {
+        Tensor::hamming_window(window_length, options).unwrap()
     }
 
-    pub fn hamming_window_out(out: &Tensor, window_length: i64) -> Tensor {
-        Tensor::f_hamming_window_out(out, window_length).unwrap()
+    pub fn f_hamming_window_out(out: &Tensor, window_length: i64) -> Tensor {
+        Tensor::hamming_window_out(out, window_length).unwrap()
     }
 
-    pub fn hamming_window_periodic(
+    pub fn f_hamming_window_periodic(
         window_length: i64,
         periodic: bool,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_hamming_window_periodic(window_length, periodic, options).unwrap()
+        Tensor::hamming_window_periodic(window_length, periodic, options).unwrap()
     }
 
-    pub fn hamming_window_periodic_alpha(
+    pub fn f_hamming_window_periodic_alpha(
         window_length: i64,
         periodic: bool,
         alpha: f64,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_hamming_window_periodic_alpha(window_length, periodic, alpha, options).unwrap()
+        Tensor::hamming_window_periodic_alpha(window_length, periodic, alpha, options).unwrap()
     }
 
-    pub fn hamming_window_periodic_alpha_beta(
+    pub fn f_hamming_window_periodic_alpha_beta(
         window_length: i64,
         periodic: bool,
         alpha: f64,
         beta: f64,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_hamming_window_periodic_alpha_beta(window_length, periodic, alpha, beta, options)
+        Tensor::hamming_window_periodic_alpha_beta(window_length, periodic, alpha, beta, options)
             .unwrap()
     }
 
-    pub fn hamming_window_periodic_alpha_beta_out(
+    pub fn f_hamming_window_periodic_alpha_beta_out(
         out: &Tensor,
         window_length: i64,
         periodic: bool,
         alpha: f64,
         beta: f64,
     ) -> Tensor {
-        Tensor::f_hamming_window_periodic_alpha_beta_out(out, window_length, periodic, alpha, beta)
+        Tensor::hamming_window_periodic_alpha_beta_out(out, window_length, periodic, alpha, beta)
             .unwrap()
     }
 
-    pub fn hamming_window_periodic_alpha_out(
+    pub fn f_hamming_window_periodic_alpha_out(
         out: &Tensor,
         window_length: i64,
         periodic: bool,
         alpha: f64,
     ) -> Tensor {
-        Tensor::f_hamming_window_periodic_alpha_out(out, window_length, periodic, alpha).unwrap()
+        Tensor::hamming_window_periodic_alpha_out(out, window_length, periodic, alpha).unwrap()
     }
 
-    pub fn hamming_window_periodic_out(out: &Tensor, window_length: i64, periodic: bool) -> Tensor {
-        Tensor::f_hamming_window_periodic_out(out, window_length, periodic).unwrap()
+    pub fn f_hamming_window_periodic_out(
+        out: &Tensor,
+        window_length: i64,
+        periodic: bool,
+    ) -> Tensor {
+        Tensor::hamming_window_periodic_out(out, window_length, periodic).unwrap()
     }
 
-    pub fn hann_window(window_length: i64, options: (Kind, Device)) -> Tensor {
-        Tensor::f_hann_window(window_length, options).unwrap()
+    pub fn f_hann_window(window_length: i64, options: (Kind, Device)) -> Tensor {
+        Tensor::hann_window(window_length, options).unwrap()
     }
 
-    pub fn hann_window_out(out: &Tensor, window_length: i64) -> Tensor {
-        Tensor::f_hann_window_out(out, window_length).unwrap()
+    pub fn f_hann_window_out(out: &Tensor, window_length: i64) -> Tensor {
+        Tensor::hann_window_out(out, window_length).unwrap()
     }
 
-    pub fn hann_window_periodic(
+    pub fn f_hann_window_periodic(
         window_length: i64,
         periodic: bool,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_hann_window_periodic(window_length, periodic, options).unwrap()
+        Tensor::hann_window_periodic(window_length, periodic, options).unwrap()
     }
 
-    pub fn hann_window_periodic_out(out: &Tensor, window_length: i64, periodic: bool) -> Tensor {
-        Tensor::f_hann_window_periodic_out(out, window_length, periodic).unwrap()
+    pub fn f_hann_window_periodic_out(out: &Tensor, window_length: i64, periodic: bool) -> Tensor {
+        Tensor::hann_window_periodic_out(out, window_length, periodic).unwrap()
     }
 
-    pub fn hardshrink(&self) -> Tensor {
-        self.f_hardshrink().unwrap()
+    pub fn f_hardshrink(&self) -> Tensor {
+        self.hardshrink().unwrap()
     }
 
-    pub fn hardshrink_backward<S: Into<Scalar>>(&self, grad_out: &Tensor, lambd: S) -> Tensor {
-        self.f_hardshrink_backward(grad_out, lambd).unwrap()
+    pub fn f_hardshrink_backward<S: Into<Scalar>>(&self, grad_out: &Tensor, lambd: S) -> Tensor {
+        self.hardshrink_backward(grad_out, lambd).unwrap()
     }
 
-    pub fn hardshrink_backward_grad_input<S: Into<Scalar>>(
+    pub fn f_hardshrink_backward_grad_input<S: Into<Scalar>>(
         &self,
         grad_input: &Tensor,
         grad_out: &Tensor,
         lambd: S,
     ) -> Tensor {
-        self.f_hardshrink_backward_grad_input(grad_input, grad_out, lambd).unwrap()
+        self.hardshrink_backward_grad_input(grad_input, grad_out, lambd).unwrap()
     }
 
-    pub fn hardshrink_out(&self, out: &Tensor) -> Tensor {
-        self.f_hardshrink_out(out).unwrap()
+    pub fn f_hardshrink_out(&self, out: &Tensor) -> Tensor {
+        self.hardshrink_out(out).unwrap()
     }
 
-    pub fn hardsigmoid(&self) -> Tensor {
-        self.f_hardsigmoid().unwrap()
+    pub fn f_hardsigmoid(&self) -> Tensor {
+        self.hardsigmoid().unwrap()
     }
 
-    pub fn hardsigmoid_(&mut self) -> Tensor {
-        self.f_hardsigmoid_().unwrap()
+    pub fn f_hardsigmoid_(&mut self) -> Tensor {
+        self.hardsigmoid_().unwrap()
     }
 
-    pub fn hardsigmoid_backward(&self, grad_output: &Tensor) -> Tensor {
-        self.f_hardsigmoid_backward(grad_output).unwrap()
+    pub fn f_hardsigmoid_backward(&self, grad_output: &Tensor) -> Tensor {
+        self.hardsigmoid_backward(grad_output).unwrap()
     }
 
-    pub fn hardsigmoid_backward_grad_input(
+    pub fn f_hardsigmoid_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
     ) -> Tensor {
-        self.f_hardsigmoid_backward_grad_input(grad_input, grad_output).unwrap()
+        self.hardsigmoid_backward_grad_input(grad_input, grad_output).unwrap()
     }
 
-    pub fn hardsigmoid_out(&self, out: &Tensor) -> Tensor {
-        self.f_hardsigmoid_out(out).unwrap()
+    pub fn f_hardsigmoid_out(&self, out: &Tensor) -> Tensor {
+        self.hardsigmoid_out(out).unwrap()
     }
 
-    pub fn hardswish(&self) -> Tensor {
-        self.f_hardswish().unwrap()
+    pub fn f_hardswish(&self) -> Tensor {
+        self.hardswish().unwrap()
     }
 
-    pub fn hardswish_(&mut self) -> Tensor {
-        self.f_hardswish_().unwrap()
+    pub fn f_hardswish_(&mut self) -> Tensor {
+        self.hardswish_().unwrap()
     }
 
-    pub fn hardswish_backward(&self, grad_output: &Tensor) -> Tensor {
-        self.f_hardswish_backward(grad_output).unwrap()
+    pub fn f_hardswish_backward(&self, grad_output: &Tensor) -> Tensor {
+        self.hardswish_backward(grad_output).unwrap()
     }
 
-    pub fn hardswish_backward_out(&self, out: &Tensor, grad_output: &Tensor) -> Tensor {
-        self.f_hardswish_backward_out(out, grad_output).unwrap()
+    pub fn f_hardswish_backward_out(&self, out: &Tensor, grad_output: &Tensor) -> Tensor {
+        self.hardswish_backward_out(out, grad_output).unwrap()
     }
 
-    pub fn hardswish_out(&self, out: &Tensor) -> Tensor {
-        self.f_hardswish_out(out).unwrap()
+    pub fn f_hardswish_out(&self, out: &Tensor) -> Tensor {
+        self.hardswish_out(out).unwrap()
     }
 
-    pub fn hardtanh(&self) -> Tensor {
-        self.f_hardtanh().unwrap()
+    pub fn f_hardtanh(&self) -> Tensor {
+        self.hardtanh().unwrap()
     }
 
-    pub fn hardtanh_(&mut self) -> Tensor {
-        self.f_hardtanh_().unwrap()
+    pub fn f_hardtanh_(&mut self) -> Tensor {
+        self.hardtanh_().unwrap()
     }
 
-    pub fn hardtanh_backward<S: Into<Scalar>>(
+    pub fn f_hardtanh_backward<S: Into<Scalar>>(
         &self,
         grad_output: &Tensor,
         min_val: S,
         max_val: S,
     ) -> Tensor {
-        self.f_hardtanh_backward(grad_output, min_val, max_val).unwrap()
+        self.hardtanh_backward(grad_output, min_val, max_val).unwrap()
     }
 
-    pub fn hardtanh_backward_grad_input<S: Into<Scalar>>(
+    pub fn f_hardtanh_backward_grad_input<S: Into<Scalar>>(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
         min_val: S,
         max_val: S,
     ) -> Tensor {
-        self.f_hardtanh_backward_grad_input(grad_input, grad_output, min_val, max_val).unwrap()
+        self.hardtanh_backward_grad_input(grad_input, grad_output, min_val, max_val).unwrap()
     }
 
-    pub fn hardtanh_out(&self, out: &Tensor) -> Tensor {
-        self.f_hardtanh_out(out).unwrap()
+    pub fn f_hardtanh_out(&self, out: &Tensor) -> Tensor {
+        self.hardtanh_out(out).unwrap()
     }
 
-    pub fn heaviside(&self, values: &Tensor) -> Tensor {
-        self.f_heaviside(values).unwrap()
+    pub fn f_heaviside(&self, values: &Tensor) -> Tensor {
+        self.heaviside(values).unwrap()
     }
 
-    pub fn heaviside_(&mut self, values: &Tensor) -> Tensor {
-        self.f_heaviside_(values).unwrap()
+    pub fn f_heaviside_(&mut self, values: &Tensor) -> Tensor {
+        self.heaviside_(values).unwrap()
     }
 
-    pub fn heaviside_out(&self, out: &Tensor, values: &Tensor) -> Tensor {
-        self.f_heaviside_out(out, values).unwrap()
+    pub fn f_heaviside_out(&self, out: &Tensor, values: &Tensor) -> Tensor {
+        self.heaviside_out(out, values).unwrap()
     }
 
-    pub fn hinge_embedding_loss(
+    pub fn f_hinge_embedding_loss(
         &self,
         target: &Tensor,
         margin: f64,
         reduction: crate::Reduction,
     ) -> Tensor {
-        self.f_hinge_embedding_loss(target, margin, reduction).unwrap()
+        self.hinge_embedding_loss(target, margin, reduction).unwrap()
     }
 
-    pub fn histc(&self, bins: i64) -> Tensor {
-        self.f_histc(bins).unwrap()
+    pub fn f_histc(&self, bins: i64) -> Tensor {
+        self.histc(bins).unwrap()
     }
 
-    pub fn histc_out(&self, out: &Tensor, bins: i64) -> Tensor {
-        self.f_histc_out(out, bins).unwrap()
+    pub fn f_histc_out(&self, out: &Tensor, bins: i64) -> Tensor {
+        self.histc_out(out, bins).unwrap()
     }
 
-    pub fn histogram<T: Borrow<Tensor>>(
+    pub fn f_histogram<T: Borrow<Tensor>>(
         &self,
         bins: &Tensor,
         weight: Option<T>,
         density: bool,
     ) -> (Tensor, Tensor) {
-        self.f_histogram(bins, weight, density).unwrap()
+        self.histogram(bins, weight, density).unwrap()
     }
 
-    pub fn histogram_bin_ct<T: Borrow<Tensor>>(
+    pub fn f_histogram_bin_ct<T: Borrow<Tensor>>(
         &self,
         bins: i64,
         range: impl DoubleList,
         weight: Option<T>,
         density: bool,
     ) -> (Tensor, Tensor) {
-        self.f_histogram_bin_ct(bins, range, weight, density).unwrap()
+        self.histogram_bin_ct(bins, range, weight, density).unwrap()
     }
 
-    pub fn histogram_bin_ct_out<T: Borrow<Tensor>>(
+    pub fn f_histogram_bin_ct_out<T: Borrow<Tensor>>(
         &self,
         hist: &Tensor,
         bin_edges: &Tensor,
@@ -9461,10 +9477,10 @@ impl Tensor {
         weight: Option<T>,
         density: bool,
     ) -> (Tensor, Tensor) {
-        self.f_histogram_bin_ct_out(hist, bin_edges, bins, range, weight, density).unwrap()
+        self.histogram_bin_ct_out(hist, bin_edges, bins, range, weight, density).unwrap()
     }
 
-    pub fn histogram_bins_tensor_out<T: Borrow<Tensor>>(
+    pub fn f_histogram_bins_tensor_out<T: Borrow<Tensor>>(
         &self,
         hist: &Tensor,
         bin_edges: &Tensor,
@@ -9472,48 +9488,48 @@ impl Tensor {
         weight: Option<T>,
         density: bool,
     ) -> (Tensor, Tensor) {
-        self.f_histogram_bins_tensor_out(hist, bin_edges, bins, weight, density).unwrap()
+        self.histogram_bins_tensor_out(hist, bin_edges, bins, weight, density).unwrap()
     }
 
-    pub fn hsplit(&self, sections: i64) -> Vec<Tensor> {
-        self.f_hsplit(sections).unwrap()
+    pub fn f_hsplit(&self, sections: i64) -> Vec<Tensor> {
+        self.hsplit(sections).unwrap()
     }
 
-    pub fn hsplit_array(&self, indices: impl IntList) -> Vec<Tensor> {
-        self.f_hsplit_array(indices).unwrap()
+    pub fn f_hsplit_array(&self, indices: impl IntList) -> Vec<Tensor> {
+        self.hsplit_array(indices).unwrap()
     }
 
-    pub fn hspmm(mat1: &Tensor, mat2: &Tensor) -> Tensor {
-        Tensor::f_hspmm(mat1, mat2).unwrap()
+    pub fn f_hspmm(mat1: &Tensor, mat2: &Tensor) -> Tensor {
+        Tensor::hspmm(mat1, mat2).unwrap()
     }
 
-    pub fn hspmm_out(out: &Tensor, mat1: &Tensor, mat2: &Tensor) -> Tensor {
-        Tensor::f_hspmm_out(out, mat1, mat2).unwrap()
+    pub fn f_hspmm_out(out: &Tensor, mat1: &Tensor, mat2: &Tensor) -> Tensor {
+        Tensor::hspmm_out(out, mat1, mat2).unwrap()
     }
 
-    pub fn hstack<T: Borrow<Tensor>>(tensors: &[T]) -> Tensor {
-        Tensor::f_hstack(tensors).unwrap()
+    pub fn f_hstack<T: Borrow<Tensor>>(tensors: &[T]) -> Tensor {
+        Tensor::hstack(tensors).unwrap()
     }
 
-    pub fn hstack_out<T: Borrow<Tensor>>(out: &Tensor, tensors: &[T]) -> Tensor {
-        Tensor::f_hstack_out(out, tensors).unwrap()
+    pub fn f_hstack_out<T: Borrow<Tensor>>(out: &Tensor, tensors: &[T]) -> Tensor {
+        Tensor::hstack_out(out, tensors).unwrap()
     }
 
-    pub fn huber_loss(&self, target: &Tensor, reduction: crate::Reduction, delta: f64) -> Tensor {
-        self.f_huber_loss(target, reduction, delta).unwrap()
+    pub fn f_huber_loss(&self, target: &Tensor, reduction: crate::Reduction, delta: f64) -> Tensor {
+        self.huber_loss(target, reduction, delta).unwrap()
     }
 
-    pub fn huber_loss_backward(
+    pub fn f_huber_loss_backward(
         &self,
         grad_output: &Tensor,
         target: &Tensor,
         reduction: crate::Reduction,
         delta: f64,
     ) -> Tensor {
-        self.f_huber_loss_backward(grad_output, target, reduction, delta).unwrap()
+        self.huber_loss_backward(grad_output, target, reduction, delta).unwrap()
     }
 
-    pub fn huber_loss_backward_out(
+    pub fn f_huber_loss_backward_out(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -9521,78 +9537,78 @@ impl Tensor {
         reduction: crate::Reduction,
         delta: f64,
     ) -> Tensor {
-        self.f_huber_loss_backward_out(grad_input, grad_output, target, reduction, delta).unwrap()
+        self.huber_loss_backward_out(grad_input, grad_output, target, reduction, delta).unwrap()
     }
 
-    pub fn huber_loss_out(
+    pub fn f_huber_loss_out(
         &self,
         out: &Tensor,
         target: &Tensor,
         reduction: crate::Reduction,
         delta: f64,
     ) -> Tensor {
-        self.f_huber_loss_out(out, target, reduction, delta).unwrap()
+        self.huber_loss_out(out, target, reduction, delta).unwrap()
     }
 
-    pub fn hypot(&self, other: &Tensor) -> Tensor {
-        self.f_hypot(other).unwrap()
+    pub fn f_hypot(&self, other: &Tensor) -> Tensor {
+        self.hypot(other).unwrap()
     }
 
-    pub fn hypot_(&mut self, other: &Tensor) -> Tensor {
-        self.f_hypot_(other).unwrap()
+    pub fn f_hypot_(&mut self, other: &Tensor) -> Tensor {
+        self.hypot_(other).unwrap()
     }
 
-    pub fn hypot_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_hypot_out(out, other).unwrap()
+    pub fn f_hypot_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.hypot_out(out, other).unwrap()
     }
 
-    pub fn i0(&self) -> Tensor {
-        self.f_i0().unwrap()
+    pub fn f_i0(&self) -> Tensor {
+        self.i0().unwrap()
     }
 
-    pub fn i0_(&mut self) -> Tensor {
-        self.f_i0_().unwrap()
+    pub fn f_i0_(&mut self) -> Tensor {
+        self.i0_().unwrap()
     }
 
-    pub fn i0_out(&self, out: &Tensor) -> Tensor {
-        self.f_i0_out(out).unwrap()
+    pub fn f_i0_out(&self, out: &Tensor) -> Tensor {
+        self.i0_out(out).unwrap()
     }
 
-    pub fn igamma(&self, other: &Tensor) -> Tensor {
-        self.f_igamma(other).unwrap()
+    pub fn f_igamma(&self, other: &Tensor) -> Tensor {
+        self.igamma(other).unwrap()
     }
 
-    pub fn igamma_(&mut self, other: &Tensor) -> Tensor {
-        self.f_igamma_(other).unwrap()
+    pub fn f_igamma_(&mut self, other: &Tensor) -> Tensor {
+        self.igamma_(other).unwrap()
     }
 
-    pub fn igamma_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_igamma_out(out, other).unwrap()
+    pub fn f_igamma_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.igamma_out(out, other).unwrap()
     }
 
-    pub fn igammac(&self, other: &Tensor) -> Tensor {
-        self.f_igammac(other).unwrap()
+    pub fn f_igammac(&self, other: &Tensor) -> Tensor {
+        self.igammac(other).unwrap()
     }
 
-    pub fn igammac_(&mut self, other: &Tensor) -> Tensor {
-        self.f_igammac_(other).unwrap()
+    pub fn f_igammac_(&mut self, other: &Tensor) -> Tensor {
+        self.igammac_(other).unwrap()
     }
 
-    pub fn igammac_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_igammac_out(out, other).unwrap()
+    pub fn f_igammac_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.igammac_out(out, other).unwrap()
     }
 
-    pub fn im2col(
+    pub fn f_im2col(
         &self,
         kernel_size: impl IntList,
         dilation: impl IntList,
         padding: impl IntList,
         stride: impl IntList,
     ) -> Tensor {
-        self.f_im2col(kernel_size, dilation, padding, stride).unwrap()
+        self.im2col(kernel_size, dilation, padding, stride).unwrap()
     }
 
-    pub fn im2col_out(
+    pub fn f_im2col_out(
         &self,
         out: &Tensor,
         kernel_size: impl IntList,
@@ -9600,112 +9616,118 @@ impl Tensor {
         padding: impl IntList,
         stride: impl IntList,
     ) -> Tensor {
-        self.f_im2col_out(out, kernel_size, dilation, padding, stride).unwrap()
+        self.im2col_out(out, kernel_size, dilation, padding, stride).unwrap()
     }
 
-    pub fn imag(&self) -> Tensor {
-        self.f_imag().unwrap()
+    pub fn f_imag(&self) -> Tensor {
+        self.imag().unwrap()
     }
 
-    pub fn index<T: Borrow<Tensor>>(&self, indices: &[Option<T>]) -> Tensor {
-        self.f_index(indices).unwrap()
+    pub fn f_index<T: Borrow<Tensor>>(&self, indices: &[Option<T>]) -> Tensor {
+        self.index(indices).unwrap()
     }
 
-    pub fn index_add(&self, dim: i64, index: &Tensor, source: &Tensor) -> Tensor {
-        self.f_index_add(dim, index, source).unwrap()
+    pub fn f_index_add(&self, dim: i64, index: &Tensor, source: &Tensor) -> Tensor {
+        self.index_add(dim, index, source).unwrap()
     }
 
-    pub fn index_add_(&mut self, dim: i64, index: &Tensor, source: &Tensor) -> Tensor {
-        self.f_index_add_(dim, index, source).unwrap()
+    pub fn f_index_add_(&mut self, dim: i64, index: &Tensor, source: &Tensor) -> Tensor {
+        self.index_add_(dim, index, source).unwrap()
     }
 
-    pub fn index_add_out(&self, out: &Tensor, dim: i64, index: &Tensor, source: &Tensor) -> Tensor {
-        self.f_index_add_out(out, dim, index, source).unwrap()
-    }
-
-    pub fn index_copy(&self, dim: i64, index: &Tensor, source: &Tensor) -> Tensor {
-        self.f_index_copy(dim, index, source).unwrap()
-    }
-
-    pub fn index_copy_(&mut self, dim: i64, index: &Tensor, source: &Tensor) -> Tensor {
-        self.f_index_copy_(dim, index, source).unwrap()
-    }
-
-    pub fn index_copy_out(
+    pub fn f_index_add_out(
         &self,
         out: &Tensor,
         dim: i64,
         index: &Tensor,
         source: &Tensor,
     ) -> Tensor {
-        self.f_index_copy_out(out, dim, index, source).unwrap()
+        self.index_add_out(out, dim, index, source).unwrap()
     }
 
-    pub fn index_fill<S: Into<Scalar>>(&self, dim: i64, index: &Tensor, value: S) -> Tensor {
-        self.f_index_fill(dim, index, value).unwrap()
+    pub fn f_index_copy(&self, dim: i64, index: &Tensor, source: &Tensor) -> Tensor {
+        self.index_copy(dim, index, source).unwrap()
     }
 
-    pub fn index_fill_<S: Into<Scalar>>(&mut self, dim: i64, index: &Tensor, value: S) -> Tensor {
-        self.f_index_fill_(dim, index, value).unwrap()
+    pub fn f_index_copy_(&mut self, dim: i64, index: &Tensor, source: &Tensor) -> Tensor {
+        self.index_copy_(dim, index, source).unwrap()
     }
 
-    pub fn index_fill_int_scalar_out<S: Into<Scalar>>(
+    pub fn f_index_copy_out(
+        &self,
+        out: &Tensor,
+        dim: i64,
+        index: &Tensor,
+        source: &Tensor,
+    ) -> Tensor {
+        self.index_copy_out(out, dim, index, source).unwrap()
+    }
+
+    pub fn f_index_fill<S: Into<Scalar>>(&self, dim: i64, index: &Tensor, value: S) -> Tensor {
+        self.index_fill(dim, index, value).unwrap()
+    }
+
+    pub fn f_index_fill_<S: Into<Scalar>>(&mut self, dim: i64, index: &Tensor, value: S) -> Tensor {
+        self.index_fill_(dim, index, value).unwrap()
+    }
+
+    pub fn f_index_fill_int_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         dim: i64,
         index: &Tensor,
         value: S,
     ) -> Tensor {
-        self.f_index_fill_int_scalar_out(out, dim, index, value).unwrap()
+        self.index_fill_int_scalar_out(out, dim, index, value).unwrap()
     }
 
-    pub fn index_fill_int_tensor(&self, dim: i64, index: &Tensor, value: &Tensor) -> Tensor {
-        self.f_index_fill_int_tensor(dim, index, value).unwrap()
+    pub fn f_index_fill_int_tensor(&self, dim: i64, index: &Tensor, value: &Tensor) -> Tensor {
+        self.index_fill_int_tensor(dim, index, value).unwrap()
     }
 
-    pub fn index_fill_int_tensor_(&mut self, dim: i64, index: &Tensor, value: &Tensor) -> Tensor {
-        self.f_index_fill_int_tensor_(dim, index, value).unwrap()
+    pub fn f_index_fill_int_tensor_(&mut self, dim: i64, index: &Tensor, value: &Tensor) -> Tensor {
+        self.index_fill_int_tensor_(dim, index, value).unwrap()
     }
 
-    pub fn index_fill_int_tensor_out(
+    pub fn f_index_fill_int_tensor_out(
         &self,
         out: &Tensor,
         dim: i64,
         index: &Tensor,
         value: &Tensor,
     ) -> Tensor {
-        self.f_index_fill_int_tensor_out(out, dim, index, value).unwrap()
+        self.index_fill_int_tensor_out(out, dim, index, value).unwrap()
     }
 
-    pub fn index_put<T: Borrow<Tensor>>(
+    pub fn f_index_put<T: Borrow<Tensor>>(
         &self,
         indices: &[Option<T>],
         values: &Tensor,
         accumulate: bool,
     ) -> Tensor {
-        self.f_index_put(indices, values, accumulate).unwrap()
+        self.index_put(indices, values, accumulate).unwrap()
     }
 
-    pub fn index_put_<T: Borrow<Tensor>>(
+    pub fn f_index_put_<T: Borrow<Tensor>>(
         &mut self,
         indices: &[Option<T>],
         values: &Tensor,
         accumulate: bool,
     ) -> Tensor {
-        self.f_index_put_(indices, values, accumulate).unwrap()
+        self.index_put_(indices, values, accumulate).unwrap()
     }
 
-    pub fn index_put_out<T: Borrow<Tensor>>(
+    pub fn f_index_put_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         indices: &[Option<T>],
         values: &Tensor,
         accumulate: bool,
     ) -> Tensor {
-        self.f_index_put_out(out, indices, values, accumulate).unwrap()
+        self.index_put_out(out, indices, values, accumulate).unwrap()
     }
 
-    pub fn index_reduce(
+    pub fn f_index_reduce(
         &self,
         dim: i64,
         index: &Tensor,
@@ -9713,10 +9735,10 @@ impl Tensor {
         reduce: &str,
         include_self: bool,
     ) -> Tensor {
-        self.f_index_reduce(dim, index, source, reduce, include_self).unwrap()
+        self.index_reduce(dim, index, source, reduce, include_self).unwrap()
     }
 
-    pub fn index_reduce_(
+    pub fn f_index_reduce_(
         &mut self,
         dim: i64,
         index: &Tensor,
@@ -9724,10 +9746,10 @@ impl Tensor {
         reduce: &str,
         include_self: bool,
     ) -> Tensor {
-        self.f_index_reduce_(dim, index, source, reduce, include_self).unwrap()
+        self.index_reduce_(dim, index, source, reduce, include_self).unwrap()
     }
 
-    pub fn index_reduce_out(
+    pub fn f_index_reduce_out(
         &self,
         out: &Tensor,
         dim: i64,
@@ -9736,59 +9758,59 @@ impl Tensor {
         reduce: &str,
         include_self: bool,
     ) -> Tensor {
-        self.f_index_reduce_out(out, dim, index, source, reduce, include_self).unwrap()
+        self.index_reduce_out(out, dim, index, source, reduce, include_self).unwrap()
     }
 
-    pub fn index_select(&self, dim: i64, index: &Tensor) -> Tensor {
-        self.f_index_select(dim, index).unwrap()
+    pub fn f_index_select(&self, dim: i64, index: &Tensor) -> Tensor {
+        self.index_select(dim, index).unwrap()
     }
 
-    pub fn index_select_backward(
+    pub fn f_index_select_backward(
         grad: &Tensor,
         self_sizes: impl IntList,
         dim: i64,
         index: &Tensor,
     ) -> Tensor {
-        Tensor::f_index_select_backward(grad, self_sizes, dim, index).unwrap()
+        Tensor::index_select_backward(grad, self_sizes, dim, index).unwrap()
     }
 
-    pub fn index_select_out(&self, out: &Tensor, dim: i64, index: &Tensor) -> Tensor {
-        self.f_index_select_out(out, dim, index).unwrap()
+    pub fn f_index_select_out(&self, out: &Tensor, dim: i64, index: &Tensor) -> Tensor {
+        self.index_select_out(out, dim, index).unwrap()
     }
 
-    pub fn index_tensor_out<T: Borrow<Tensor>>(
+    pub fn f_index_tensor_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         indices: &[Option<T>],
     ) -> Tensor {
-        self.f_index_tensor_out(out, indices).unwrap()
+        self.index_tensor_out(out, indices).unwrap()
     }
 
-    pub fn indices(&self) -> Tensor {
-        self.f_indices().unwrap()
+    pub fn f_indices(&self) -> Tensor {
+        self.indices().unwrap()
     }
 
-    pub fn indices_copy(&self) -> Tensor {
-        self.f_indices_copy().unwrap()
+    pub fn f_indices_copy(&self) -> Tensor {
+        self.indices_copy().unwrap()
     }
 
-    pub fn indices_copy_out(&self, out: &Tensor) -> Tensor {
-        self.f_indices_copy_out(out).unwrap()
+    pub fn f_indices_copy_out(&self, out: &Tensor) -> Tensor {
+        self.indices_copy_out(out).unwrap()
     }
 
-    pub fn infinitely_differentiable_gelu_backward(&self, grad: &Tensor) -> Tensor {
-        self.f_infinitely_differentiable_gelu_backward(grad).unwrap()
+    pub fn f_infinitely_differentiable_gelu_backward(&self, grad: &Tensor) -> Tensor {
+        self.infinitely_differentiable_gelu_backward(grad).unwrap()
     }
 
-    pub fn inner(&self, other: &Tensor) -> Tensor {
-        self.f_inner(other).unwrap()
+    pub fn f_inner(&self, other: &Tensor) -> Tensor {
+        self.inner(other).unwrap()
     }
 
-    pub fn inner_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_inner_out(out, other).unwrap()
+    pub fn f_inner_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.inner_out(out, other).unwrap()
     }
 
-    pub fn instance_norm<T: Borrow<Tensor>>(
+    pub fn f_instance_norm<T: Borrow<Tensor>>(
         &self,
         weight: Option<T>,
         bias: Option<T>,
@@ -9799,7 +9821,7 @@ impl Tensor {
         eps: f64,
         cudnn_enabled: bool,
     ) -> Tensor {
-        self.f_instance_norm(
+        self.instance_norm(
             weight,
             bias,
             running_mean,
@@ -9812,183 +9834,180 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn int_repr(&self) -> Tensor {
-        self.f_int_repr().unwrap()
+    pub fn f_int_repr(&self) -> Tensor {
+        self.int_repr().unwrap()
     }
 
-    pub fn int_repr_out(&self, out: &Tensor) -> Tensor {
-        self.f_int_repr_out(out).unwrap()
+    pub fn f_int_repr_out(&self, out: &Tensor) -> Tensor {
+        self.int_repr_out(out).unwrap()
     }
 
-    pub fn inverse(&self) -> Tensor {
-        self.f_inverse().unwrap()
+    pub fn f_inverse(&self) -> Tensor {
+        self.inverse().unwrap()
     }
 
-    pub fn inverse_out(&self, out: &Tensor) -> Tensor {
-        self.f_inverse_out(out).unwrap()
+    pub fn f_inverse_out(&self, out: &Tensor) -> Tensor {
+        self.inverse_out(out).unwrap()
     }
 
-    pub fn is_coalesced(&self) -> bool {
-        self.f_is_coalesced().unwrap()
+    pub fn f_is_coalesced(&self) -> bool {
+        self.is_coalesced().unwrap()
     }
 
-    pub fn is_complex(&self) -> bool {
-        self.f_is_complex().unwrap()
+    pub fn f_is_complex(&self) -> bool {
+        self.is_complex().unwrap()
     }
 
-    pub fn is_conj(&self) -> bool {
-        self.f_is_conj().unwrap()
+    pub fn f_is_conj(&self) -> bool {
+        self.is_conj().unwrap()
     }
 
-    pub fn is_distributed(&self) -> bool {
-        self.f_is_distributed().unwrap()
+    pub fn f_is_distributed(&self) -> bool {
+        self.is_distributed().unwrap()
     }
 
-    pub fn is_floating_point(&self) -> bool {
-        self.f_is_floating_point().unwrap()
+    pub fn f_is_floating_point(&self) -> bool {
+        self.is_floating_point().unwrap()
     }
 
-    pub fn is_inference(&self) -> bool {
-        self.f_is_inference().unwrap()
+    pub fn f_is_inference(&self) -> bool {
+        self.is_inference().unwrap()
     }
 
-    pub fn is_leaf(&self) -> bool {
-        self.f_is_leaf().unwrap()
+    pub fn f_is_leaf(&self) -> bool {
+        self.is_leaf().unwrap()
     }
 
-    pub fn is_neg(&self) -> bool {
-        self.f_is_neg().unwrap()
+    pub fn f_is_neg(&self) -> bool {
+        self.is_neg().unwrap()
     }
 
-    pub fn is_nonzero(&self) -> bool {
-        self.f_is_nonzero().unwrap()
+    pub fn f_is_nonzero(&self) -> bool {
+        self.is_nonzero().unwrap()
     }
 
-    pub fn is_pinned(&self, device: Device) -> bool {
-        self.f_is_pinned(device).unwrap()
+    pub fn f_is_pinned(&self, device: Device) -> bool {
+        self.is_pinned(device).unwrap()
     }
 
-    pub fn is_same_size(&self, other: &Tensor) -> bool {
-        self.f_is_same_size(other).unwrap()
+    pub fn f_is_same_size(&self, other: &Tensor) -> bool {
+        self.is_same_size(other).unwrap()
     }
 
-    pub fn is_set_to(&self, tensor: &Tensor) -> bool {
-        self.f_is_set_to(tensor).unwrap()
+    pub fn f_is_set_to(&self, tensor: &Tensor) -> bool {
+        self.is_set_to(tensor).unwrap()
     }
 
-    pub fn is_signed(&self) -> bool {
-        self.f_is_signed().unwrap()
+    pub fn f_is_signed(&self) -> bool {
+        self.is_signed().unwrap()
     }
 
-    pub fn is_vulkan_available() -> bool {
-        Tensor::f_is_vulkan_available().unwrap()
+    pub fn f_is_vulkan_available() -> bool {
+        Tensor::is_vulkan_available().unwrap()
     }
 
-    pub fn isclose(&self, other: &Tensor, rtol: f64, atol: f64, equal_nan: bool) -> Tensor {
-        self.f_isclose(other, rtol, atol, equal_nan).unwrap()
+    pub fn f_isclose(&self, other: &Tensor, rtol: f64, atol: f64, equal_nan: bool) -> Tensor {
+        self.isclose(other, rtol, atol, equal_nan).unwrap()
     }
 
-    pub fn isfinite(&self) -> Tensor {
-        self.f_isfinite().unwrap()
+    pub fn f_isfinite(&self) -> Tensor {
+        self.isfinite().unwrap()
     }
 
-    pub fn isin(
+    pub fn f_isin(
         elements: &Tensor,
         test_elements: &Tensor,
         assume_unique: bool,
         invert: bool,
     ) -> Tensor {
-        Tensor::f_isin(elements, test_elements, assume_unique, invert).unwrap()
+        Tensor::isin(elements, test_elements, assume_unique, invert).unwrap()
     }
 
-    pub fn isin_scalar_tensor<S: Into<Scalar>>(
+    pub fn f_isin_scalar_tensor<S: Into<Scalar>>(
         element: S,
         test_elements: &Tensor,
         assume_unique: bool,
         invert: bool,
     ) -> Tensor {
-        Tensor::f_isin_scalar_tensor(element, test_elements, assume_unique, invert).unwrap()
+        Tensor::isin_scalar_tensor(element, test_elements, assume_unique, invert).unwrap()
     }
 
-    pub fn isin_scalar_tensor_out<S: Into<Scalar>>(
+    pub fn f_isin_scalar_tensor_out<S: Into<Scalar>>(
         out: &Tensor,
         element: S,
         test_elements: &Tensor,
         assume_unique: bool,
         invert: bool,
     ) -> Tensor {
-        Tensor::f_isin_scalar_tensor_out(out, element, test_elements, assume_unique, invert)
-            .unwrap()
+        Tensor::isin_scalar_tensor_out(out, element, test_elements, assume_unique, invert).unwrap()
     }
 
-    pub fn isin_tensor_scalar<S: Into<Scalar>>(
+    pub fn f_isin_tensor_scalar<S: Into<Scalar>>(
         elements: &Tensor,
         test_element: S,
         assume_unique: bool,
         invert: bool,
     ) -> Tensor {
-        Tensor::f_isin_tensor_scalar(elements, test_element, assume_unique, invert).unwrap()
+        Tensor::isin_tensor_scalar(elements, test_element, assume_unique, invert).unwrap()
     }
 
-    pub fn isin_tensor_scalar_out<S: Into<Scalar>>(
+    pub fn f_isin_tensor_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         elements: &Tensor,
         test_element: S,
         assume_unique: bool,
         invert: bool,
     ) -> Tensor {
-        Tensor::f_isin_tensor_scalar_out(out, elements, test_element, assume_unique, invert)
-            .unwrap()
+        Tensor::isin_tensor_scalar_out(out, elements, test_element, assume_unique, invert).unwrap()
     }
 
-    pub fn isin_tensor_tensor_out(
+    pub fn f_isin_tensor_tensor_out(
         out: &Tensor,
         elements: &Tensor,
         test_elements: &Tensor,
         assume_unique: bool,
         invert: bool,
     ) -> Tensor {
-        Tensor::f_isin_tensor_tensor_out(out, elements, test_elements, assume_unique, invert)
-            .unwrap()
+        Tensor::isin_tensor_tensor_out(out, elements, test_elements, assume_unique, invert).unwrap()
     }
 
-    pub fn isinf(&self) -> Tensor {
-        self.f_isinf().unwrap()
+    pub fn f_isinf(&self) -> Tensor {
+        self.isinf().unwrap()
     }
 
-    pub fn isinf_out(&self, out: &Tensor) -> Tensor {
-        self.f_isinf_out(out).unwrap()
+    pub fn f_isinf_out(&self, out: &Tensor) -> Tensor {
+        self.isinf_out(out).unwrap()
     }
 
-    pub fn isnan(&self) -> Tensor {
-        self.f_isnan().unwrap()
+    pub fn f_isnan(&self) -> Tensor {
+        self.isnan().unwrap()
     }
 
-    pub fn isnan_out(&self, out: &Tensor) -> Tensor {
-        self.f_isnan_out(out).unwrap()
+    pub fn f_isnan_out(&self, out: &Tensor) -> Tensor {
+        self.isnan_out(out).unwrap()
     }
 
-    pub fn isneginf(&self) -> Tensor {
-        self.f_isneginf().unwrap()
+    pub fn f_isneginf(&self) -> Tensor {
+        self.isneginf().unwrap()
     }
 
-    pub fn isneginf_out(&self, out: &Tensor) -> Tensor {
-        self.f_isneginf_out(out).unwrap()
+    pub fn f_isneginf_out(&self, out: &Tensor) -> Tensor {
+        self.isneginf_out(out).unwrap()
     }
 
-    pub fn isposinf(&self) -> Tensor {
-        self.f_isposinf().unwrap()
+    pub fn f_isposinf(&self) -> Tensor {
+        self.isposinf().unwrap()
     }
 
-    pub fn isposinf_out(&self, out: &Tensor) -> Tensor {
-        self.f_isposinf_out(out).unwrap()
+    pub fn f_isposinf_out(&self, out: &Tensor) -> Tensor {
+        self.isposinf_out(out).unwrap()
     }
 
-    pub fn isreal(&self) -> Tensor {
-        self.f_isreal().unwrap()
+    pub fn f_isreal(&self) -> Tensor {
+        self.isreal().unwrap()
     }
 
-    pub fn istft<T: Borrow<Tensor>>(
+    pub fn f_istft<T: Borrow<Tensor>>(
         &self,
         n_fft: i64,
         hop_length: impl Into<Option<i64>>,
@@ -10000,7 +10019,7 @@ impl Tensor {
         length: impl Into<Option<i64>>,
         return_complex: bool,
     ) -> Tensor {
-        self.f_istft(
+        self.istft(
             n_fft,
             hop_length,
             win_length,
@@ -10014,61 +10033,70 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn kaiser_window(window_length: i64, options: (Kind, Device)) -> Tensor {
-        Tensor::f_kaiser_window(window_length, options).unwrap()
+    pub fn f_kaiser_window(window_length: i64, options: (Kind, Device)) -> Tensor {
+        Tensor::kaiser_window(window_length, options).unwrap()
     }
 
-    pub fn kaiser_window_beta(
+    pub fn f_kaiser_window_beta(
         window_length: i64,
         periodic: bool,
         beta: f64,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_kaiser_window_beta(window_length, periodic, beta, options).unwrap()
+        Tensor::kaiser_window_beta(window_length, periodic, beta, options).unwrap()
     }
 
-    pub fn kaiser_window_beta_out(
+    pub fn f_kaiser_window_beta_out(
         out: &Tensor,
         window_length: i64,
         periodic: bool,
         beta: f64,
     ) -> Tensor {
-        Tensor::f_kaiser_window_beta_out(out, window_length, periodic, beta).unwrap()
+        Tensor::kaiser_window_beta_out(out, window_length, periodic, beta).unwrap()
     }
 
-    pub fn kaiser_window_out(out: &Tensor, window_length: i64) -> Tensor {
-        Tensor::f_kaiser_window_out(out, window_length).unwrap()
+    pub fn f_kaiser_window_out(out: &Tensor, window_length: i64) -> Tensor {
+        Tensor::kaiser_window_out(out, window_length).unwrap()
     }
 
-    pub fn kaiser_window_periodic(
+    pub fn f_kaiser_window_periodic(
         window_length: i64,
         periodic: bool,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_kaiser_window_periodic(window_length, periodic, options).unwrap()
+        Tensor::kaiser_window_periodic(window_length, periodic, options).unwrap()
     }
 
-    pub fn kaiser_window_periodic_out(out: &Tensor, window_length: i64, periodic: bool) -> Tensor {
-        Tensor::f_kaiser_window_periodic_out(out, window_length, periodic).unwrap()
+    pub fn f_kaiser_window_periodic_out(
+        out: &Tensor,
+        window_length: i64,
+        periodic: bool,
+    ) -> Tensor {
+        Tensor::kaiser_window_periodic_out(out, window_length, periodic).unwrap()
     }
 
-    pub fn kl_div(&self, target: &Tensor, reduction: crate::Reduction, log_target: bool) -> Tensor {
-        self.f_kl_div(target, reduction, log_target).unwrap()
+    pub fn f_kl_div(
+        &self,
+        target: &Tensor,
+        reduction: crate::Reduction,
+        log_target: bool,
+    ) -> Tensor {
+        self.kl_div(target, reduction, log_target).unwrap()
     }
 
-    pub fn kron(&self, other: &Tensor) -> Tensor {
-        self.f_kron(other).unwrap()
+    pub fn f_kron(&self, other: &Tensor) -> Tensor {
+        self.kron(other).unwrap()
     }
 
-    pub fn kron_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_kron_out(out, other).unwrap()
+    pub fn f_kron_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.kron_out(out, other).unwrap()
     }
 
-    pub fn kthvalue(&self, k: i64, dim: i64, keepdim: bool) -> (Tensor, Tensor) {
-        self.f_kthvalue(k, dim, keepdim).unwrap()
+    pub fn f_kthvalue(&self, k: i64, dim: i64, keepdim: bool) -> (Tensor, Tensor) {
+        self.kthvalue(k, dim, keepdim).unwrap()
     }
 
-    pub fn kthvalue_values(
+    pub fn f_kthvalue_values(
         &self,
         values: &Tensor,
         indices: &Tensor,
@@ -10076,14 +10104,14 @@ impl Tensor {
         dim: i64,
         keepdim: bool,
     ) -> (Tensor, Tensor) {
-        self.f_kthvalue_values(values, indices, k, dim, keepdim).unwrap()
+        self.kthvalue_values(values, indices, k, dim, keepdim).unwrap()
     }
 
-    pub fn l1_loss(&self, target: &Tensor, reduction: crate::Reduction) -> Tensor {
-        self.f_l1_loss(target, reduction).unwrap()
+    pub fn f_l1_loss(&self, target: &Tensor, reduction: crate::Reduction) -> Tensor {
+        self.l1_loss(target, reduction).unwrap()
     }
 
-    pub fn layer_norm<T: Borrow<Tensor>>(
+    pub fn f_layer_norm<T: Borrow<Tensor>>(
         &self,
         normalized_shape: impl IntList,
         weight: Option<T>,
@@ -10091,340 +10119,339 @@ impl Tensor {
         eps: f64,
         cudnn_enable: bool,
     ) -> Tensor {
-        self.f_layer_norm(normalized_shape, weight, bias, eps, cudnn_enable).unwrap()
+        self.layer_norm(normalized_shape, weight, bias, eps, cudnn_enable).unwrap()
     }
 
-    pub fn lcm(&self, other: &Tensor) -> Tensor {
-        self.f_lcm(other).unwrap()
+    pub fn f_lcm(&self, other: &Tensor) -> Tensor {
+        self.lcm(other).unwrap()
     }
 
-    pub fn lcm_(&mut self, other: &Tensor) -> Tensor {
-        self.f_lcm_(other).unwrap()
+    pub fn f_lcm_(&mut self, other: &Tensor) -> Tensor {
+        self.lcm_(other).unwrap()
     }
 
-    pub fn lcm_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_lcm_out(out, other).unwrap()
+    pub fn f_lcm_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.lcm_out(out, other).unwrap()
     }
 
-    pub fn ldexp(&self, other: &Tensor) -> Tensor {
-        self.f_ldexp(other).unwrap()
+    pub fn f_ldexp(&self, other: &Tensor) -> Tensor {
+        self.ldexp(other).unwrap()
     }
 
-    pub fn ldexp_(&mut self, other: &Tensor) -> Tensor {
-        self.f_ldexp_(other).unwrap()
+    pub fn f_ldexp_(&mut self, other: &Tensor) -> Tensor {
+        self.ldexp_(other).unwrap()
     }
 
-    pub fn ldexp_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_ldexp_out(out, other).unwrap()
+    pub fn f_ldexp_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.ldexp_out(out, other).unwrap()
     }
 
-    pub fn le<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_le(other).unwrap()
+    pub fn f_le<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.le(other).unwrap()
     }
 
-    pub fn le_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_le_(other).unwrap()
+    pub fn f_le_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.le_(other).unwrap()
     }
 
-    pub fn le_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
-        self.f_le_scalar_out(out, other).unwrap()
+    pub fn f_le_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
+        self.le_scalar_out(out, other).unwrap()
     }
 
-    pub fn le_tensor(&self, other: &Tensor) -> Tensor {
-        self.f_le_tensor(other).unwrap()
+    pub fn f_le_tensor(&self, other: &Tensor) -> Tensor {
+        self.le_tensor(other).unwrap()
     }
 
-    pub fn le_tensor_(&mut self, other: &Tensor) -> Tensor {
-        self.f_le_tensor_(other).unwrap()
+    pub fn f_le_tensor_(&mut self, other: &Tensor) -> Tensor {
+        self.le_tensor_(other).unwrap()
     }
 
-    pub fn le_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_le_tensor_out(out, other).unwrap()
+    pub fn f_le_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.le_tensor_out(out, other).unwrap()
     }
 
-    pub fn leaky_relu(&self) -> Tensor {
-        self.f_leaky_relu().unwrap()
+    pub fn f_leaky_relu(&self) -> Tensor {
+        self.leaky_relu().unwrap()
     }
 
-    pub fn leaky_relu_(&mut self) -> Tensor {
-        self.f_leaky_relu_().unwrap()
+    pub fn f_leaky_relu_(&mut self) -> Tensor {
+        self.leaky_relu_().unwrap()
     }
 
-    pub fn leaky_relu_backward<S: Into<Scalar>>(
+    pub fn f_leaky_relu_backward<S: Into<Scalar>>(
         &self,
         grad_output: &Tensor,
         negative_slope: S,
         self_is_result: bool,
     ) -> Tensor {
-        self.f_leaky_relu_backward(grad_output, negative_slope, self_is_result).unwrap()
+        self.leaky_relu_backward(grad_output, negative_slope, self_is_result).unwrap()
     }
 
-    pub fn leaky_relu_backward_grad_input<S: Into<Scalar>>(
+    pub fn f_leaky_relu_backward_grad_input<S: Into<Scalar>>(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
         negative_slope: S,
         self_is_result: bool,
     ) -> Tensor {
-        self.f_leaky_relu_backward_grad_input(
-            grad_input,
-            grad_output,
-            negative_slope,
-            self_is_result,
-        )
-        .unwrap()
+        self.leaky_relu_backward_grad_input(grad_input, grad_output, negative_slope, self_is_result)
+            .unwrap()
     }
 
-    pub fn leaky_relu_out(&self, out: &Tensor) -> Tensor {
-        self.f_leaky_relu_out(out).unwrap()
+    pub fn f_leaky_relu_out(&self, out: &Tensor) -> Tensor {
+        self.leaky_relu_out(out).unwrap()
     }
 
-    pub fn lerp<S: Into<Scalar>>(&self, end: &Tensor, weight: S) -> Tensor {
-        self.f_lerp(end, weight).unwrap()
+    pub fn f_lerp<S: Into<Scalar>>(&self, end: &Tensor, weight: S) -> Tensor {
+        self.lerp(end, weight).unwrap()
     }
 
-    pub fn lerp_<S: Into<Scalar>>(&mut self, end: &Tensor, weight: S) -> Tensor {
-        self.f_lerp_(end, weight).unwrap()
+    pub fn f_lerp_<S: Into<Scalar>>(&mut self, end: &Tensor, weight: S) -> Tensor {
+        self.lerp_(end, weight).unwrap()
     }
 
-    pub fn lerp_scalar_out<S: Into<Scalar>>(
+    pub fn f_lerp_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         end: &Tensor,
         weight: S,
     ) -> Tensor {
-        self.f_lerp_scalar_out(out, end, weight).unwrap()
+        self.lerp_scalar_out(out, end, weight).unwrap()
     }
 
-    pub fn lerp_tensor(&self, end: &Tensor, weight: &Tensor) -> Tensor {
-        self.f_lerp_tensor(end, weight).unwrap()
+    pub fn f_lerp_tensor(&self, end: &Tensor, weight: &Tensor) -> Tensor {
+        self.lerp_tensor(end, weight).unwrap()
     }
 
-    pub fn lerp_tensor_(&mut self, end: &Tensor, weight: &Tensor) -> Tensor {
-        self.f_lerp_tensor_(end, weight).unwrap()
+    pub fn f_lerp_tensor_(&mut self, end: &Tensor, weight: &Tensor) -> Tensor {
+        self.lerp_tensor_(end, weight).unwrap()
     }
 
-    pub fn lerp_tensor_out(&self, out: &Tensor, end: &Tensor, weight: &Tensor) -> Tensor {
-        self.f_lerp_tensor_out(out, end, weight).unwrap()
+    pub fn f_lerp_tensor_out(&self, out: &Tensor, end: &Tensor, weight: &Tensor) -> Tensor {
+        self.lerp_tensor_out(out, end, weight).unwrap()
     }
 
-    pub fn less<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_less(other).unwrap()
+    pub fn f_less<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.less(other).unwrap()
     }
 
-    pub fn less_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_less_(other).unwrap()
+    pub fn f_less_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.less_(other).unwrap()
     }
 
-    pub fn less_equal<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_less_equal(other).unwrap()
+    pub fn f_less_equal<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.less_equal(other).unwrap()
     }
 
-    pub fn less_equal_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_less_equal_(other).unwrap()
+    pub fn f_less_equal_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.less_equal_(other).unwrap()
     }
 
-    pub fn less_equal_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
-        self.f_less_equal_scalar_out(out, other).unwrap()
+    pub fn f_less_equal_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
+        self.less_equal_scalar_out(out, other).unwrap()
     }
 
-    pub fn less_equal_tensor(&self, other: &Tensor) -> Tensor {
-        self.f_less_equal_tensor(other).unwrap()
+    pub fn f_less_equal_tensor(&self, other: &Tensor) -> Tensor {
+        self.less_equal_tensor(other).unwrap()
     }
 
-    pub fn less_equal_tensor_(&mut self, other: &Tensor) -> Tensor {
-        self.f_less_equal_tensor_(other).unwrap()
+    pub fn f_less_equal_tensor_(&mut self, other: &Tensor) -> Tensor {
+        self.less_equal_tensor_(other).unwrap()
     }
 
-    pub fn less_equal_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_less_equal_tensor_out(out, other).unwrap()
+    pub fn f_less_equal_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.less_equal_tensor_out(out, other).unwrap()
     }
 
-    pub fn less_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
-        self.f_less_scalar_out(out, other).unwrap()
+    pub fn f_less_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
+        self.less_scalar_out(out, other).unwrap()
     }
 
-    pub fn less_tensor(&self, other: &Tensor) -> Tensor {
-        self.f_less_tensor(other).unwrap()
+    pub fn f_less_tensor(&self, other: &Tensor) -> Tensor {
+        self.less_tensor(other).unwrap()
     }
 
-    pub fn less_tensor_(&mut self, other: &Tensor) -> Tensor {
-        self.f_less_tensor_(other).unwrap()
+    pub fn f_less_tensor_(&mut self, other: &Tensor) -> Tensor {
+        self.less_tensor_(other).unwrap()
     }
 
-    pub fn less_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_less_tensor_out(out, other).unwrap()
+    pub fn f_less_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.less_tensor_out(out, other).unwrap()
     }
 
-    pub fn lgamma(&self) -> Tensor {
-        self.f_lgamma().unwrap()
+    pub fn f_lgamma(&self) -> Tensor {
+        self.lgamma().unwrap()
     }
 
-    pub fn lgamma_(&mut self) -> Tensor {
-        self.f_lgamma_().unwrap()
+    pub fn f_lgamma_(&mut self) -> Tensor {
+        self.lgamma_().unwrap()
     }
 
-    pub fn lgamma_out(&self, out: &Tensor) -> Tensor {
-        self.f_lgamma_out(out).unwrap()
+    pub fn f_lgamma_out(&self, out: &Tensor) -> Tensor {
+        self.lgamma_out(out).unwrap()
     }
 
-    pub fn lift(&self) -> Tensor {
-        self.f_lift().unwrap()
+    pub fn f_lift(&self) -> Tensor {
+        self.lift().unwrap()
     }
 
-    pub fn lift_fresh(&self) -> Tensor {
-        self.f_lift_fresh().unwrap()
+    pub fn f_lift_fresh(&self) -> Tensor {
+        self.lift_fresh().unwrap()
     }
 
-    pub fn lift_fresh_copy(&self) -> Tensor {
-        self.f_lift_fresh_copy().unwrap()
+    pub fn f_lift_fresh_copy(&self) -> Tensor {
+        self.lift_fresh_copy().unwrap()
     }
 
-    pub fn lift_fresh_copy_out(&self, out: &Tensor) -> Tensor {
-        self.f_lift_fresh_copy_out(out).unwrap()
+    pub fn f_lift_fresh_copy_out(&self, out: &Tensor) -> Tensor {
+        self.lift_fresh_copy_out(out).unwrap()
     }
 
-    pub fn lift_out(&self, out: &Tensor) -> Tensor {
-        self.f_lift_out(out).unwrap()
+    pub fn f_lift_out(&self, out: &Tensor) -> Tensor {
+        self.lift_out(out).unwrap()
     }
 
-    pub fn linalg_cholesky(&self, upper: bool) -> Tensor {
-        self.f_linalg_cholesky(upper).unwrap()
+    pub fn f_linalg_cholesky(&self, upper: bool) -> Tensor {
+        self.linalg_cholesky(upper).unwrap()
     }
 
-    pub fn linalg_cholesky_ex(&self, upper: bool, check_errors: bool) -> (Tensor, Tensor) {
-        self.f_linalg_cholesky_ex(upper, check_errors).unwrap()
+    pub fn f_linalg_cholesky_ex(&self, upper: bool, check_errors: bool) -> (Tensor, Tensor) {
+        self.linalg_cholesky_ex(upper, check_errors).unwrap()
     }
 
-    pub fn linalg_cholesky_ex_l(
+    pub fn f_linalg_cholesky_ex_l(
         &self,
         l: &Tensor,
         info: &Tensor,
         upper: bool,
         check_errors: bool,
     ) -> (Tensor, Tensor) {
-        self.f_linalg_cholesky_ex_l(l, info, upper, check_errors).unwrap()
+        self.linalg_cholesky_ex_l(l, info, upper, check_errors).unwrap()
     }
 
-    pub fn linalg_cholesky_out(&self, out: &Tensor, upper: bool) -> Tensor {
-        self.f_linalg_cholesky_out(out, upper).unwrap()
+    pub fn f_linalg_cholesky_out(&self, out: &Tensor, upper: bool) -> Tensor {
+        self.linalg_cholesky_out(out, upper).unwrap()
     }
 
-    pub fn linalg_cond<S: Into<Scalar>>(&self, p: S) -> Tensor {
-        self.f_linalg_cond(p).unwrap()
+    pub fn f_linalg_cond<S: Into<Scalar>>(&self, p: S) -> Tensor {
+        self.linalg_cond(p).unwrap()
     }
 
-    pub fn linalg_cond_out<S: Into<Scalar>>(&self, out: &Tensor, p: S) -> Tensor {
-        self.f_linalg_cond_out(out, p).unwrap()
+    pub fn f_linalg_cond_out<S: Into<Scalar>>(&self, out: &Tensor, p: S) -> Tensor {
+        self.linalg_cond_out(out, p).unwrap()
     }
 
-    pub fn linalg_cond_p_str(&self, p: &str) -> Tensor {
-        self.f_linalg_cond_p_str(p).unwrap()
+    pub fn f_linalg_cond_p_str(&self, p: &str) -> Tensor {
+        self.linalg_cond_p_str(p).unwrap()
     }
 
-    pub fn linalg_cond_p_str_out(&self, out: &Tensor, p: &str) -> Tensor {
-        self.f_linalg_cond_p_str_out(out, p).unwrap()
+    pub fn f_linalg_cond_p_str_out(&self, out: &Tensor, p: &str) -> Tensor {
+        self.linalg_cond_p_str_out(out, p).unwrap()
     }
 
-    pub fn linalg_cross(&self, other: &Tensor, dim: i64) -> Tensor {
-        self.f_linalg_cross(other, dim).unwrap()
+    pub fn f_linalg_cross(&self, other: &Tensor, dim: i64) -> Tensor {
+        self.linalg_cross(other, dim).unwrap()
     }
 
-    pub fn linalg_cross_out(&self, out: &Tensor, other: &Tensor, dim: i64) -> Tensor {
-        self.f_linalg_cross_out(out, other, dim).unwrap()
+    pub fn f_linalg_cross_out(&self, out: &Tensor, other: &Tensor, dim: i64) -> Tensor {
+        self.linalg_cross_out(out, other, dim).unwrap()
     }
 
-    pub fn linalg_det(a: &Tensor) -> Tensor {
-        Tensor::f_linalg_det(a).unwrap()
+    pub fn f_linalg_det(a: &Tensor) -> Tensor {
+        Tensor::linalg_det(a).unwrap()
     }
 
-    pub fn linalg_det_out(out: &Tensor, a: &Tensor) -> Tensor {
-        Tensor::f_linalg_det_out(out, a).unwrap()
+    pub fn f_linalg_det_out(out: &Tensor, a: &Tensor) -> Tensor {
+        Tensor::linalg_det_out(out, a).unwrap()
     }
 
-    pub fn linalg_diagonal(a: &Tensor, offset: i64, dim1: i64, dim2: i64) -> Tensor {
-        Tensor::f_linalg_diagonal(a, offset, dim1, dim2).unwrap()
+    pub fn f_linalg_diagonal(a: &Tensor, offset: i64, dim1: i64, dim2: i64) -> Tensor {
+        Tensor::linalg_diagonal(a, offset, dim1, dim2).unwrap()
     }
 
-    pub fn linalg_eig(&self) -> (Tensor, Tensor) {
-        self.f_linalg_eig().unwrap()
+    pub fn f_linalg_eig(&self) -> (Tensor, Tensor) {
+        self.linalg_eig().unwrap()
     }
 
-    pub fn linalg_eig_out(&self, eigenvalues: &Tensor, eigenvectors: &Tensor) -> (Tensor, Tensor) {
-        self.f_linalg_eig_out(eigenvalues, eigenvectors).unwrap()
+    pub fn f_linalg_eig_out(
+        &self,
+        eigenvalues: &Tensor,
+        eigenvectors: &Tensor,
+    ) -> (Tensor, Tensor) {
+        self.linalg_eig_out(eigenvalues, eigenvectors).unwrap()
     }
 
-    pub fn linalg_eigh(&self, uplo: &str) -> (Tensor, Tensor) {
-        self.f_linalg_eigh(uplo).unwrap()
+    pub fn f_linalg_eigh(&self, uplo: &str) -> (Tensor, Tensor) {
+        self.linalg_eigh(uplo).unwrap()
     }
 
-    pub fn linalg_eigh_eigvals(
+    pub fn f_linalg_eigh_eigvals(
         &self,
         eigvals: &Tensor,
         eigvecs: &Tensor,
         uplo: &str,
     ) -> (Tensor, Tensor) {
-        self.f_linalg_eigh_eigvals(eigvals, eigvecs, uplo).unwrap()
+        self.linalg_eigh_eigvals(eigvals, eigvecs, uplo).unwrap()
     }
 
-    pub fn linalg_eigvals(&self) -> Tensor {
-        self.f_linalg_eigvals().unwrap()
+    pub fn f_linalg_eigvals(&self) -> Tensor {
+        self.linalg_eigvals().unwrap()
     }
 
-    pub fn linalg_eigvals_out(&self, out: &Tensor) -> Tensor {
-        self.f_linalg_eigvals_out(out).unwrap()
+    pub fn f_linalg_eigvals_out(&self, out: &Tensor) -> Tensor {
+        self.linalg_eigvals_out(out).unwrap()
     }
 
-    pub fn linalg_eigvalsh(&self, uplo: &str) -> Tensor {
-        self.f_linalg_eigvalsh(uplo).unwrap()
+    pub fn f_linalg_eigvalsh(&self, uplo: &str) -> Tensor {
+        self.linalg_eigvalsh(uplo).unwrap()
     }
 
-    pub fn linalg_eigvalsh_out(&self, out: &Tensor, uplo: &str) -> Tensor {
-        self.f_linalg_eigvalsh_out(out, uplo).unwrap()
+    pub fn f_linalg_eigvalsh_out(&self, out: &Tensor, uplo: &str) -> Tensor {
+        self.linalg_eigvalsh_out(out, uplo).unwrap()
     }
 
-    pub fn linalg_householder_product(&self, tau: &Tensor) -> Tensor {
-        self.f_linalg_householder_product(tau).unwrap()
+    pub fn f_linalg_householder_product(&self, tau: &Tensor) -> Tensor {
+        self.linalg_householder_product(tau).unwrap()
     }
 
-    pub fn linalg_householder_product_out(&self, out: &Tensor, tau: &Tensor) -> Tensor {
-        self.f_linalg_householder_product_out(out, tau).unwrap()
+    pub fn f_linalg_householder_product_out(&self, out: &Tensor, tau: &Tensor) -> Tensor {
+        self.linalg_householder_product_out(out, tau).unwrap()
     }
 
-    pub fn linalg_inv(a: &Tensor) -> Tensor {
-        Tensor::f_linalg_inv(a).unwrap()
+    pub fn f_linalg_inv(a: &Tensor) -> Tensor {
+        Tensor::linalg_inv(a).unwrap()
     }
 
-    pub fn linalg_inv_ex(a: &Tensor, check_errors: bool) -> (Tensor, Tensor) {
-        Tensor::f_linalg_inv_ex(a, check_errors).unwrap()
+    pub fn f_linalg_inv_ex(a: &Tensor, check_errors: bool) -> (Tensor, Tensor) {
+        Tensor::linalg_inv_ex(a, check_errors).unwrap()
     }
 
-    pub fn linalg_inv_ex_inverse(
+    pub fn f_linalg_inv_ex_inverse(
         inverse: &Tensor,
         info: &Tensor,
         a: &Tensor,
         check_errors: bool,
     ) -> (Tensor, Tensor) {
-        Tensor::f_linalg_inv_ex_inverse(inverse, info, a, check_errors).unwrap()
+        Tensor::linalg_inv_ex_inverse(inverse, info, a, check_errors).unwrap()
     }
 
-    pub fn linalg_inv_out(out: &Tensor, a: &Tensor) -> Tensor {
-        Tensor::f_linalg_inv_out(out, a).unwrap()
+    pub fn f_linalg_inv_out(out: &Tensor, a: &Tensor) -> Tensor {
+        Tensor::linalg_inv_out(out, a).unwrap()
     }
 
-    pub fn linalg_ldl_factor(&self, hermitian: bool) -> (Tensor, Tensor) {
-        self.f_linalg_ldl_factor(hermitian).unwrap()
+    pub fn f_linalg_ldl_factor(&self, hermitian: bool) -> (Tensor, Tensor) {
+        self.linalg_ldl_factor(hermitian).unwrap()
     }
 
-    pub fn linalg_ldl_factor_ex(
+    pub fn f_linalg_ldl_factor_ex(
         &self,
         hermitian: bool,
         check_errors: bool,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_linalg_ldl_factor_ex(hermitian, check_errors).unwrap()
+        self.linalg_ldl_factor_ex(hermitian, check_errors).unwrap()
     }
 
-    pub fn linalg_ldl_factor_ex_out(
+    pub fn f_linalg_ldl_factor_ex_out(
         &self,
         ld: &Tensor,
         pivots: &Tensor,
@@ -10432,42 +10459,42 @@ impl Tensor {
         hermitian: bool,
         check_errors: bool,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_linalg_ldl_factor_ex_out(ld, pivots, info, hermitian, check_errors).unwrap()
+        self.linalg_ldl_factor_ex_out(ld, pivots, info, hermitian, check_errors).unwrap()
     }
 
-    pub fn linalg_ldl_factor_out(
+    pub fn f_linalg_ldl_factor_out(
         &self,
         ld: &Tensor,
         pivots: &Tensor,
         hermitian: bool,
     ) -> (Tensor, Tensor) {
-        self.f_linalg_ldl_factor_out(ld, pivots, hermitian).unwrap()
+        self.linalg_ldl_factor_out(ld, pivots, hermitian).unwrap()
     }
 
-    pub fn linalg_ldl_solve(ld: &Tensor, pivots: &Tensor, b: &Tensor, hermitian: bool) -> Tensor {
-        Tensor::f_linalg_ldl_solve(ld, pivots, b, hermitian).unwrap()
+    pub fn f_linalg_ldl_solve(ld: &Tensor, pivots: &Tensor, b: &Tensor, hermitian: bool) -> Tensor {
+        Tensor::linalg_ldl_solve(ld, pivots, b, hermitian).unwrap()
     }
 
-    pub fn linalg_ldl_solve_out(
+    pub fn f_linalg_ldl_solve_out(
         out: &Tensor,
         ld: &Tensor,
         pivots: &Tensor,
         b: &Tensor,
         hermitian: bool,
     ) -> Tensor {
-        Tensor::f_linalg_ldl_solve_out(out, ld, pivots, b, hermitian).unwrap()
+        Tensor::linalg_ldl_solve_out(out, ld, pivots, b, hermitian).unwrap()
     }
 
-    pub fn linalg_lstsq(
+    pub fn f_linalg_lstsq(
         &self,
         b: &Tensor,
         rcond: impl Into<Option<f64>>,
         driver: &str,
     ) -> (Tensor, Tensor, Tensor, Tensor) {
-        self.f_linalg_lstsq(b, rcond, driver).unwrap()
+        self.linalg_lstsq(b, rcond, driver).unwrap()
     }
 
-    pub fn linalg_lstsq_out(
+    pub fn f_linalg_lstsq_out(
         &self,
         solution: &Tensor,
         residuals: &Tensor,
@@ -10477,27 +10504,26 @@ impl Tensor {
         rcond: impl Into<Option<f64>>,
         driver: &str,
     ) -> (Tensor, Tensor, Tensor, Tensor) {
-        self.f_linalg_lstsq_out(solution, residuals, rank, singular_values, b, rcond, driver)
-            .unwrap()
+        self.linalg_lstsq_out(solution, residuals, rank, singular_values, b, rcond, driver).unwrap()
     }
 
-    pub fn linalg_lu(a: &Tensor, pivot: bool) -> (Tensor, Tensor, Tensor) {
-        Tensor::f_linalg_lu(a, pivot).unwrap()
+    pub fn f_linalg_lu(a: &Tensor, pivot: bool) -> (Tensor, Tensor, Tensor) {
+        Tensor::linalg_lu(a, pivot).unwrap()
     }
 
-    pub fn linalg_lu_factor(a: &Tensor, pivot: bool) -> (Tensor, Tensor) {
-        Tensor::f_linalg_lu_factor(a, pivot).unwrap()
+    pub fn f_linalg_lu_factor(a: &Tensor, pivot: bool) -> (Tensor, Tensor) {
+        Tensor::linalg_lu_factor(a, pivot).unwrap()
     }
 
-    pub fn linalg_lu_factor_ex(
+    pub fn f_linalg_lu_factor_ex(
         a: &Tensor,
         pivot: bool,
         check_errors: bool,
     ) -> (Tensor, Tensor, Tensor) {
-        Tensor::f_linalg_lu_factor_ex(a, pivot, check_errors).unwrap()
+        Tensor::linalg_lu_factor_ex(a, pivot, check_errors).unwrap()
     }
 
-    pub fn linalg_lu_factor_ex_out(
+    pub fn f_linalg_lu_factor_ex_out(
         lu: &Tensor,
         pivots: &Tensor,
         info: &Tensor,
@@ -10505,39 +10531,39 @@ impl Tensor {
         pivot: bool,
         check_errors: bool,
     ) -> (Tensor, Tensor, Tensor) {
-        Tensor::f_linalg_lu_factor_ex_out(lu, pivots, info, a, pivot, check_errors).unwrap()
+        Tensor::linalg_lu_factor_ex_out(lu, pivots, info, a, pivot, check_errors).unwrap()
     }
 
-    pub fn linalg_lu_factor_out(
+    pub fn f_linalg_lu_factor_out(
         lu: &Tensor,
         pivots: &Tensor,
         a: &Tensor,
         pivot: bool,
     ) -> (Tensor, Tensor) {
-        Tensor::f_linalg_lu_factor_out(lu, pivots, a, pivot).unwrap()
+        Tensor::linalg_lu_factor_out(lu, pivots, a, pivot).unwrap()
     }
 
-    pub fn linalg_lu_out(
+    pub fn f_linalg_lu_out(
         p: &Tensor,
         l: &Tensor,
         u: &Tensor,
         a: &Tensor,
         pivot: bool,
     ) -> (Tensor, Tensor, Tensor) {
-        Tensor::f_linalg_lu_out(p, l, u, a, pivot).unwrap()
+        Tensor::linalg_lu_out(p, l, u, a, pivot).unwrap()
     }
 
-    pub fn linalg_lu_solve(
+    pub fn f_linalg_lu_solve(
         lu: &Tensor,
         pivots: &Tensor,
         b: &Tensor,
         left: bool,
         adjoint: bool,
     ) -> Tensor {
-        Tensor::f_linalg_lu_solve(lu, pivots, b, left, adjoint).unwrap()
+        Tensor::linalg_lu_solve(lu, pivots, b, left, adjoint).unwrap()
     }
 
-    pub fn linalg_lu_solve_out(
+    pub fn f_linalg_lu_solve_out(
         out: &Tensor,
         lu: &Tensor,
         pivots: &Tensor,
@@ -10545,121 +10571,121 @@ impl Tensor {
         left: bool,
         adjoint: bool,
     ) -> Tensor {
-        Tensor::f_linalg_lu_solve_out(out, lu, pivots, b, left, adjoint).unwrap()
+        Tensor::linalg_lu_solve_out(out, lu, pivots, b, left, adjoint).unwrap()
     }
 
-    pub fn linalg_matmul(&self, other: &Tensor) -> Tensor {
-        self.f_linalg_matmul(other).unwrap()
+    pub fn f_linalg_matmul(&self, other: &Tensor) -> Tensor {
+        self.linalg_matmul(other).unwrap()
     }
 
-    pub fn linalg_matmul_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_linalg_matmul_out(out, other).unwrap()
+    pub fn f_linalg_matmul_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.linalg_matmul_out(out, other).unwrap()
     }
 
-    pub fn linalg_matrix_exp(&self) -> Tensor {
-        self.f_linalg_matrix_exp().unwrap()
+    pub fn f_linalg_matrix_exp(&self) -> Tensor {
+        self.linalg_matrix_exp().unwrap()
     }
 
-    pub fn linalg_matrix_exp_out(&self, out: &Tensor) -> Tensor {
-        self.f_linalg_matrix_exp_out(out).unwrap()
+    pub fn f_linalg_matrix_exp_out(&self, out: &Tensor) -> Tensor {
+        self.linalg_matrix_exp_out(out).unwrap()
     }
 
-    pub fn linalg_matrix_power(&self, n: i64) -> Tensor {
-        self.f_linalg_matrix_power(n).unwrap()
+    pub fn f_linalg_matrix_power(&self, n: i64) -> Tensor {
+        self.linalg_matrix_power(n).unwrap()
     }
 
-    pub fn linalg_matrix_power_out(&self, out: &Tensor, n: i64) -> Tensor {
-        self.f_linalg_matrix_power_out(out, n).unwrap()
+    pub fn f_linalg_matrix_power_out(&self, out: &Tensor, n: i64) -> Tensor {
+        self.linalg_matrix_power_out(out, n).unwrap()
     }
 
-    pub fn linalg_matrix_rank(&self, tol: f64, hermitian: bool) -> Tensor {
-        self.f_linalg_matrix_rank(tol, hermitian).unwrap()
+    pub fn f_linalg_matrix_rank(&self, tol: f64, hermitian: bool) -> Tensor {
+        self.linalg_matrix_rank(tol, hermitian).unwrap()
     }
 
-    pub fn linalg_matrix_rank_atol_rtol_float(
+    pub fn f_linalg_matrix_rank_atol_rtol_float(
         &self,
         atol: impl Into<Option<f64>>,
         rtol: impl Into<Option<f64>>,
         hermitian: bool,
     ) -> Tensor {
-        self.f_linalg_matrix_rank_atol_rtol_float(atol, rtol, hermitian).unwrap()
+        self.linalg_matrix_rank_atol_rtol_float(atol, rtol, hermitian).unwrap()
     }
 
-    pub fn linalg_matrix_rank_atol_rtol_float_out(
+    pub fn f_linalg_matrix_rank_atol_rtol_float_out(
         &self,
         out: &Tensor,
         atol: impl Into<Option<f64>>,
         rtol: impl Into<Option<f64>>,
         hermitian: bool,
     ) -> Tensor {
-        self.f_linalg_matrix_rank_atol_rtol_float_out(out, atol, rtol, hermitian).unwrap()
+        self.linalg_matrix_rank_atol_rtol_float_out(out, atol, rtol, hermitian).unwrap()
     }
 
-    pub fn linalg_matrix_rank_atol_rtol_tensor<T: Borrow<Tensor>>(
+    pub fn f_linalg_matrix_rank_atol_rtol_tensor<T: Borrow<Tensor>>(
         &self,
         atol: Option<T>,
         rtol: Option<T>,
         hermitian: bool,
     ) -> Tensor {
-        self.f_linalg_matrix_rank_atol_rtol_tensor(atol, rtol, hermitian).unwrap()
+        self.linalg_matrix_rank_atol_rtol_tensor(atol, rtol, hermitian).unwrap()
     }
 
-    pub fn linalg_matrix_rank_atol_rtol_tensor_out<T: Borrow<Tensor>>(
+    pub fn f_linalg_matrix_rank_atol_rtol_tensor_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         atol: Option<T>,
         rtol: Option<T>,
         hermitian: bool,
     ) -> Tensor {
-        self.f_linalg_matrix_rank_atol_rtol_tensor_out(out, atol, rtol, hermitian).unwrap()
+        self.linalg_matrix_rank_atol_rtol_tensor_out(out, atol, rtol, hermitian).unwrap()
     }
 
-    pub fn linalg_matrix_rank_out(&self, out: &Tensor, tol: f64, hermitian: bool) -> Tensor {
-        self.f_linalg_matrix_rank_out(out, tol, hermitian).unwrap()
+    pub fn f_linalg_matrix_rank_out(&self, out: &Tensor, tol: f64, hermitian: bool) -> Tensor {
+        self.linalg_matrix_rank_out(out, tol, hermitian).unwrap()
     }
 
-    pub fn linalg_matrix_rank_out_tol_tensor(
+    pub fn f_linalg_matrix_rank_out_tol_tensor(
         &self,
         out: &Tensor,
         tol: &Tensor,
         hermitian: bool,
     ) -> Tensor {
-        self.f_linalg_matrix_rank_out_tol_tensor(out, tol, hermitian).unwrap()
+        self.linalg_matrix_rank_out_tol_tensor(out, tol, hermitian).unwrap()
     }
 
-    pub fn linalg_matrix_rank_tol_tensor(&self, tol: &Tensor, hermitian: bool) -> Tensor {
-        self.f_linalg_matrix_rank_tol_tensor(tol, hermitian).unwrap()
+    pub fn f_linalg_matrix_rank_tol_tensor(&self, tol: &Tensor, hermitian: bool) -> Tensor {
+        self.linalg_matrix_rank_tol_tensor(tol, hermitian).unwrap()
     }
 
-    pub fn linalg_multi_dot<T: Borrow<Tensor>>(tensors: &[T]) -> Tensor {
-        Tensor::f_linalg_multi_dot(tensors).unwrap()
+    pub fn f_linalg_multi_dot<T: Borrow<Tensor>>(tensors: &[T]) -> Tensor {
+        Tensor::linalg_multi_dot(tensors).unwrap()
     }
 
-    pub fn linalg_multi_dot_out<T: Borrow<Tensor>>(out: &Tensor, tensors: &[T]) -> Tensor {
-        Tensor::f_linalg_multi_dot_out(out, tensors).unwrap()
+    pub fn f_linalg_multi_dot_out<T: Borrow<Tensor>>(out: &Tensor, tensors: &[T]) -> Tensor {
+        Tensor::linalg_multi_dot_out(out, tensors).unwrap()
     }
 
-    pub fn linalg_norm<S: Into<Scalar>>(
+    pub fn f_linalg_norm<S: Into<Scalar>>(
         &self,
         ord: S,
         dim: impl IntListOption,
         keepdim: bool,
         dtype: impl Into<Option<Kind>>,
     ) -> Tensor {
-        self.f_linalg_norm(ord, dim, keepdim, dtype).unwrap()
+        self.linalg_norm(ord, dim, keepdim, dtype).unwrap()
     }
 
-    pub fn linalg_norm_ord_str(
+    pub fn f_linalg_norm_ord_str(
         &self,
         ord: &str,
         dim: impl IntListOption,
         keepdim: bool,
         dtype: impl Into<Option<Kind>>,
     ) -> Tensor {
-        self.f_linalg_norm_ord_str(ord, dim, keepdim, dtype).unwrap()
+        self.linalg_norm_ord_str(ord, dim, keepdim, dtype).unwrap()
     }
 
-    pub fn linalg_norm_ord_str_out(
+    pub fn f_linalg_norm_ord_str_out(
         &self,
         out: &Tensor,
         ord: &str,
@@ -10667,10 +10693,10 @@ impl Tensor {
         keepdim: bool,
         dtype: impl Into<Option<Kind>>,
     ) -> Tensor {
-        self.f_linalg_norm_ord_str_out(out, ord, dim, keepdim, dtype).unwrap()
+        self.linalg_norm_ord_str_out(out, ord, dim, keepdim, dtype).unwrap()
     }
 
-    pub fn linalg_norm_out<S: Into<Scalar>>(
+    pub fn f_linalg_norm_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         ord: S,
@@ -10678,98 +10704,98 @@ impl Tensor {
         keepdim: bool,
         dtype: impl Into<Option<Kind>>,
     ) -> Tensor {
-        self.f_linalg_norm_out(out, ord, dim, keepdim, dtype).unwrap()
+        self.linalg_norm_out(out, ord, dim, keepdim, dtype).unwrap()
     }
 
-    pub fn linalg_pinv(&self, rcond: f64, hermitian: bool) -> Tensor {
-        self.f_linalg_pinv(rcond, hermitian).unwrap()
+    pub fn f_linalg_pinv(&self, rcond: f64, hermitian: bool) -> Tensor {
+        self.linalg_pinv(rcond, hermitian).unwrap()
     }
 
-    pub fn linalg_pinv_atol_rtol_float(
+    pub fn f_linalg_pinv_atol_rtol_float(
         &self,
         atol: impl Into<Option<f64>>,
         rtol: impl Into<Option<f64>>,
         hermitian: bool,
     ) -> Tensor {
-        self.f_linalg_pinv_atol_rtol_float(atol, rtol, hermitian).unwrap()
+        self.linalg_pinv_atol_rtol_float(atol, rtol, hermitian).unwrap()
     }
 
-    pub fn linalg_pinv_atol_rtol_float_out(
+    pub fn f_linalg_pinv_atol_rtol_float_out(
         &self,
         out: &Tensor,
         atol: impl Into<Option<f64>>,
         rtol: impl Into<Option<f64>>,
         hermitian: bool,
     ) -> Tensor {
-        self.f_linalg_pinv_atol_rtol_float_out(out, atol, rtol, hermitian).unwrap()
+        self.linalg_pinv_atol_rtol_float_out(out, atol, rtol, hermitian).unwrap()
     }
 
-    pub fn linalg_pinv_atol_rtol_tensor<T: Borrow<Tensor>>(
+    pub fn f_linalg_pinv_atol_rtol_tensor<T: Borrow<Tensor>>(
         &self,
         atol: Option<T>,
         rtol: Option<T>,
         hermitian: bool,
     ) -> Tensor {
-        self.f_linalg_pinv_atol_rtol_tensor(atol, rtol, hermitian).unwrap()
+        self.linalg_pinv_atol_rtol_tensor(atol, rtol, hermitian).unwrap()
     }
 
-    pub fn linalg_pinv_atol_rtol_tensor_out<T: Borrow<Tensor>>(
+    pub fn f_linalg_pinv_atol_rtol_tensor_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         atol: Option<T>,
         rtol: Option<T>,
         hermitian: bool,
     ) -> Tensor {
-        self.f_linalg_pinv_atol_rtol_tensor_out(out, atol, rtol, hermitian).unwrap()
+        self.linalg_pinv_atol_rtol_tensor_out(out, atol, rtol, hermitian).unwrap()
     }
 
-    pub fn linalg_pinv_out(&self, out: &Tensor, rcond: f64, hermitian: bool) -> Tensor {
-        self.f_linalg_pinv_out(out, rcond, hermitian).unwrap()
+    pub fn f_linalg_pinv_out(&self, out: &Tensor, rcond: f64, hermitian: bool) -> Tensor {
+        self.linalg_pinv_out(out, rcond, hermitian).unwrap()
     }
 
-    pub fn linalg_pinv_out_rcond_tensor(
+    pub fn f_linalg_pinv_out_rcond_tensor(
         &self,
         out: &Tensor,
         rcond: &Tensor,
         hermitian: bool,
     ) -> Tensor {
-        self.f_linalg_pinv_out_rcond_tensor(out, rcond, hermitian).unwrap()
+        self.linalg_pinv_out_rcond_tensor(out, rcond, hermitian).unwrap()
     }
 
-    pub fn linalg_pinv_rcond_tensor(&self, rcond: &Tensor, hermitian: bool) -> Tensor {
-        self.f_linalg_pinv_rcond_tensor(rcond, hermitian).unwrap()
+    pub fn f_linalg_pinv_rcond_tensor(&self, rcond: &Tensor, hermitian: bool) -> Tensor {
+        self.linalg_pinv_rcond_tensor(rcond, hermitian).unwrap()
     }
 
-    pub fn linalg_qr(a: &Tensor, mode: &str) -> (Tensor, Tensor) {
-        Tensor::f_linalg_qr(a, mode).unwrap()
+    pub fn f_linalg_qr(a: &Tensor, mode: &str) -> (Tensor, Tensor) {
+        Tensor::linalg_qr(a, mode).unwrap()
     }
 
-    pub fn linalg_qr_out(q: &Tensor, r: &Tensor, a: &Tensor, mode: &str) -> (Tensor, Tensor) {
-        Tensor::f_linalg_qr_out(q, r, a, mode).unwrap()
+    pub fn f_linalg_qr_out(q: &Tensor, r: &Tensor, a: &Tensor, mode: &str) -> (Tensor, Tensor) {
+        Tensor::linalg_qr_out(q, r, a, mode).unwrap()
     }
 
-    pub fn linalg_slogdet(a: &Tensor) -> (Tensor, Tensor) {
-        Tensor::f_linalg_slogdet(a).unwrap()
+    pub fn f_linalg_slogdet(a: &Tensor) -> (Tensor, Tensor) {
+        Tensor::linalg_slogdet(a).unwrap()
     }
 
-    pub fn linalg_slogdet_out(sign: &Tensor, logabsdet: &Tensor, a: &Tensor) -> (Tensor, Tensor) {
-        Tensor::f_linalg_slogdet_out(sign, logabsdet, a).unwrap()
+    pub fn f_linalg_slogdet_out(sign: &Tensor, logabsdet: &Tensor, a: &Tensor) -> (Tensor, Tensor) {
+        Tensor::linalg_slogdet_out(sign, logabsdet, a).unwrap()
     }
 
-    pub fn linalg_solve(a: &Tensor, b: &Tensor, left: bool) -> Tensor {
-        Tensor::f_linalg_solve(a, b, left).unwrap()
+    pub fn f_linalg_solve(a: &Tensor, b: &Tensor, left: bool) -> Tensor {
+        Tensor::linalg_solve(a, b, left).unwrap()
     }
 
-    pub fn linalg_solve_ex(
+    pub fn f_linalg_solve_ex(
         a: &Tensor,
         b: &Tensor,
         left: bool,
         check_errors: bool,
     ) -> (Tensor, Tensor) {
-        Tensor::f_linalg_solve_ex(a, b, left, check_errors).unwrap()
+        Tensor::linalg_solve_ex(a, b, left, check_errors).unwrap()
     }
 
-    pub fn linalg_solve_ex_out(
+    pub fn f_linalg_solve_ex_out(
         result: &Tensor,
         info: &Tensor,
         a: &Tensor,
@@ -10777,24 +10803,24 @@ impl Tensor {
         left: bool,
         check_errors: bool,
     ) -> (Tensor, Tensor) {
-        Tensor::f_linalg_solve_ex_out(result, info, a, b, left, check_errors).unwrap()
+        Tensor::linalg_solve_ex_out(result, info, a, b, left, check_errors).unwrap()
     }
 
-    pub fn linalg_solve_out(out: &Tensor, a: &Tensor, b: &Tensor, left: bool) -> Tensor {
-        Tensor::f_linalg_solve_out(out, a, b, left).unwrap()
+    pub fn f_linalg_solve_out(out: &Tensor, a: &Tensor, b: &Tensor, left: bool) -> Tensor {
+        Tensor::linalg_solve_out(out, a, b, left).unwrap()
     }
 
-    pub fn linalg_solve_triangular(
+    pub fn f_linalg_solve_triangular(
         &self,
         b: &Tensor,
         upper: bool,
         left: bool,
         unitriangular: bool,
     ) -> Tensor {
-        self.f_linalg_solve_triangular(b, upper, left, unitriangular).unwrap()
+        self.linalg_solve_triangular(b, upper, left, unitriangular).unwrap()
     }
 
-    pub fn linalg_solve_triangular_out(
+    pub fn f_linalg_solve_triangular_out(
         &self,
         out: &Tensor,
         b: &Tensor,
@@ -10802,14 +10828,14 @@ impl Tensor {
         left: bool,
         unitriangular: bool,
     ) -> Tensor {
-        self.f_linalg_solve_triangular_out(out, b, upper, left, unitriangular).unwrap()
+        self.linalg_solve_triangular_out(out, b, upper, left, unitriangular).unwrap()
     }
 
-    pub fn linalg_svd(a: &Tensor, full_matrices: bool, driver: &str) -> (Tensor, Tensor, Tensor) {
-        Tensor::f_linalg_svd(a, full_matrices, driver).unwrap()
+    pub fn f_linalg_svd(a: &Tensor, full_matrices: bool, driver: &str) -> (Tensor, Tensor, Tensor) {
+        Tensor::linalg_svd(a, full_matrices, driver).unwrap()
     }
 
-    pub fn linalg_svd_u(
+    pub fn f_linalg_svd_u(
         u: &Tensor,
         s: &Tensor,
         vh: &Tensor,
@@ -10817,300 +10843,300 @@ impl Tensor {
         full_matrices: bool,
         driver: &str,
     ) -> (Tensor, Tensor, Tensor) {
-        Tensor::f_linalg_svd_u(u, s, vh, a, full_matrices, driver).unwrap()
+        Tensor::linalg_svd_u(u, s, vh, a, full_matrices, driver).unwrap()
     }
 
-    pub fn linalg_svdvals(a: &Tensor, driver: &str) -> Tensor {
-        Tensor::f_linalg_svdvals(a, driver).unwrap()
+    pub fn f_linalg_svdvals(a: &Tensor, driver: &str) -> Tensor {
+        Tensor::linalg_svdvals(a, driver).unwrap()
     }
 
-    pub fn linalg_svdvals_out(out: &Tensor, a: &Tensor, driver: &str) -> Tensor {
-        Tensor::f_linalg_svdvals_out(out, a, driver).unwrap()
+    pub fn f_linalg_svdvals_out(out: &Tensor, a: &Tensor, driver: &str) -> Tensor {
+        Tensor::linalg_svdvals_out(out, a, driver).unwrap()
     }
 
-    pub fn linalg_tensorinv(&self, ind: i64) -> Tensor {
-        self.f_linalg_tensorinv(ind).unwrap()
+    pub fn f_linalg_tensorinv(&self, ind: i64) -> Tensor {
+        self.linalg_tensorinv(ind).unwrap()
     }
 
-    pub fn linalg_tensorinv_out(&self, out: &Tensor, ind: i64) -> Tensor {
-        self.f_linalg_tensorinv_out(out, ind).unwrap()
+    pub fn f_linalg_tensorinv_out(&self, out: &Tensor, ind: i64) -> Tensor {
+        self.linalg_tensorinv_out(out, ind).unwrap()
     }
 
-    pub fn linalg_tensorsolve(&self, other: &Tensor, dims: impl IntListOption) -> Tensor {
-        self.f_linalg_tensorsolve(other, dims).unwrap()
+    pub fn f_linalg_tensorsolve(&self, other: &Tensor, dims: impl IntListOption) -> Tensor {
+        self.linalg_tensorsolve(other, dims).unwrap()
     }
 
-    pub fn linalg_tensorsolve_out(
+    pub fn f_linalg_tensorsolve_out(
         &self,
         out: &Tensor,
         other: &Tensor,
         dims: impl IntListOption,
     ) -> Tensor {
-        self.f_linalg_tensorsolve_out(out, other, dims).unwrap()
+        self.linalg_tensorsolve_out(out, other, dims).unwrap()
     }
 
-    pub fn linalg_vander(x: &Tensor, n: impl Into<Option<i64>>) -> Tensor {
-        Tensor::f_linalg_vander(x, n).unwrap()
+    pub fn f_linalg_vander(x: &Tensor, n: impl Into<Option<i64>>) -> Tensor {
+        Tensor::linalg_vander(x, n).unwrap()
     }
 
-    pub fn linalg_vecdot(x: &Tensor, y: &Tensor, dim: i64) -> Tensor {
-        Tensor::f_linalg_vecdot(x, y, dim).unwrap()
+    pub fn f_linalg_vecdot(x: &Tensor, y: &Tensor, dim: i64) -> Tensor {
+        Tensor::linalg_vecdot(x, y, dim).unwrap()
     }
 
-    pub fn linalg_vecdot_out(out: &Tensor, x: &Tensor, y: &Tensor, dim: i64) -> Tensor {
-        Tensor::f_linalg_vecdot_out(out, x, y, dim).unwrap()
+    pub fn f_linalg_vecdot_out(out: &Tensor, x: &Tensor, y: &Tensor, dim: i64) -> Tensor {
+        Tensor::linalg_vecdot_out(out, x, y, dim).unwrap()
     }
 
-    pub fn linear<T: Borrow<Tensor>>(&self, weight: &Tensor, bias: Option<T>) -> Tensor {
-        self.f_linear(weight, bias).unwrap()
+    pub fn f_linear<T: Borrow<Tensor>>(&self, weight: &Tensor, bias: Option<T>) -> Tensor {
+        self.linear(weight, bias).unwrap()
     }
 
-    pub fn linear_out<T: Borrow<Tensor>>(
+    pub fn f_linear_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
         bias: Option<T>,
     ) -> Tensor {
-        self.f_linear_out(out, weight, bias).unwrap()
+        self.linear_out(out, weight, bias).unwrap()
     }
 
-    pub fn linspace<S: Into<Scalar>>(
+    pub fn f_linspace<S: Into<Scalar>>(
         start: S,
         end: S,
         steps: i64,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_linspace(start, end, steps, options).unwrap()
+        Tensor::linspace(start, end, steps, options).unwrap()
     }
 
-    pub fn linspace_out<S: Into<Scalar>>(out: &Tensor, start: S, end: S, steps: i64) -> Tensor {
-        Tensor::f_linspace_out(out, start, end, steps).unwrap()
+    pub fn f_linspace_out<S: Into<Scalar>>(out: &Tensor, start: S, end: S, steps: i64) -> Tensor {
+        Tensor::linspace_out(out, start, end, steps).unwrap()
     }
 
-    pub fn log(&self) -> Tensor {
-        self.f_log().unwrap()
+    pub fn f_log(&self) -> Tensor {
+        self.log().unwrap()
     }
 
-    pub fn log10(&self) -> Tensor {
-        self.f_log10().unwrap()
+    pub fn f_log10(&self) -> Tensor {
+        self.log10().unwrap()
     }
 
-    pub fn log10_(&mut self) -> Tensor {
-        self.f_log10_().unwrap()
+    pub fn f_log10_(&mut self) -> Tensor {
+        self.log10_().unwrap()
     }
 
-    pub fn log10_out(&self, out: &Tensor) -> Tensor {
-        self.f_log10_out(out).unwrap()
+    pub fn f_log10_out(&self, out: &Tensor) -> Tensor {
+        self.log10_out(out).unwrap()
     }
 
-    pub fn log1p(&self) -> Tensor {
-        self.f_log1p().unwrap()
+    pub fn f_log1p(&self) -> Tensor {
+        self.log1p().unwrap()
     }
 
-    pub fn log1p_(&mut self) -> Tensor {
-        self.f_log1p_().unwrap()
+    pub fn f_log1p_(&mut self) -> Tensor {
+        self.log1p_().unwrap()
     }
 
-    pub fn log1p_out(&self, out: &Tensor) -> Tensor {
-        self.f_log1p_out(out).unwrap()
+    pub fn f_log1p_out(&self, out: &Tensor) -> Tensor {
+        self.log1p_out(out).unwrap()
     }
 
-    pub fn log2(&self) -> Tensor {
-        self.f_log2().unwrap()
+    pub fn f_log2(&self) -> Tensor {
+        self.log2().unwrap()
     }
 
-    pub fn log2_(&mut self) -> Tensor {
-        self.f_log2_().unwrap()
+    pub fn f_log2_(&mut self) -> Tensor {
+        self.log2_().unwrap()
     }
 
-    pub fn log2_out(&self, out: &Tensor) -> Tensor {
-        self.f_log2_out(out).unwrap()
+    pub fn f_log2_out(&self, out: &Tensor) -> Tensor {
+        self.log2_out(out).unwrap()
     }
 
-    pub fn log_(&mut self) -> Tensor {
-        self.f_log_().unwrap()
+    pub fn f_log_(&mut self) -> Tensor {
+        self.log_().unwrap()
     }
 
-    pub fn log_normal(&self, mean: f64, std: f64) -> Tensor {
-        self.f_log_normal(mean, std).unwrap()
+    pub fn f_log_normal(&self, mean: f64, std: f64) -> Tensor {
+        self.log_normal(mean, std).unwrap()
     }
 
-    pub fn log_normal_(&mut self, mean: f64, std: f64) -> Tensor {
-        self.f_log_normal_(mean, std).unwrap()
+    pub fn f_log_normal_(&mut self, mean: f64, std: f64) -> Tensor {
+        self.log_normal_(mean, std).unwrap()
     }
 
-    pub fn log_normal_out(&self, out: &Tensor, mean: f64, std: f64) -> Tensor {
-        self.f_log_normal_out(out, mean, std).unwrap()
+    pub fn f_log_normal_out(&self, out: &Tensor, mean: f64, std: f64) -> Tensor {
+        self.log_normal_out(out, mean, std).unwrap()
     }
 
-    pub fn log_out(&self, out: &Tensor) -> Tensor {
-        self.f_log_out(out).unwrap()
+    pub fn f_log_out(&self, out: &Tensor) -> Tensor {
+        self.log_out(out).unwrap()
     }
 
-    pub fn log_sigmoid(&self) -> Tensor {
-        self.f_log_sigmoid().unwrap()
+    pub fn f_log_sigmoid(&self) -> Tensor {
+        self.log_sigmoid().unwrap()
     }
 
-    pub fn log_sigmoid_backward(&self, grad_output: &Tensor, buffer: &Tensor) -> Tensor {
-        self.f_log_sigmoid_backward(grad_output, buffer).unwrap()
+    pub fn f_log_sigmoid_backward(&self, grad_output: &Tensor, buffer: &Tensor) -> Tensor {
+        self.log_sigmoid_backward(grad_output, buffer).unwrap()
     }
 
-    pub fn log_sigmoid_backward_grad_input(
+    pub fn f_log_sigmoid_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
         buffer: &Tensor,
     ) -> Tensor {
-        self.f_log_sigmoid_backward_grad_input(grad_input, grad_output, buffer).unwrap()
+        self.log_sigmoid_backward_grad_input(grad_input, grad_output, buffer).unwrap()
     }
 
-    pub fn log_sigmoid_out(&self, out: &Tensor) -> Tensor {
-        self.f_log_sigmoid_out(out).unwrap()
+    pub fn f_log_sigmoid_out(&self, out: &Tensor) -> Tensor {
+        self.log_sigmoid_out(out).unwrap()
     }
 
-    pub fn log_softmax(&self, dim: i64, dtype: impl Into<Option<Kind>>) -> Tensor {
-        self.f_log_softmax(dim, dtype).unwrap()
+    pub fn f_log_softmax(&self, dim: i64, dtype: impl Into<Option<Kind>>) -> Tensor {
+        self.log_softmax(dim, dtype).unwrap()
     }
 
-    pub fn log_softmax_int_out(
+    pub fn f_log_softmax_int_out(
         &self,
         out: &Tensor,
         dim: i64,
         dtype: impl Into<Option<Kind>>,
     ) -> Tensor {
-        self.f_log_softmax_int_out(out, dim, dtype).unwrap()
+        self.log_softmax_int_out(out, dim, dtype).unwrap()
     }
 
-    pub fn logaddexp(&self, other: &Tensor) -> Tensor {
-        self.f_logaddexp(other).unwrap()
+    pub fn f_logaddexp(&self, other: &Tensor) -> Tensor {
+        self.logaddexp(other).unwrap()
     }
 
-    pub fn logaddexp2(&self, other: &Tensor) -> Tensor {
-        self.f_logaddexp2(other).unwrap()
+    pub fn f_logaddexp2(&self, other: &Tensor) -> Tensor {
+        self.logaddexp2(other).unwrap()
     }
 
-    pub fn logaddexp2_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_logaddexp2_out(out, other).unwrap()
+    pub fn f_logaddexp2_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.logaddexp2_out(out, other).unwrap()
     }
 
-    pub fn logaddexp_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_logaddexp_out(out, other).unwrap()
+    pub fn f_logaddexp_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.logaddexp_out(out, other).unwrap()
     }
 
-    pub fn logcumsumexp(&self, dim: i64) -> Tensor {
-        self.f_logcumsumexp(dim).unwrap()
+    pub fn f_logcumsumexp(&self, dim: i64) -> Tensor {
+        self.logcumsumexp(dim).unwrap()
     }
 
-    pub fn logcumsumexp_out(&self, out: &Tensor, dim: i64) -> Tensor {
-        self.f_logcumsumexp_out(out, dim).unwrap()
+    pub fn f_logcumsumexp_out(&self, out: &Tensor, dim: i64) -> Tensor {
+        self.logcumsumexp_out(out, dim).unwrap()
     }
 
-    pub fn logdet(&self) -> Tensor {
-        self.f_logdet().unwrap()
+    pub fn f_logdet(&self) -> Tensor {
+        self.logdet().unwrap()
     }
 
-    pub fn logical_and(&self, other: &Tensor) -> Tensor {
-        self.f_logical_and(other).unwrap()
+    pub fn f_logical_and(&self, other: &Tensor) -> Tensor {
+        self.logical_and(other).unwrap()
     }
 
-    pub fn logical_and_(&mut self, other: &Tensor) -> Tensor {
-        self.f_logical_and_(other).unwrap()
+    pub fn f_logical_and_(&mut self, other: &Tensor) -> Tensor {
+        self.logical_and_(other).unwrap()
     }
 
-    pub fn logical_and_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_logical_and_out(out, other).unwrap()
+    pub fn f_logical_and_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.logical_and_out(out, other).unwrap()
     }
 
-    pub fn logical_not(&self) -> Tensor {
-        self.f_logical_not().unwrap()
+    pub fn f_logical_not(&self) -> Tensor {
+        self.logical_not().unwrap()
     }
 
-    pub fn logical_not_(&mut self) -> Tensor {
-        self.f_logical_not_().unwrap()
+    pub fn f_logical_not_(&mut self) -> Tensor {
+        self.logical_not_().unwrap()
     }
 
-    pub fn logical_not_out(&self, out: &Tensor) -> Tensor {
-        self.f_logical_not_out(out).unwrap()
+    pub fn f_logical_not_out(&self, out: &Tensor) -> Tensor {
+        self.logical_not_out(out).unwrap()
     }
 
-    pub fn logical_or(&self, other: &Tensor) -> Tensor {
-        self.f_logical_or(other).unwrap()
+    pub fn f_logical_or(&self, other: &Tensor) -> Tensor {
+        self.logical_or(other).unwrap()
     }
 
-    pub fn logical_or_(&mut self, other: &Tensor) -> Tensor {
-        self.f_logical_or_(other).unwrap()
+    pub fn f_logical_or_(&mut self, other: &Tensor) -> Tensor {
+        self.logical_or_(other).unwrap()
     }
 
-    pub fn logical_or_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_logical_or_out(out, other).unwrap()
+    pub fn f_logical_or_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.logical_or_out(out, other).unwrap()
     }
 
-    pub fn logical_xor(&self, other: &Tensor) -> Tensor {
-        self.f_logical_xor(other).unwrap()
+    pub fn f_logical_xor(&self, other: &Tensor) -> Tensor {
+        self.logical_xor(other).unwrap()
     }
 
-    pub fn logical_xor_(&mut self, other: &Tensor) -> Tensor {
-        self.f_logical_xor_(other).unwrap()
+    pub fn f_logical_xor_(&mut self, other: &Tensor) -> Tensor {
+        self.logical_xor_(other).unwrap()
     }
 
-    pub fn logical_xor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_logical_xor_out(out, other).unwrap()
+    pub fn f_logical_xor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.logical_xor_out(out, other).unwrap()
     }
 
-    pub fn logit(&self, eps: impl Into<Option<f64>>) -> Tensor {
-        self.f_logit(eps).unwrap()
+    pub fn f_logit(&self, eps: impl Into<Option<f64>>) -> Tensor {
+        self.logit(eps).unwrap()
     }
 
-    pub fn logit_(&mut self, eps: impl Into<Option<f64>>) -> Tensor {
-        self.f_logit_(eps).unwrap()
+    pub fn f_logit_(&mut self, eps: impl Into<Option<f64>>) -> Tensor {
+        self.logit_(eps).unwrap()
     }
 
-    pub fn logit_backward(&self, grad_output: &Tensor, eps: impl Into<Option<f64>>) -> Tensor {
-        self.f_logit_backward(grad_output, eps).unwrap()
+    pub fn f_logit_backward(&self, grad_output: &Tensor, eps: impl Into<Option<f64>>) -> Tensor {
+        self.logit_backward(grad_output, eps).unwrap()
     }
 
-    pub fn logit_backward_grad_input(
+    pub fn f_logit_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
         eps: impl Into<Option<f64>>,
     ) -> Tensor {
-        self.f_logit_backward_grad_input(grad_input, grad_output, eps).unwrap()
+        self.logit_backward_grad_input(grad_input, grad_output, eps).unwrap()
     }
 
-    pub fn logit_out(&self, out: &Tensor, eps: impl Into<Option<f64>>) -> Tensor {
-        self.f_logit_out(out, eps).unwrap()
+    pub fn f_logit_out(&self, out: &Tensor, eps: impl Into<Option<f64>>) -> Tensor {
+        self.logit_out(out, eps).unwrap()
     }
 
-    pub fn logspace<S: Into<Scalar>>(
+    pub fn f_logspace<S: Into<Scalar>>(
         start: S,
         end: S,
         steps: i64,
         base: f64,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_logspace(start, end, steps, base, options).unwrap()
+        Tensor::logspace(start, end, steps, base, options).unwrap()
     }
 
-    pub fn logspace_out<S: Into<Scalar>>(
+    pub fn f_logspace_out<S: Into<Scalar>>(
         out: &Tensor,
         start: S,
         end: S,
         steps: i64,
         base: f64,
     ) -> Tensor {
-        Tensor::f_logspace_out(out, start, end, steps, base).unwrap()
+        Tensor::logspace_out(out, start, end, steps, base).unwrap()
     }
 
-    pub fn logsumexp(&self, dim: impl IntList, keepdim: bool) -> Tensor {
-        self.f_logsumexp(dim, keepdim).unwrap()
+    pub fn f_logsumexp(&self, dim: impl IntList, keepdim: bool) -> Tensor {
+        self.logsumexp(dim, keepdim).unwrap()
     }
 
-    pub fn logsumexp_out(&self, out: &Tensor, dim: impl IntList, keepdim: bool) -> Tensor {
-        self.f_logsumexp_out(out, dim, keepdim).unwrap()
+    pub fn f_logsumexp_out(&self, out: &Tensor, dim: impl IntList, keepdim: bool) -> Tensor {
+        self.logsumexp_out(out, dim, keepdim).unwrap()
     }
 
-    pub fn lstm<T: Borrow<Tensor>>(
+    pub fn f_lstm<T: Borrow<Tensor>>(
         &self,
         hx: &[T],
         params: &[T],
@@ -11121,11 +11147,11 @@ impl Tensor {
         bidirectional: bool,
         batch_first: bool,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_lstm(hx, params, has_biases, num_layers, dropout, train, bidirectional, batch_first)
+        self.lstm(hx, params, has_biases, num_layers, dropout, train, bidirectional, batch_first)
             .unwrap()
     }
 
-    pub fn lstm_cell<T: Borrow<Tensor>>(
+    pub fn f_lstm_cell<T: Borrow<Tensor>>(
         &self,
         hx: &[T],
         w_ih: &Tensor,
@@ -11133,10 +11159,10 @@ impl Tensor {
         b_ih: Option<T>,
         b_hh: Option<T>,
     ) -> (Tensor, Tensor) {
-        self.f_lstm_cell(hx, w_ih, w_hh, b_ih, b_hh).unwrap()
+        self.lstm_cell(hx, w_ih, w_hh, b_ih, b_hh).unwrap()
     }
 
-    pub fn lstm_data<T: Borrow<Tensor>>(
+    pub fn f_lstm_data<T: Borrow<Tensor>>(
         data: &Tensor,
         batch_sizes: &Tensor,
         hx: &[T],
@@ -11147,7 +11173,7 @@ impl Tensor {
         train: bool,
         bidirectional: bool,
     ) -> (Tensor, Tensor, Tensor) {
-        Tensor::f_lstm_data(
+        Tensor::lstm_data(
             data,
             batch_sizes,
             hx,
@@ -11161,7 +11187,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn lstm_mps_backward<T: Borrow<Tensor>>(
+    pub fn f_lstm_mps_backward<T: Borrow<Tensor>>(
         &self,
         out0: &Tensor,
         out1: &[T],
@@ -11181,7 +11207,7 @@ impl Tensor {
         bidirectional: bool,
         batch_first: bool,
     ) {
-        self.f_lstm_mps_backward(
+        self.lstm_mps_backward(
             out0,
             out1,
             out2,
@@ -11203,48 +11229,48 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn lt<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_lt(other).unwrap()
+    pub fn f_lt<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.lt(other).unwrap()
     }
 
-    pub fn lt_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_lt_(other).unwrap()
+    pub fn f_lt_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.lt_(other).unwrap()
     }
 
-    pub fn lt_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
-        self.f_lt_scalar_out(out, other).unwrap()
+    pub fn f_lt_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
+        self.lt_scalar_out(out, other).unwrap()
     }
 
-    pub fn lt_tensor(&self, other: &Tensor) -> Tensor {
-        self.f_lt_tensor(other).unwrap()
+    pub fn f_lt_tensor(&self, other: &Tensor) -> Tensor {
+        self.lt_tensor(other).unwrap()
     }
 
-    pub fn lt_tensor_(&mut self, other: &Tensor) -> Tensor {
-        self.f_lt_tensor_(other).unwrap()
+    pub fn f_lt_tensor_(&mut self, other: &Tensor) -> Tensor {
+        self.lt_tensor_(other).unwrap()
     }
 
-    pub fn lt_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_lt_tensor_out(out, other).unwrap()
+    pub fn f_lt_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.lt_tensor_out(out, other).unwrap()
     }
 
-    pub fn lu_solve(&self, lu_data: &Tensor, lu_pivots: &Tensor) -> Tensor {
-        self.f_lu_solve(lu_data, lu_pivots).unwrap()
+    pub fn f_lu_solve(&self, lu_data: &Tensor, lu_pivots: &Tensor) -> Tensor {
+        self.lu_solve(lu_data, lu_pivots).unwrap()
     }
 
-    pub fn lu_solve_out(&self, out: &Tensor, lu_data: &Tensor, lu_pivots: &Tensor) -> Tensor {
-        self.f_lu_solve_out(out, lu_data, lu_pivots).unwrap()
+    pub fn f_lu_solve_out(&self, out: &Tensor, lu_data: &Tensor, lu_pivots: &Tensor) -> Tensor {
+        self.lu_solve_out(out, lu_data, lu_pivots).unwrap()
     }
 
-    pub fn lu_unpack(
+    pub fn f_lu_unpack(
         lu_data: &Tensor,
         lu_pivots: &Tensor,
         unpack_data: bool,
         unpack_pivots: bool,
     ) -> (Tensor, Tensor, Tensor) {
-        Tensor::f_lu_unpack(lu_data, lu_pivots, unpack_data, unpack_pivots).unwrap()
+        Tensor::lu_unpack(lu_data, lu_pivots, unpack_data, unpack_pivots).unwrap()
     }
 
-    pub fn lu_unpack_out(
+    pub fn f_lu_unpack_out(
         p: &Tensor,
         l: &Tensor,
         u: &Tensor,
@@ -11253,127 +11279,127 @@ impl Tensor {
         unpack_data: bool,
         unpack_pivots: bool,
     ) -> (Tensor, Tensor, Tensor) {
-        Tensor::f_lu_unpack_out(p, l, u, lu_data, lu_pivots, unpack_data, unpack_pivots).unwrap()
+        Tensor::lu_unpack_out(p, l, u, lu_data, lu_pivots, unpack_data, unpack_pivots).unwrap()
     }
 
-    pub fn margin_ranking_loss(
+    pub fn f_margin_ranking_loss(
         input1: &Tensor,
         input2: &Tensor,
         target: &Tensor,
         margin: f64,
         reduction: crate::Reduction,
     ) -> Tensor {
-        Tensor::f_margin_ranking_loss(input1, input2, target, margin, reduction).unwrap()
+        Tensor::margin_ranking_loss(input1, input2, target, margin, reduction).unwrap()
     }
 
-    pub fn masked_fill<S: Into<Scalar>>(&self, mask: &Tensor, value: S) -> Tensor {
-        self.f_masked_fill(mask, value).unwrap()
+    pub fn f_masked_fill<S: Into<Scalar>>(&self, mask: &Tensor, value: S) -> Tensor {
+        self.masked_fill(mask, value).unwrap()
     }
 
-    pub fn masked_fill_<S: Into<Scalar>>(&mut self, mask: &Tensor, value: S) -> Tensor {
-        self.f_masked_fill_(mask, value).unwrap()
+    pub fn f_masked_fill_<S: Into<Scalar>>(&mut self, mask: &Tensor, value: S) -> Tensor {
+        self.masked_fill_(mask, value).unwrap()
     }
 
-    pub fn masked_fill_scalar_out<S: Into<Scalar>>(
+    pub fn f_masked_fill_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         mask: &Tensor,
         value: S,
     ) -> Tensor {
-        self.f_masked_fill_scalar_out(out, mask, value).unwrap()
+        self.masked_fill_scalar_out(out, mask, value).unwrap()
     }
 
-    pub fn masked_fill_tensor(&self, mask: &Tensor, value: &Tensor) -> Tensor {
-        self.f_masked_fill_tensor(mask, value).unwrap()
+    pub fn f_masked_fill_tensor(&self, mask: &Tensor, value: &Tensor) -> Tensor {
+        self.masked_fill_tensor(mask, value).unwrap()
     }
 
-    pub fn masked_fill_tensor_(&mut self, mask: &Tensor, value: &Tensor) -> Tensor {
-        self.f_masked_fill_tensor_(mask, value).unwrap()
+    pub fn f_masked_fill_tensor_(&mut self, mask: &Tensor, value: &Tensor) -> Tensor {
+        self.masked_fill_tensor_(mask, value).unwrap()
     }
 
-    pub fn masked_fill_tensor_out(&self, out: &Tensor, mask: &Tensor, value: &Tensor) -> Tensor {
-        self.f_masked_fill_tensor_out(out, mask, value).unwrap()
+    pub fn f_masked_fill_tensor_out(&self, out: &Tensor, mask: &Tensor, value: &Tensor) -> Tensor {
+        self.masked_fill_tensor_out(out, mask, value).unwrap()
     }
 
-    pub fn masked_scatter(&self, mask: &Tensor, source: &Tensor) -> Tensor {
-        self.f_masked_scatter(mask, source).unwrap()
+    pub fn f_masked_scatter(&self, mask: &Tensor, source: &Tensor) -> Tensor {
+        self.masked_scatter(mask, source).unwrap()
     }
 
-    pub fn masked_scatter_(&mut self, mask: &Tensor, source: &Tensor) -> Tensor {
-        self.f_masked_scatter_(mask, source).unwrap()
+    pub fn f_masked_scatter_(&mut self, mask: &Tensor, source: &Tensor) -> Tensor {
+        self.masked_scatter_(mask, source).unwrap()
     }
 
-    pub fn masked_scatter_out(&self, out: &Tensor, mask: &Tensor, source: &Tensor) -> Tensor {
-        self.f_masked_scatter_out(out, mask, source).unwrap()
+    pub fn f_masked_scatter_out(&self, out: &Tensor, mask: &Tensor, source: &Tensor) -> Tensor {
+        self.masked_scatter_out(out, mask, source).unwrap()
     }
 
-    pub fn masked_select(&self, mask: &Tensor) -> Tensor {
-        self.f_masked_select(mask).unwrap()
+    pub fn f_masked_select(&self, mask: &Tensor) -> Tensor {
+        self.masked_select(mask).unwrap()
     }
 
-    pub fn masked_select_backward(&self, grad: &Tensor, mask: &Tensor) -> Tensor {
-        self.f_masked_select_backward(grad, mask).unwrap()
+    pub fn f_masked_select_backward(&self, grad: &Tensor, mask: &Tensor) -> Tensor {
+        self.masked_select_backward(grad, mask).unwrap()
     }
 
-    pub fn masked_select_out(&self, out: &Tensor, mask: &Tensor) -> Tensor {
-        self.f_masked_select_out(out, mask).unwrap()
+    pub fn f_masked_select_out(&self, out: &Tensor, mask: &Tensor) -> Tensor {
+        self.masked_select_out(out, mask).unwrap()
     }
 
-    pub fn matmul(&self, other: &Tensor) -> Tensor {
-        self.f_matmul(other).unwrap()
+    pub fn f_matmul(&self, other: &Tensor) -> Tensor {
+        self.matmul(other).unwrap()
     }
 
-    pub fn matmul_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_matmul_out(out, other).unwrap()
+    pub fn f_matmul_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.matmul_out(out, other).unwrap()
     }
 
-    pub fn matrix_exp(&self) -> Tensor {
-        self.f_matrix_exp().unwrap()
+    pub fn f_matrix_exp(&self) -> Tensor {
+        self.matrix_exp().unwrap()
     }
 
-    pub fn matrix_exp_backward(&self, grad: &Tensor) -> Tensor {
-        self.f_matrix_exp_backward(grad).unwrap()
+    pub fn f_matrix_exp_backward(&self, grad: &Tensor) -> Tensor {
+        self.matrix_exp_backward(grad).unwrap()
     }
 
-    pub fn matrix_h(&self) -> Tensor {
-        self.f_matrix_h().unwrap()
+    pub fn f_matrix_h(&self) -> Tensor {
+        self.matrix_h().unwrap()
     }
 
-    pub fn matrix_power(&self, n: i64) -> Tensor {
-        self.f_matrix_power(n).unwrap()
+    pub fn f_matrix_power(&self, n: i64) -> Tensor {
+        self.matrix_power(n).unwrap()
     }
 
-    pub fn matrix_power_out(&self, out: &Tensor, n: i64) -> Tensor {
-        self.f_matrix_power_out(out, n).unwrap()
+    pub fn f_matrix_power_out(&self, out: &Tensor, n: i64) -> Tensor {
+        self.matrix_power_out(out, n).unwrap()
     }
 
-    pub fn max(&self) -> Tensor {
-        self.f_max().unwrap()
+    pub fn f_max(&self) -> Tensor {
+        self.max().unwrap()
     }
 
-    pub fn max_dim(&self, dim: i64, keepdim: bool) -> (Tensor, Tensor) {
-        self.f_max_dim(dim, keepdim).unwrap()
+    pub fn f_max_dim(&self, dim: i64, keepdim: bool) -> (Tensor, Tensor) {
+        self.max_dim(dim, keepdim).unwrap()
     }
 
-    pub fn max_dim_max(
+    pub fn f_max_dim_max(
         &self,
         max: &Tensor,
         max_values: &Tensor,
         dim: i64,
         keepdim: bool,
     ) -> (Tensor, Tensor) {
-        self.f_max_dim_max(max, max_values, dim, keepdim).unwrap()
+        self.max_dim_max(max, max_values, dim, keepdim).unwrap()
     }
 
-    pub fn max_other(&self, other: &Tensor) -> Tensor {
-        self.f_max_other(other).unwrap()
+    pub fn f_max_other(&self, other: &Tensor) -> Tensor {
+        self.max_other(other).unwrap()
     }
 
-    pub fn max_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_max_out(out, other).unwrap()
+    pub fn f_max_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.max_out(out, other).unwrap()
     }
 
-    pub fn max_pool1d(
+    pub fn f_max_pool1d(
         &self,
         kernel_size: impl IntList,
         stride: impl IntList,
@@ -11381,10 +11407,10 @@ impl Tensor {
         dilation: impl IntList,
         ceil_mode: bool,
     ) -> Tensor {
-        self.f_max_pool1d(kernel_size, stride, padding, dilation, ceil_mode).unwrap()
+        self.max_pool1d(kernel_size, stride, padding, dilation, ceil_mode).unwrap()
     }
 
-    pub fn max_pool1d_with_indices(
+    pub fn f_max_pool1d_with_indices(
         &self,
         kernel_size: impl IntList,
         stride: impl IntList,
@@ -11392,10 +11418,10 @@ impl Tensor {
         dilation: impl IntList,
         ceil_mode: bool,
     ) -> (Tensor, Tensor) {
-        self.f_max_pool1d_with_indices(kernel_size, stride, padding, dilation, ceil_mode).unwrap()
+        self.max_pool1d_with_indices(kernel_size, stride, padding, dilation, ceil_mode).unwrap()
     }
 
-    pub fn max_pool2d(
+    pub fn f_max_pool2d(
         &self,
         kernel_size: impl IntList,
         stride: impl IntList,
@@ -11403,10 +11429,10 @@ impl Tensor {
         dilation: impl IntList,
         ceil_mode: bool,
     ) -> Tensor {
-        self.f_max_pool2d(kernel_size, stride, padding, dilation, ceil_mode).unwrap()
+        self.max_pool2d(kernel_size, stride, padding, dilation, ceil_mode).unwrap()
     }
 
-    pub fn max_pool2d_backward(
+    pub fn f_max_pool2d_backward(
         &self,
         grad_output: &Tensor,
         kernel_size: impl IntList,
@@ -11415,11 +11441,11 @@ impl Tensor {
         dilation: impl IntList,
         ceil_mode: bool,
     ) -> Tensor {
-        self.f_max_pool2d_backward(grad_output, kernel_size, stride, padding, dilation, ceil_mode)
+        self.max_pool2d_backward(grad_output, kernel_size, stride, padding, dilation, ceil_mode)
             .unwrap()
     }
 
-    pub fn max_pool2d_backward_out(
+    pub fn f_max_pool2d_backward_out(
         &self,
         out: &Tensor,
         grad_output: &Tensor,
@@ -11429,7 +11455,7 @@ impl Tensor {
         dilation: impl IntList,
         ceil_mode: bool,
     ) -> Tensor {
-        self.f_max_pool2d_backward_out(
+        self.max_pool2d_backward_out(
             out,
             grad_output,
             kernel_size,
@@ -11441,7 +11467,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn max_pool2d_with_indices(
+    pub fn f_max_pool2d_with_indices(
         &self,
         kernel_size: impl IntList,
         stride: impl IntList,
@@ -11449,10 +11475,10 @@ impl Tensor {
         dilation: impl IntList,
         ceil_mode: bool,
     ) -> (Tensor, Tensor) {
-        self.f_max_pool2d_with_indices(kernel_size, stride, padding, dilation, ceil_mode).unwrap()
+        self.max_pool2d_with_indices(kernel_size, stride, padding, dilation, ceil_mode).unwrap()
     }
 
-    pub fn max_pool2d_with_indices_backward(
+    pub fn f_max_pool2d_with_indices_backward(
         &self,
         grad_output: &Tensor,
         kernel_size: impl IntList,
@@ -11462,7 +11488,7 @@ impl Tensor {
         ceil_mode: bool,
         indices: &Tensor,
     ) -> Tensor {
-        self.f_max_pool2d_with_indices_backward(
+        self.max_pool2d_with_indices_backward(
             grad_output,
             kernel_size,
             stride,
@@ -11474,7 +11500,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn max_pool2d_with_indices_backward_grad_input(
+    pub fn f_max_pool2d_with_indices_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -11485,7 +11511,7 @@ impl Tensor {
         ceil_mode: bool,
         indices: &Tensor,
     ) -> Tensor {
-        self.f_max_pool2d_with_indices_backward_grad_input(
+        self.max_pool2d_with_indices_backward_grad_input(
             grad_input,
             grad_output,
             kernel_size,
@@ -11498,7 +11524,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn max_pool2d_with_indices_out(
+    pub fn f_max_pool2d_with_indices_out(
         &self,
         out: &Tensor,
         indices: &Tensor,
@@ -11508,7 +11534,7 @@ impl Tensor {
         dilation: impl IntList,
         ceil_mode: bool,
     ) -> (Tensor, Tensor) {
-        self.f_max_pool2d_with_indices_out(
+        self.max_pool2d_with_indices_out(
             out,
             indices,
             kernel_size,
@@ -11520,7 +11546,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn max_pool3d(
+    pub fn f_max_pool3d(
         &self,
         kernel_size: impl IntList,
         stride: impl IntList,
@@ -11528,10 +11554,10 @@ impl Tensor {
         dilation: impl IntList,
         ceil_mode: bool,
     ) -> Tensor {
-        self.f_max_pool3d(kernel_size, stride, padding, dilation, ceil_mode).unwrap()
+        self.max_pool3d(kernel_size, stride, padding, dilation, ceil_mode).unwrap()
     }
 
-    pub fn max_pool3d_with_indices(
+    pub fn f_max_pool3d_with_indices(
         &self,
         kernel_size: impl IntList,
         stride: impl IntList,
@@ -11539,10 +11565,10 @@ impl Tensor {
         dilation: impl IntList,
         ceil_mode: bool,
     ) -> (Tensor, Tensor) {
-        self.f_max_pool3d_with_indices(kernel_size, stride, padding, dilation, ceil_mode).unwrap()
+        self.max_pool3d_with_indices(kernel_size, stride, padding, dilation, ceil_mode).unwrap()
     }
 
-    pub fn max_pool3d_with_indices_backward(
+    pub fn f_max_pool3d_with_indices_backward(
         &self,
         grad_output: &Tensor,
         kernel_size: impl IntList,
@@ -11552,7 +11578,7 @@ impl Tensor {
         ceil_mode: bool,
         indices: &Tensor,
     ) -> Tensor {
-        self.f_max_pool3d_with_indices_backward(
+        self.max_pool3d_with_indices_backward(
             grad_output,
             kernel_size,
             stride,
@@ -11564,7 +11590,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn max_pool3d_with_indices_backward_grad_input(
+    pub fn f_max_pool3d_with_indices_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -11575,7 +11601,7 @@ impl Tensor {
         ceil_mode: bool,
         indices: &Tensor,
     ) -> Tensor {
-        self.f_max_pool3d_with_indices_backward_grad_input(
+        self.max_pool3d_with_indices_backward_grad_input(
             grad_input,
             grad_output,
             kernel_size,
@@ -11588,7 +11614,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn max_pool3d_with_indices_out(
+    pub fn f_max_pool3d_with_indices_out(
         &self,
         out: &Tensor,
         indices: &Tensor,
@@ -11598,7 +11624,7 @@ impl Tensor {
         dilation: impl IntList,
         ceil_mode: bool,
     ) -> (Tensor, Tensor) {
-        self.f_max_pool3d_with_indices_out(
+        self.max_pool3d_with_indices_out(
             out,
             indices,
             kernel_size,
@@ -11610,144 +11636,144 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn max_unary_out(&self, out: &Tensor) -> Tensor {
-        self.f_max_unary_out(out).unwrap()
+    pub fn f_max_unary_out(&self, out: &Tensor) -> Tensor {
+        self.max_unary_out(out).unwrap()
     }
 
-    pub fn max_unpool2d(&self, indices: &Tensor, output_size: impl IntList) -> Tensor {
-        self.f_max_unpool2d(indices, output_size).unwrap()
+    pub fn f_max_unpool2d(&self, indices: &Tensor, output_size: impl IntList) -> Tensor {
+        self.max_unpool2d(indices, output_size).unwrap()
     }
 
-    pub fn max_unpool2d_out(
+    pub fn f_max_unpool2d_out(
         &self,
         out: &Tensor,
         indices: &Tensor,
         output_size: impl IntList,
     ) -> Tensor {
-        self.f_max_unpool2d_out(out, indices, output_size).unwrap()
+        self.max_unpool2d_out(out, indices, output_size).unwrap()
     }
 
-    pub fn max_unpool3d(
+    pub fn f_max_unpool3d(
         &self,
-        indices: &Tensor,
-        output_size: impl IntList,
-        stride: impl IntList,
-        padding: impl IntList,
-    ) -> Tensor {
-        self.f_max_unpool3d(indices, output_size, stride, padding).unwrap()
-    }
-
-    pub fn max_unpool3d_out(
-        &self,
-        out: &Tensor,
         indices: &Tensor,
         output_size: impl IntList,
         stride: impl IntList,
         padding: impl IntList,
     ) -> Tensor {
-        self.f_max_unpool3d_out(out, indices, output_size, stride, padding).unwrap()
+        self.max_unpool3d(indices, output_size, stride, padding).unwrap()
     }
 
-    pub fn maximum(&self, other: &Tensor) -> Tensor {
-        self.f_maximum(other).unwrap()
+    pub fn f_max_unpool3d_out(
+        &self,
+        out: &Tensor,
+        indices: &Tensor,
+        output_size: impl IntList,
+        stride: impl IntList,
+        padding: impl IntList,
+    ) -> Tensor {
+        self.max_unpool3d_out(out, indices, output_size, stride, padding).unwrap()
     }
 
-    pub fn maximum_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_maximum_out(out, other).unwrap()
+    pub fn f_maximum(&self, other: &Tensor) -> Tensor {
+        self.maximum(other).unwrap()
     }
 
-    pub fn mean(&self, dtype: impl Into<Option<Kind>>) -> Tensor {
-        self.f_mean(dtype).unwrap()
+    pub fn f_maximum_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.maximum_out(out, other).unwrap()
     }
 
-    pub fn mean_dim(
+    pub fn f_mean(&self, dtype: impl Into<Option<Kind>>) -> Tensor {
+        self.mean(dtype).unwrap()
+    }
+
+    pub fn f_mean_dim(
         &self,
         dim: impl IntListOption,
         keepdim: bool,
         dtype: impl Into<Option<Kind>>,
     ) -> Tensor {
-        self.f_mean_dim(dim, keepdim, dtype).unwrap()
+        self.mean_dim(dim, keepdim, dtype).unwrap()
     }
 
-    pub fn mean_out(
+    pub fn f_mean_out(
         &self,
         out: &Tensor,
         dim: impl IntListOption,
         keepdim: bool,
         dtype: impl Into<Option<Kind>>,
     ) -> Tensor {
-        self.f_mean_out(out, dim, keepdim, dtype).unwrap()
+        self.mean_out(out, dim, keepdim, dtype).unwrap()
     }
 
-    pub fn median(&self) -> Tensor {
-        self.f_median().unwrap()
+    pub fn f_median(&self) -> Tensor {
+        self.median().unwrap()
     }
 
-    pub fn median_dim(&self, dim: i64, keepdim: bool) -> (Tensor, Tensor) {
-        self.f_median_dim(dim, keepdim).unwrap()
+    pub fn f_median_dim(&self, dim: i64, keepdim: bool) -> (Tensor, Tensor) {
+        self.median_dim(dim, keepdim).unwrap()
     }
 
-    pub fn median_dim_values(
+    pub fn f_median_dim_values(
         &self,
         values: &Tensor,
         indices: &Tensor,
         dim: i64,
         keepdim: bool,
     ) -> (Tensor, Tensor) {
-        self.f_median_dim_values(values, indices, dim, keepdim).unwrap()
+        self.median_dim_values(values, indices, dim, keepdim).unwrap()
     }
 
-    pub fn median_out(&self, out: &Tensor) -> Tensor {
-        self.f_median_out(out).unwrap()
+    pub fn f_median_out(&self, out: &Tensor) -> Tensor {
+        self.median_out(out).unwrap()
     }
 
-    pub fn meshgrid<T: Borrow<Tensor>>(tensors: &[T]) -> Vec<Tensor> {
-        Tensor::f_meshgrid(tensors).unwrap()
+    pub fn f_meshgrid<T: Borrow<Tensor>>(tensors: &[T]) -> Vec<Tensor> {
+        Tensor::meshgrid(tensors).unwrap()
     }
 
-    pub fn meshgrid_indexing<T: Borrow<Tensor>>(tensors: &[T], indexing: &str) -> Vec<Tensor> {
-        Tensor::f_meshgrid_indexing(tensors, indexing).unwrap()
+    pub fn f_meshgrid_indexing<T: Borrow<Tensor>>(tensors: &[T], indexing: &str) -> Vec<Tensor> {
+        Tensor::meshgrid_indexing(tensors, indexing).unwrap()
     }
 
-    pub fn mh(&self) -> Tensor {
-        self.f_mh().unwrap()
+    pub fn f_mh(&self) -> Tensor {
+        self.mh().unwrap()
     }
 
-    pub fn min(&self) -> Tensor {
-        self.f_min().unwrap()
+    pub fn f_min(&self) -> Tensor {
+        self.min().unwrap()
     }
 
-    pub fn min_dim(&self, dim: i64, keepdim: bool) -> (Tensor, Tensor) {
-        self.f_min_dim(dim, keepdim).unwrap()
+    pub fn f_min_dim(&self, dim: i64, keepdim: bool) -> (Tensor, Tensor) {
+        self.min_dim(dim, keepdim).unwrap()
     }
 
-    pub fn min_dim_min(
+    pub fn f_min_dim_min(
         &self,
         min: &Tensor,
         min_indices: &Tensor,
         dim: i64,
         keepdim: bool,
     ) -> (Tensor, Tensor) {
-        self.f_min_dim_min(min, min_indices, dim, keepdim).unwrap()
+        self.min_dim_min(min, min_indices, dim, keepdim).unwrap()
     }
 
-    pub fn min_other(&self, other: &Tensor) -> Tensor {
-        self.f_min_other(other).unwrap()
+    pub fn f_min_other(&self, other: &Tensor) -> Tensor {
+        self.min_other(other).unwrap()
     }
 
-    pub fn min_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_min_out(out, other).unwrap()
+    pub fn f_min_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.min_out(out, other).unwrap()
     }
 
-    pub fn minimum(&self, other: &Tensor) -> Tensor {
-        self.f_minimum(other).unwrap()
+    pub fn f_minimum(&self, other: &Tensor) -> Tensor {
+        self.minimum(other).unwrap()
     }
 
-    pub fn minimum_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_minimum_out(out, other).unwrap()
+    pub fn f_minimum_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.minimum_out(out, other).unwrap()
     }
 
-    pub fn miopen_batch_norm<T: Borrow<Tensor>>(
+    pub fn f_miopen_batch_norm<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -11757,7 +11783,7 @@ impl Tensor {
         exponential_average_factor: f64,
         epsilon: f64,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_miopen_batch_norm(
+        self.miopen_batch_norm(
             weight,
             bias,
             running_mean,
@@ -11769,7 +11795,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn miopen_batch_norm_backward<T: Borrow<Tensor>>(
+    pub fn f_miopen_batch_norm_backward<T: Borrow<Tensor>>(
         &self,
         grad_output: &Tensor,
         weight: &Tensor,
@@ -11779,7 +11805,7 @@ impl Tensor {
         save_var: Option<T>,
         epsilon: f64,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_miopen_batch_norm_backward(
+        self.miopen_batch_norm_backward(
             grad_output,
             weight,
             running_mean,
@@ -11791,7 +11817,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn miopen_batch_norm_backward_out<T: Borrow<Tensor>>(
+    pub fn f_miopen_batch_norm_backward_out<T: Borrow<Tensor>>(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -11804,7 +11830,7 @@ impl Tensor {
         save_var: Option<T>,
         epsilon: f64,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_miopen_batch_norm_backward_out(
+        self.miopen_batch_norm_backward_out(
             out0,
             out1,
             out2,
@@ -11819,7 +11845,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn miopen_batch_norm_out<T: Borrow<Tensor>>(
+    pub fn f_miopen_batch_norm_out<T: Borrow<Tensor>>(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -11832,7 +11858,7 @@ impl Tensor {
         exponential_average_factor: f64,
         epsilon: f64,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_miopen_batch_norm_out(
+        self.miopen_batch_norm_out(
             out0,
             out1,
             out2,
@@ -11847,7 +11873,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn miopen_convolution<T: Borrow<Tensor>>(
+    pub fn f_miopen_convolution<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -11858,7 +11884,7 @@ impl Tensor {
         benchmark: bool,
         deterministic: bool,
     ) -> Tensor {
-        self.f_miopen_convolution(
+        self.miopen_convolution(
             weight,
             bias,
             padding,
@@ -11871,7 +11897,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn miopen_convolution_add_relu<T: Borrow<Tensor>, S: Into<Scalar>>(
+    pub fn f_miopen_convolution_add_relu<T: Borrow<Tensor>, S: Into<Scalar>>(
         &self,
         weight: &Tensor,
         z: &Tensor,
@@ -11882,13 +11908,11 @@ impl Tensor {
         dilation: impl IntList,
         groups: i64,
     ) -> Tensor {
-        self.f_miopen_convolution_add_relu(
-            weight, z, alpha, bias, stride, padding, dilation, groups,
-        )
-        .unwrap()
+        self.miopen_convolution_add_relu(weight, z, alpha, bias, stride, padding, dilation, groups)
+            .unwrap()
     }
 
-    pub fn miopen_convolution_out<T: Borrow<Tensor>>(
+    pub fn f_miopen_convolution_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -11900,7 +11924,7 @@ impl Tensor {
         benchmark: bool,
         deterministic: bool,
     ) -> Tensor {
-        self.f_miopen_convolution_out(
+        self.miopen_convolution_out(
             out,
             weight,
             bias,
@@ -11914,7 +11938,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn miopen_convolution_relu<T: Borrow<Tensor>>(
+    pub fn f_miopen_convolution_relu<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -11923,10 +11947,10 @@ impl Tensor {
         dilation: impl IntList,
         groups: i64,
     ) -> Tensor {
-        self.f_miopen_convolution_relu(weight, bias, stride, padding, dilation, groups).unwrap()
+        self.miopen_convolution_relu(weight, bias, stride, padding, dilation, groups).unwrap()
     }
 
-    pub fn miopen_convolution_transpose<T: Borrow<Tensor>>(
+    pub fn f_miopen_convolution_transpose<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -11938,7 +11962,7 @@ impl Tensor {
         benchmark: bool,
         deterministic: bool,
     ) -> Tensor {
-        self.f_miopen_convolution_transpose(
+        self.miopen_convolution_transpose(
             weight,
             bias,
             padding,
@@ -11952,7 +11976,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn miopen_convolution_transpose_out<T: Borrow<Tensor>>(
+    pub fn f_miopen_convolution_transpose_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -11965,7 +11989,7 @@ impl Tensor {
         benchmark: bool,
         deterministic: bool,
     ) -> Tensor {
-        self.f_miopen_convolution_transpose_out(
+        self.miopen_convolution_transpose_out(
             out,
             weight,
             bias,
@@ -11980,7 +12004,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn miopen_depthwise_convolution<T: Borrow<Tensor>>(
+    pub fn f_miopen_depthwise_convolution<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -11991,7 +12015,7 @@ impl Tensor {
         benchmark: bool,
         deterministic: bool,
     ) -> Tensor {
-        self.f_miopen_depthwise_convolution(
+        self.miopen_depthwise_convolution(
             weight,
             bias,
             padding,
@@ -12004,7 +12028,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn miopen_depthwise_convolution_out<T: Borrow<Tensor>>(
+    pub fn f_miopen_depthwise_convolution_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -12016,7 +12040,7 @@ impl Tensor {
         benchmark: bool,
         deterministic: bool,
     ) -> Tensor {
-        self.f_miopen_depthwise_convolution_out(
+        self.miopen_depthwise_convolution_out(
             out,
             weight,
             bias,
@@ -12030,7 +12054,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn miopen_rnn<T: Borrow<Tensor>>(
+    pub fn f_miopen_rnn<T: Borrow<Tensor>>(
         &self,
         weight: &[T],
         weight_stride0: i64,
@@ -12046,7 +12070,7 @@ impl Tensor {
         batch_sizes: impl IntList,
         dropout_state: Option<T>,
     ) -> (Tensor, Tensor, Tensor, Tensor, Tensor) {
-        self.f_miopen_rnn(
+        self.miopen_rnn(
             weight,
             weight_stride0,
             hx,
@@ -12064,7 +12088,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn miopen_rnn_out<T: Borrow<Tensor>>(
+    pub fn f_miopen_rnn_out<T: Borrow<Tensor>>(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -12085,7 +12109,7 @@ impl Tensor {
         batch_sizes: impl IntList,
         dropout_state: Option<T>,
     ) -> (Tensor, Tensor, Tensor, Tensor, Tensor) {
-        self.f_miopen_rnn_out(
+        self.miopen_rnn_out(
             out0,
             out1,
             out2,
@@ -12108,47 +12132,47 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn mish(&self) -> Tensor {
-        self.f_mish().unwrap()
+    pub fn f_mish(&self) -> Tensor {
+        self.mish().unwrap()
     }
 
-    pub fn mish_(&mut self) -> Tensor {
-        self.f_mish_().unwrap()
+    pub fn f_mish_(&mut self) -> Tensor {
+        self.mish_().unwrap()
     }
 
-    pub fn mish_backward(&self, grad_output: &Tensor) -> Tensor {
-        self.f_mish_backward(grad_output).unwrap()
+    pub fn f_mish_backward(&self, grad_output: &Tensor) -> Tensor {
+        self.mish_backward(grad_output).unwrap()
     }
 
-    pub fn mish_out(&self, out: &Tensor) -> Tensor {
-        self.f_mish_out(out).unwrap()
+    pub fn f_mish_out(&self, out: &Tensor) -> Tensor {
+        self.mish_out(out).unwrap()
     }
 
-    pub fn mkldnn_adaptive_avg_pool2d(&self, output_size: impl IntList) -> Tensor {
-        self.f_mkldnn_adaptive_avg_pool2d(output_size).unwrap()
+    pub fn f_mkldnn_adaptive_avg_pool2d(&self, output_size: impl IntList) -> Tensor {
+        self.mkldnn_adaptive_avg_pool2d(output_size).unwrap()
     }
 
-    pub fn mkldnn_adaptive_avg_pool2d_backward(&self, grad_output: &Tensor) -> Tensor {
-        self.f_mkldnn_adaptive_avg_pool2d_backward(grad_output).unwrap()
+    pub fn f_mkldnn_adaptive_avg_pool2d_backward(&self, grad_output: &Tensor) -> Tensor {
+        self.mkldnn_adaptive_avg_pool2d_backward(grad_output).unwrap()
     }
 
-    pub fn mkldnn_adaptive_avg_pool2d_backward_out(
+    pub fn f_mkldnn_adaptive_avg_pool2d_backward_out(
         &self,
         out: &Tensor,
         grad_output: &Tensor,
     ) -> Tensor {
-        self.f_mkldnn_adaptive_avg_pool2d_backward_out(out, grad_output).unwrap()
+        self.mkldnn_adaptive_avg_pool2d_backward_out(out, grad_output).unwrap()
     }
 
-    pub fn mkldnn_adaptive_avg_pool2d_out(
+    pub fn f_mkldnn_adaptive_avg_pool2d_out(
         &self,
         out: &Tensor,
         output_size: impl IntList,
     ) -> Tensor {
-        self.f_mkldnn_adaptive_avg_pool2d_out(out, output_size).unwrap()
+        self.mkldnn_adaptive_avg_pool2d_out(out, output_size).unwrap()
     }
 
-    pub fn mkldnn_convolution<T: Borrow<Tensor>>(
+    pub fn f_mkldnn_convolution<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         bias: Option<T>,
@@ -12157,10 +12181,10 @@ impl Tensor {
         dilation: impl IntList,
         groups: i64,
     ) -> Tensor {
-        self.f_mkldnn_convolution(weight, bias, padding, stride, dilation, groups).unwrap()
+        self.mkldnn_convolution(weight, bias, padding, stride, dilation, groups).unwrap()
     }
 
-    pub fn mkldnn_convolution_out<T: Borrow<Tensor>>(
+    pub fn f_mkldnn_convolution_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -12170,40 +12194,40 @@ impl Tensor {
         dilation: impl IntList,
         groups: i64,
     ) -> Tensor {
-        self.f_mkldnn_convolution_out(out, weight, bias, padding, stride, dilation, groups).unwrap()
+        self.mkldnn_convolution_out(out, weight, bias, padding, stride, dilation, groups).unwrap()
     }
 
-    pub fn mkldnn_linear<T: Borrow<Tensor>>(&self, weight: &Tensor, bias: Option<T>) -> Tensor {
-        self.f_mkldnn_linear(weight, bias).unwrap()
+    pub fn f_mkldnn_linear<T: Borrow<Tensor>>(&self, weight: &Tensor, bias: Option<T>) -> Tensor {
+        self.mkldnn_linear(weight, bias).unwrap()
     }
 
-    pub fn mkldnn_linear_backward_input(
+    pub fn f_mkldnn_linear_backward_input(
         input_size: impl IntList,
         grad_output: &Tensor,
         weight: &Tensor,
     ) -> Tensor {
-        Tensor::f_mkldnn_linear_backward_input(input_size, grad_output, weight).unwrap()
+        Tensor::mkldnn_linear_backward_input(input_size, grad_output, weight).unwrap()
     }
 
-    pub fn mkldnn_linear_backward_input_out(
+    pub fn f_mkldnn_linear_backward_input_out(
         out: &Tensor,
         input_size: impl IntList,
         grad_output: &Tensor,
         weight: &Tensor,
     ) -> Tensor {
-        Tensor::f_mkldnn_linear_backward_input_out(out, input_size, grad_output, weight).unwrap()
+        Tensor::mkldnn_linear_backward_input_out(out, input_size, grad_output, weight).unwrap()
     }
 
-    pub fn mkldnn_linear_backward_weights(
+    pub fn f_mkldnn_linear_backward_weights(
         &self,
         grad_output: &Tensor,
         weight: &Tensor,
         bias_defined: bool,
     ) -> (Tensor, Tensor) {
-        self.f_mkldnn_linear_backward_weights(grad_output, weight, bias_defined).unwrap()
+        self.mkldnn_linear_backward_weights(grad_output, weight, bias_defined).unwrap()
     }
 
-    pub fn mkldnn_linear_backward_weights_out(
+    pub fn f_mkldnn_linear_backward_weights_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -12211,20 +12235,20 @@ impl Tensor {
         weight: &Tensor,
         bias_defined: bool,
     ) -> (Tensor, Tensor) {
-        self.f_mkldnn_linear_backward_weights_out(out0, out1, grad_output, weight, bias_defined)
+        self.mkldnn_linear_backward_weights_out(out0, out1, grad_output, weight, bias_defined)
             .unwrap()
     }
 
-    pub fn mkldnn_linear_out<T: Borrow<Tensor>>(
+    pub fn f_mkldnn_linear_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
         bias: Option<T>,
     ) -> Tensor {
-        self.f_mkldnn_linear_out(out, weight, bias).unwrap()
+        self.mkldnn_linear_out(out, weight, bias).unwrap()
     }
 
-    pub fn mkldnn_max_pool2d(
+    pub fn f_mkldnn_max_pool2d(
         &self,
         kernel_size: impl IntList,
         stride: impl IntList,
@@ -12232,10 +12256,10 @@ impl Tensor {
         dilation: impl IntList,
         ceil_mode: bool,
     ) -> Tensor {
-        self.f_mkldnn_max_pool2d(kernel_size, stride, padding, dilation, ceil_mode).unwrap()
+        self.mkldnn_max_pool2d(kernel_size, stride, padding, dilation, ceil_mode).unwrap()
     }
 
-    pub fn mkldnn_max_pool2d_backward(
+    pub fn f_mkldnn_max_pool2d_backward(
         &self,
         grad_output: &Tensor,
         output: &Tensor,
@@ -12245,7 +12269,7 @@ impl Tensor {
         dilation: impl IntList,
         ceil_mode: bool,
     ) -> Tensor {
-        self.f_mkldnn_max_pool2d_backward(
+        self.mkldnn_max_pool2d_backward(
             grad_output,
             output,
             kernel_size,
@@ -12257,7 +12281,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn mkldnn_max_pool2d_backward_out(
+    pub fn f_mkldnn_max_pool2d_backward_out(
         &self,
         out: &Tensor,
         grad_output: &Tensor,
@@ -12268,7 +12292,7 @@ impl Tensor {
         dilation: impl IntList,
         ceil_mode: bool,
     ) -> Tensor {
-        self.f_mkldnn_max_pool2d_backward_out(
+        self.mkldnn_max_pool2d_backward_out(
             out,
             grad_output,
             output,
@@ -12281,7 +12305,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn mkldnn_max_pool2d_out(
+    pub fn f_mkldnn_max_pool2d_out(
         &self,
         out: &Tensor,
         kernel_size: impl IntList,
@@ -12290,11 +12314,10 @@ impl Tensor {
         dilation: impl IntList,
         ceil_mode: bool,
     ) -> Tensor {
-        self.f_mkldnn_max_pool2d_out(out, kernel_size, stride, padding, dilation, ceil_mode)
-            .unwrap()
+        self.mkldnn_max_pool2d_out(out, kernel_size, stride, padding, dilation, ceil_mode).unwrap()
     }
 
-    pub fn mkldnn_max_pool3d(
+    pub fn f_mkldnn_max_pool3d(
         &self,
         kernel_size: impl IntList,
         stride: impl IntList,
@@ -12302,10 +12325,10 @@ impl Tensor {
         dilation: impl IntList,
         ceil_mode: bool,
     ) -> Tensor {
-        self.f_mkldnn_max_pool3d(kernel_size, stride, padding, dilation, ceil_mode).unwrap()
+        self.mkldnn_max_pool3d(kernel_size, stride, padding, dilation, ceil_mode).unwrap()
     }
 
-    pub fn mkldnn_max_pool3d_backward(
+    pub fn f_mkldnn_max_pool3d_backward(
         &self,
         grad_output: &Tensor,
         output: &Tensor,
@@ -12315,7 +12338,7 @@ impl Tensor {
         dilation: impl IntList,
         ceil_mode: bool,
     ) -> Tensor {
-        self.f_mkldnn_max_pool3d_backward(
+        self.mkldnn_max_pool3d_backward(
             grad_output,
             output,
             kernel_size,
@@ -12327,7 +12350,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn mkldnn_max_pool3d_backward_out(
+    pub fn f_mkldnn_max_pool3d_backward_out(
         &self,
         out: &Tensor,
         grad_output: &Tensor,
@@ -12338,7 +12361,7 @@ impl Tensor {
         dilation: impl IntList,
         ceil_mode: bool,
     ) -> Tensor {
-        self.f_mkldnn_max_pool3d_backward_out(
+        self.mkldnn_max_pool3d_backward_out(
             out,
             grad_output,
             output,
@@ -12351,7 +12374,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn mkldnn_max_pool3d_out(
+    pub fn f_mkldnn_max_pool3d_out(
         &self,
         out: &Tensor,
         kernel_size: impl IntList,
@@ -12360,11 +12383,10 @@ impl Tensor {
         dilation: impl IntList,
         ceil_mode: bool,
     ) -> Tensor {
-        self.f_mkldnn_max_pool3d_out(out, kernel_size, stride, padding, dilation, ceil_mode)
-            .unwrap()
+        self.mkldnn_max_pool3d_out(out, kernel_size, stride, padding, dilation, ceil_mode).unwrap()
     }
 
-    pub fn mkldnn_reorder_conv2d_weight(
+    pub fn f_mkldnn_reorder_conv2d_weight(
         &self,
         padding: impl IntList,
         stride: impl IntList,
@@ -12372,10 +12394,10 @@ impl Tensor {
         groups: i64,
         input_size: impl IntListOption,
     ) -> Tensor {
-        self.f_mkldnn_reorder_conv2d_weight(padding, stride, dilation, groups, input_size).unwrap()
+        self.mkldnn_reorder_conv2d_weight(padding, stride, dilation, groups, input_size).unwrap()
     }
 
-    pub fn mkldnn_reorder_conv2d_weight_out(
+    pub fn f_mkldnn_reorder_conv2d_weight_out(
         &self,
         out: &Tensor,
         padding: impl IntList,
@@ -12384,21 +12406,21 @@ impl Tensor {
         groups: i64,
         input_size: impl IntListOption,
     ) -> Tensor {
-        self.f_mkldnn_reorder_conv2d_weight_out(out, padding, stride, dilation, groups, input_size)
+        self.mkldnn_reorder_conv2d_weight_out(out, padding, stride, dilation, groups, input_size)
             .unwrap()
     }
 
-    pub fn mkldnn_reorder_conv3d_weight(
+    pub fn f_mkldnn_reorder_conv3d_weight(
         &self,
         padding: impl IntList,
         stride: impl IntList,
         dilation: impl IntList,
         groups: i64,
     ) -> Tensor {
-        self.f_mkldnn_reorder_conv3d_weight(padding, stride, dilation, groups).unwrap()
+        self.mkldnn_reorder_conv3d_weight(padding, stride, dilation, groups).unwrap()
     }
 
-    pub fn mkldnn_reorder_conv3d_weight_out(
+    pub fn f_mkldnn_reorder_conv3d_weight_out(
         &self,
         out: &Tensor,
         padding: impl IntList,
@@ -12406,10 +12428,10 @@ impl Tensor {
         dilation: impl IntList,
         groups: i64,
     ) -> Tensor {
-        self.f_mkldnn_reorder_conv3d_weight_out(out, padding, stride, dilation, groups).unwrap()
+        self.mkldnn_reorder_conv3d_weight_out(out, padding, stride, dilation, groups).unwrap()
     }
 
-    pub fn mkldnn_rnn_layer(
+    pub fn f_mkldnn_rnn_layer(
         &self,
         weight0: &Tensor,
         weight1: &Tensor,
@@ -12427,7 +12449,7 @@ impl Tensor {
         batch_first: bool,
         train: bool,
     ) -> (Tensor, Tensor, Tensor, Tensor) {
-        self.f_mkldnn_rnn_layer(
+        self.mkldnn_rnn_layer(
             weight0,
             weight1,
             weight2,
@@ -12447,7 +12469,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn mkldnn_rnn_layer_backward<T: Borrow<Tensor>>(
+    pub fn f_mkldnn_rnn_layer_backward<T: Borrow<Tensor>>(
         &self,
         weight1: &Tensor,
         weight2: &Tensor,
@@ -12472,7 +12494,7 @@ impl Tensor {
         batch_first: bool,
         workspace: &Tensor,
     ) -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor) {
-        self.f_mkldnn_rnn_layer_backward(
+        self.mkldnn_rnn_layer_backward(
             weight1,
             weight2,
             weight3,
@@ -12499,7 +12521,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn mkldnn_rnn_layer_backward_out<T: Borrow<Tensor>>(
+    pub fn f_mkldnn_rnn_layer_backward_out<T: Borrow<Tensor>>(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -12531,7 +12553,7 @@ impl Tensor {
         batch_first: bool,
         workspace: &Tensor,
     ) -> (Tensor, Tensor, Tensor, Tensor, Tensor, Tensor, Tensor) {
-        self.f_mkldnn_rnn_layer_backward_out(
+        self.mkldnn_rnn_layer_backward_out(
             out0,
             out1,
             out2,
@@ -12565,7 +12587,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn mkldnn_rnn_layer_out(
+    pub fn f_mkldnn_rnn_layer_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -12587,7 +12609,7 @@ impl Tensor {
         batch_first: bool,
         train: bool,
     ) -> (Tensor, Tensor, Tensor, Tensor) {
-        self.f_mkldnn_rnn_layer_out(
+        self.mkldnn_rnn_layer_out(
             out0,
             out1,
             out2,
@@ -12611,113 +12633,113 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn mm(&self, mat2: &Tensor) -> Tensor {
-        self.f_mm(mat2).unwrap()
+    pub fn f_mm(&self, mat2: &Tensor) -> Tensor {
+        self.mm(mat2).unwrap()
     }
 
-    pub fn mm_out(&self, out: &Tensor, mat2: &Tensor) -> Tensor {
-        self.f_mm_out(out, mat2).unwrap()
+    pub fn f_mm_out(&self, out: &Tensor, mat2: &Tensor) -> Tensor {
+        self.mm_out(out, mat2).unwrap()
     }
 
-    pub fn mode(&self, dim: i64, keepdim: bool) -> (Tensor, Tensor) {
-        self.f_mode(dim, keepdim).unwrap()
+    pub fn f_mode(&self, dim: i64, keepdim: bool) -> (Tensor, Tensor) {
+        self.mode(dim, keepdim).unwrap()
     }
 
-    pub fn mode_values(
+    pub fn f_mode_values(
         &self,
         values: &Tensor,
         indices: &Tensor,
         dim: i64,
         keepdim: bool,
     ) -> (Tensor, Tensor) {
-        self.f_mode_values(values, indices, dim, keepdim).unwrap()
+        self.mode_values(values, indices, dim, keepdim).unwrap()
     }
 
-    pub fn moveaxis(&self, source: impl IntList, destination: impl IntList) -> Tensor {
-        self.f_moveaxis(source, destination).unwrap()
+    pub fn f_moveaxis(&self, source: impl IntList, destination: impl IntList) -> Tensor {
+        self.moveaxis(source, destination).unwrap()
     }
 
-    pub fn moveaxis_int(&self, source: i64, destination: i64) -> Tensor {
-        self.f_moveaxis_int(source, destination).unwrap()
+    pub fn f_moveaxis_int(&self, source: i64, destination: i64) -> Tensor {
+        self.moveaxis_int(source, destination).unwrap()
     }
 
-    pub fn movedim(&self, source: impl IntList, destination: impl IntList) -> Tensor {
-        self.f_movedim(source, destination).unwrap()
+    pub fn f_movedim(&self, source: impl IntList, destination: impl IntList) -> Tensor {
+        self.movedim(source, destination).unwrap()
     }
 
-    pub fn movedim_int(&self, source: i64, destination: i64) -> Tensor {
-        self.f_movedim_int(source, destination).unwrap()
+    pub fn f_movedim_int(&self, source: i64, destination: i64) -> Tensor {
+        self.movedim_int(source, destination).unwrap()
     }
 
-    pub fn mse_loss(&self, target: &Tensor, reduction: crate::Reduction) -> Tensor {
-        self.f_mse_loss(target, reduction).unwrap()
+    pub fn f_mse_loss(&self, target: &Tensor, reduction: crate::Reduction) -> Tensor {
+        self.mse_loss(target, reduction).unwrap()
     }
 
-    pub fn mse_loss_backward(
+    pub fn f_mse_loss_backward(
         &self,
         grad_output: &Tensor,
         target: &Tensor,
         reduction: crate::Reduction,
     ) -> Tensor {
-        self.f_mse_loss_backward(grad_output, target, reduction).unwrap()
+        self.mse_loss_backward(grad_output, target, reduction).unwrap()
     }
 
-    pub fn mse_loss_backward_grad_input(
+    pub fn f_mse_loss_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
         target: &Tensor,
         reduction: crate::Reduction,
     ) -> Tensor {
-        self.f_mse_loss_backward_grad_input(grad_input, grad_output, target, reduction).unwrap()
+        self.mse_loss_backward_grad_input(grad_input, grad_output, target, reduction).unwrap()
     }
 
-    pub fn mse_loss_out(
+    pub fn f_mse_loss_out(
         &self,
         out: &Tensor,
         target: &Tensor,
         reduction: crate::Reduction,
     ) -> Tensor {
-        self.f_mse_loss_out(out, target, reduction).unwrap()
+        self.mse_loss_out(out, target, reduction).unwrap()
     }
 
-    pub fn msort(&self) -> Tensor {
-        self.f_msort().unwrap()
+    pub fn f_msort(&self) -> Tensor {
+        self.msort().unwrap()
     }
 
-    pub fn msort_out(&self, out: &Tensor) -> Tensor {
-        self.f_msort_out(out).unwrap()
+    pub fn f_msort_out(&self, out: &Tensor) -> Tensor {
+        self.msort_out(out).unwrap()
     }
 
-    pub fn mt(&self) -> Tensor {
-        self.f_mt().unwrap()
+    pub fn f_mt(&self) -> Tensor {
+        self.mt().unwrap()
     }
 
-    pub fn g_mul(&self, other: &Tensor) -> Tensor {
-        self.f_mul(other).unwrap()
+    pub fn f_mul(&self, other: &Tensor) -> Tensor {
+        self.g_mul(other).unwrap()
     }
 
-    pub fn g_mul_(&mut self, other: &Tensor) -> Tensor {
-        self.f_mul_(other).unwrap()
+    pub fn f_mul_(&mut self, other: &Tensor) -> Tensor {
+        self.g_mul_(other).unwrap()
     }
 
-    pub fn mul_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_mul_out(out, other).unwrap()
+    pub fn f_mul_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.mul_out(out, other).unwrap()
     }
 
-    pub fn g_mul_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_mul_scalar(other).unwrap()
+    pub fn f_mul_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.g_mul_scalar(other).unwrap()
     }
 
-    pub fn g_mul_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_mul_scalar_(other).unwrap()
+    pub fn f_mul_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.g_mul_scalar_(other).unwrap()
     }
 
-    pub fn mul_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
-        self.f_mul_scalar_out(out, other).unwrap()
+    pub fn f_mul_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
+        self.mul_scalar_out(out, other).unwrap()
     }
 
-    pub fn multi_margin_loss_backward<T: Borrow<Tensor>, S: Into<Scalar>>(
+    pub fn f_multi_margin_loss_backward<T: Borrow<Tensor>, S: Into<Scalar>>(
         &self,
         grad_output: &Tensor,
         target: &Tensor,
@@ -12726,11 +12748,10 @@ impl Tensor {
         weight: Option<T>,
         reduction: crate::Reduction,
     ) -> Tensor {
-        self.f_multi_margin_loss_backward(grad_output, target, p, margin, weight, reduction)
-            .unwrap()
+        self.multi_margin_loss_backward(grad_output, target, p, margin, weight, reduction).unwrap()
     }
 
-    pub fn multi_margin_loss_backward_grad_input<T: Borrow<Tensor>, S: Into<Scalar>>(
+    pub fn f_multi_margin_loss_backward_grad_input<T: Borrow<Tensor>, S: Into<Scalar>>(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -12740,7 +12761,7 @@ impl Tensor {
         weight: Option<T>,
         reduction: crate::Reduction,
     ) -> Tensor {
-        self.f_multi_margin_loss_backward_grad_input(
+        self.multi_margin_loss_backward_grad_input(
             grad_input,
             grad_output,
             target,
@@ -12752,21 +12773,21 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn multilabel_margin_loss(&self, target: &Tensor, reduction: crate::Reduction) -> Tensor {
-        self.f_multilabel_margin_loss(target, reduction).unwrap()
+    pub fn f_multilabel_margin_loss(&self, target: &Tensor, reduction: crate::Reduction) -> Tensor {
+        self.multilabel_margin_loss(target, reduction).unwrap()
     }
 
-    pub fn multilabel_margin_loss_backward(
+    pub fn f_multilabel_margin_loss_backward(
         &self,
         grad_output: &Tensor,
         target: &Tensor,
         reduction: crate::Reduction,
         is_target: &Tensor,
     ) -> Tensor {
-        self.f_multilabel_margin_loss_backward(grad_output, target, reduction, is_target).unwrap()
+        self.multilabel_margin_loss_backward(grad_output, target, reduction, is_target).unwrap()
     }
 
-    pub fn multilabel_margin_loss_backward_grad_input(
+    pub fn f_multilabel_margin_loss_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -12774,7 +12795,7 @@ impl Tensor {
         reduction: crate::Reduction,
         is_target: &Tensor,
     ) -> Tensor {
-        self.f_multilabel_margin_loss_backward_grad_input(
+        self.multilabel_margin_loss_backward_grad_input(
             grad_input,
             grad_output,
             target,
@@ -12784,143 +12805,143 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn multilabel_margin_loss_out(
+    pub fn f_multilabel_margin_loss_out(
         &self,
         out: &Tensor,
         target: &Tensor,
         reduction: crate::Reduction,
     ) -> Tensor {
-        self.f_multilabel_margin_loss_out(out, target, reduction).unwrap()
+        self.multilabel_margin_loss_out(out, target, reduction).unwrap()
     }
 
-    pub fn multinomial(&self, num_samples: i64, replacement: bool) -> Tensor {
-        self.f_multinomial(num_samples, replacement).unwrap()
+    pub fn f_multinomial(&self, num_samples: i64, replacement: bool) -> Tensor {
+        self.multinomial(num_samples, replacement).unwrap()
     }
 
-    pub fn multinomial_out(&self, out: &Tensor, num_samples: i64, replacement: bool) -> Tensor {
-        self.f_multinomial_out(out, num_samples, replacement).unwrap()
+    pub fn f_multinomial_out(&self, out: &Tensor, num_samples: i64, replacement: bool) -> Tensor {
+        self.multinomial_out(out, num_samples, replacement).unwrap()
     }
 
-    pub fn multiply(&self, other: &Tensor) -> Tensor {
-        self.f_multiply(other).unwrap()
+    pub fn f_multiply(&self, other: &Tensor) -> Tensor {
+        self.multiply(other).unwrap()
     }
 
-    pub fn multiply_(&mut self, other: &Tensor) -> Tensor {
-        self.f_multiply_(other).unwrap()
+    pub fn f_multiply_(&mut self, other: &Tensor) -> Tensor {
+        self.multiply_(other).unwrap()
     }
 
-    pub fn multiply_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_multiply_out(out, other).unwrap()
+    pub fn f_multiply_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.multiply_out(out, other).unwrap()
     }
 
-    pub fn multiply_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_multiply_scalar(other).unwrap()
+    pub fn f_multiply_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.multiply_scalar(other).unwrap()
     }
 
-    pub fn multiply_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_multiply_scalar_(other).unwrap()
+    pub fn f_multiply_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.multiply_scalar_(other).unwrap()
     }
 
-    pub fn mv(&self, vec: &Tensor) -> Tensor {
-        self.f_mv(vec).unwrap()
+    pub fn f_mv(&self, vec: &Tensor) -> Tensor {
+        self.mv(vec).unwrap()
     }
 
-    pub fn mv_out(&self, out: &Tensor, vec: &Tensor) -> Tensor {
-        self.f_mv_out(out, vec).unwrap()
+    pub fn f_mv_out(&self, out: &Tensor, vec: &Tensor) -> Tensor {
+        self.mv_out(out, vec).unwrap()
     }
 
-    pub fn mvlgamma(&self, p: i64) -> Tensor {
-        self.f_mvlgamma(p).unwrap()
+    pub fn f_mvlgamma(&self, p: i64) -> Tensor {
+        self.mvlgamma(p).unwrap()
     }
 
-    pub fn mvlgamma_(&mut self, p: i64) -> Tensor {
-        self.f_mvlgamma_(p).unwrap()
+    pub fn f_mvlgamma_(&mut self, p: i64) -> Tensor {
+        self.mvlgamma_(p).unwrap()
     }
 
-    pub fn mvlgamma_out(&self, out: &Tensor, p: i64) -> Tensor {
-        self.f_mvlgamma_out(out, p).unwrap()
+    pub fn f_mvlgamma_out(&self, out: &Tensor, p: i64) -> Tensor {
+        self.mvlgamma_out(out, p).unwrap()
     }
 
-    pub fn nan_to_num(
+    pub fn f_nan_to_num(
         &self,
         nan: impl Into<Option<f64>>,
         posinf: impl Into<Option<f64>>,
         neginf: impl Into<Option<f64>>,
     ) -> Tensor {
-        self.f_nan_to_num(nan, posinf, neginf).unwrap()
+        self.nan_to_num(nan, posinf, neginf).unwrap()
     }
 
-    pub fn nan_to_num_(
+    pub fn f_nan_to_num_(
         &mut self,
         nan: impl Into<Option<f64>>,
         posinf: impl Into<Option<f64>>,
         neginf: impl Into<Option<f64>>,
     ) -> Tensor {
-        self.f_nan_to_num_(nan, posinf, neginf).unwrap()
+        self.nan_to_num_(nan, posinf, neginf).unwrap()
     }
 
-    pub fn nan_to_num_out(
+    pub fn f_nan_to_num_out(
         &self,
         out: &Tensor,
         nan: impl Into<Option<f64>>,
         posinf: impl Into<Option<f64>>,
         neginf: impl Into<Option<f64>>,
     ) -> Tensor {
-        self.f_nan_to_num_out(out, nan, posinf, neginf).unwrap()
+        self.nan_to_num_out(out, nan, posinf, neginf).unwrap()
     }
 
-    pub fn nanmean(
+    pub fn f_nanmean(
         &self,
         dim: impl IntListOption,
         keepdim: bool,
         dtype: impl Into<Option<Kind>>,
     ) -> Tensor {
-        self.f_nanmean(dim, keepdim, dtype).unwrap()
+        self.nanmean(dim, keepdim, dtype).unwrap()
     }
 
-    pub fn nanmean_out(
+    pub fn f_nanmean_out(
         &self,
         out: &Tensor,
         dim: impl IntListOption,
         keepdim: bool,
         dtype: impl Into<Option<Kind>>,
     ) -> Tensor {
-        self.f_nanmean_out(out, dim, keepdim, dtype).unwrap()
+        self.nanmean_out(out, dim, keepdim, dtype).unwrap()
     }
 
-    pub fn nanmedian(&self) -> Tensor {
-        self.f_nanmedian().unwrap()
+    pub fn f_nanmedian(&self) -> Tensor {
+        self.nanmedian().unwrap()
     }
 
-    pub fn nanmedian_dim(&self, dim: i64, keepdim: bool) -> (Tensor, Tensor) {
-        self.f_nanmedian_dim(dim, keepdim).unwrap()
+    pub fn f_nanmedian_dim(&self, dim: i64, keepdim: bool) -> (Tensor, Tensor) {
+        self.nanmedian_dim(dim, keepdim).unwrap()
     }
 
-    pub fn nanmedian_dim_values(
+    pub fn f_nanmedian_dim_values(
         &self,
         values: &Tensor,
         indices: &Tensor,
         dim: i64,
         keepdim: bool,
     ) -> (Tensor, Tensor) {
-        self.f_nanmedian_dim_values(values, indices, dim, keepdim).unwrap()
+        self.nanmedian_dim_values(values, indices, dim, keepdim).unwrap()
     }
 
-    pub fn nanmedian_out(&self, out: &Tensor) -> Tensor {
-        self.f_nanmedian_out(out).unwrap()
+    pub fn f_nanmedian_out(&self, out: &Tensor) -> Tensor {
+        self.nanmedian_out(out).unwrap()
     }
 
-    pub fn nanquantile(
+    pub fn f_nanquantile(
         &self,
         q: &Tensor,
         dim: impl Into<Option<i64>>,
         keepdim: bool,
         interpolation: &str,
     ) -> Tensor {
-        self.f_nanquantile(q, dim, keepdim, interpolation).unwrap()
+        self.nanquantile(q, dim, keepdim, interpolation).unwrap()
     }
 
-    pub fn nanquantile_out(
+    pub fn f_nanquantile_out(
         &self,
         out: &Tensor,
         q: &Tensor,
@@ -12928,20 +12949,20 @@ impl Tensor {
         keepdim: bool,
         interpolation: &str,
     ) -> Tensor {
-        self.f_nanquantile_out(out, q, dim, keepdim, interpolation).unwrap()
+        self.nanquantile_out(out, q, dim, keepdim, interpolation).unwrap()
     }
 
-    pub fn nanquantile_scalar(
+    pub fn f_nanquantile_scalar(
         &self,
         q: f64,
         dim: impl Into<Option<i64>>,
         keepdim: bool,
         interpolation: &str,
     ) -> Tensor {
-        self.f_nanquantile_scalar(q, dim, keepdim, interpolation).unwrap()
+        self.nanquantile_scalar(q, dim, keepdim, interpolation).unwrap()
     }
 
-    pub fn nanquantile_scalar_out(
+    pub fn f_nanquantile_scalar_out(
         &self,
         out: &Tensor,
         q: f64,
@@ -12949,45 +12970,45 @@ impl Tensor {
         keepdim: bool,
         interpolation: &str,
     ) -> Tensor {
-        self.f_nanquantile_scalar_out(out, q, dim, keepdim, interpolation).unwrap()
+        self.nanquantile_scalar_out(out, q, dim, keepdim, interpolation).unwrap()
     }
 
-    pub fn nansum(
+    pub fn f_nansum(
         &self,
         dim: impl IntListOption,
         keepdim: bool,
         dtype: impl Into<Option<Kind>>,
     ) -> Tensor {
-        self.f_nansum(dim, keepdim, dtype).unwrap()
+        self.nansum(dim, keepdim, dtype).unwrap()
     }
 
-    pub fn nansum_out(
+    pub fn f_nansum_out(
         &self,
         out: &Tensor,
         dim: impl IntListOption,
         keepdim: bool,
         dtype: impl Into<Option<Kind>>,
     ) -> Tensor {
-        self.f_nansum_out(out, dim, keepdim, dtype).unwrap()
+        self.nansum_out(out, dim, keepdim, dtype).unwrap()
     }
 
-    pub fn narrow(&self, dim: i64, start: i64, length: i64) -> Tensor {
-        self.f_narrow(dim, start, length).unwrap()
+    pub fn f_narrow(&self, dim: i64, start: i64, length: i64) -> Tensor {
+        self.narrow(dim, start, length).unwrap()
     }
 
-    pub fn narrow_copy(&self, dim: i64, start: i64, length: i64) -> Tensor {
-        self.f_narrow_copy(dim, start, length).unwrap()
+    pub fn f_narrow_copy(&self, dim: i64, start: i64, length: i64) -> Tensor {
+        self.narrow_copy(dim, start, length).unwrap()
     }
 
-    pub fn narrow_copy_out(&self, out: &Tensor, dim: i64, start: i64, length: i64) -> Tensor {
-        self.f_narrow_copy_out(out, dim, start, length).unwrap()
+    pub fn f_narrow_copy_out(&self, out: &Tensor, dim: i64, start: i64, length: i64) -> Tensor {
+        self.narrow_copy_out(out, dim, start, length).unwrap()
     }
 
-    pub fn narrow_tensor(&self, dim: i64, start: &Tensor, length: i64) -> Tensor {
-        self.f_narrow_tensor(dim, start, length).unwrap()
+    pub fn f_narrow_tensor(&self, dim: i64, start: &Tensor, length: i64) -> Tensor {
+        self.narrow_tensor(dim, start, length).unwrap()
     }
 
-    pub fn native_batch_norm<T: Borrow<Tensor>>(
+    pub fn f_native_batch_norm<T: Borrow<Tensor>>(
         &self,
         weight: Option<T>,
         bias: Option<T>,
@@ -12997,11 +13018,11 @@ impl Tensor {
         momentum: f64,
         eps: f64,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_native_batch_norm(weight, bias, running_mean, running_var, training, momentum, eps)
+        self.native_batch_norm(weight, bias, running_mean, running_var, training, momentum, eps)
             .unwrap()
     }
 
-    pub fn native_batch_norm_out<T: Borrow<Tensor>>(
+    pub fn f_native_batch_norm_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         save_mean: &Tensor,
@@ -13014,7 +13035,7 @@ impl Tensor {
         momentum: f64,
         eps: f64,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_native_batch_norm_out(
+        self.native_batch_norm_out(
             out,
             save_mean,
             save_invstd,
@@ -13029,38 +13050,38 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn native_channel_shuffle(&self, groups: i64) -> Tensor {
-        self.f_native_channel_shuffle(groups).unwrap()
+    pub fn f_native_channel_shuffle(&self, groups: i64) -> Tensor {
+        self.native_channel_shuffle(groups).unwrap()
     }
 
-    pub fn native_dropout(&self, p: f64, train: bool) -> (Tensor, Tensor) {
-        self.f_native_dropout(p, train).unwrap()
+    pub fn f_native_dropout(&self, p: f64, train: bool) -> (Tensor, Tensor) {
+        self.native_dropout(p, train).unwrap()
     }
 
-    pub fn native_dropout_backward(grad_output: &Tensor, mask: &Tensor, scale: f64) -> Tensor {
-        Tensor::f_native_dropout_backward(grad_output, mask, scale).unwrap()
+    pub fn f_native_dropout_backward(grad_output: &Tensor, mask: &Tensor, scale: f64) -> Tensor {
+        Tensor::native_dropout_backward(grad_output, mask, scale).unwrap()
     }
 
-    pub fn native_dropout_backward_out(
+    pub fn f_native_dropout_backward_out(
         out: &Tensor,
         grad_output: &Tensor,
         mask: &Tensor,
         scale: f64,
     ) -> Tensor {
-        Tensor::f_native_dropout_backward_out(out, grad_output, mask, scale).unwrap()
+        Tensor::native_dropout_backward_out(out, grad_output, mask, scale).unwrap()
     }
 
-    pub fn native_dropout_out(
+    pub fn f_native_dropout_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
         p: f64,
         train: bool,
     ) -> (Tensor, Tensor) {
-        self.f_native_dropout_out(out0, out1, p, train).unwrap()
+        self.native_dropout_out(out0, out1, p, train).unwrap()
     }
 
-    pub fn native_group_norm<T: Borrow<Tensor>>(
+    pub fn f_native_group_norm<T: Borrow<Tensor>>(
         &self,
         weight: Option<T>,
         bias: Option<T>,
@@ -13070,10 +13091,10 @@ impl Tensor {
         group: i64,
         eps: f64,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_native_group_norm(weight, bias, n, c, hxw, group, eps).unwrap()
+        self.native_group_norm(weight, bias, n, c, hxw, group, eps).unwrap()
     }
 
-    pub fn native_group_norm_out<T: Borrow<Tensor>>(
+    pub fn f_native_group_norm_out<T: Borrow<Tensor>>(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -13086,20 +13107,20 @@ impl Tensor {
         group: i64,
         eps: f64,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_native_group_norm_out(out0, out1, out2, weight, bias, n, c, hxw, group, eps).unwrap()
+        self.native_group_norm_out(out0, out1, out2, weight, bias, n, c, hxw, group, eps).unwrap()
     }
 
-    pub fn native_layer_norm<T: Borrow<Tensor>>(
+    pub fn f_native_layer_norm<T: Borrow<Tensor>>(
         &self,
         normalized_shape: impl IntList,
         weight: Option<T>,
         bias: Option<T>,
         eps: f64,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_native_layer_norm(normalized_shape, weight, bias, eps).unwrap()
+        self.native_layer_norm(normalized_shape, weight, bias, eps).unwrap()
     }
 
-    pub fn native_layer_norm_out<T: Borrow<Tensor>>(
+    pub fn f_native_layer_norm_out<T: Borrow<Tensor>>(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -13109,28 +13130,28 @@ impl Tensor {
         bias: Option<T>,
         eps: f64,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_native_layer_norm_out(out0, out1, out2, normalized_shape, weight, bias, eps).unwrap()
+        self.native_layer_norm_out(out0, out1, out2, normalized_shape, weight, bias, eps).unwrap()
     }
 
-    pub fn native_norm(&self) -> Tensor {
-        self.f_native_norm().unwrap()
+    pub fn f_native_norm(&self) -> Tensor {
+        self.native_norm().unwrap()
     }
 
-    pub fn native_norm_out(&self, out: &Tensor) -> Tensor {
-        self.f_native_norm_out(out).unwrap()
+    pub fn f_native_norm_out(&self, out: &Tensor) -> Tensor {
+        self.native_norm_out(out).unwrap()
     }
 
-    pub fn native_norm_scalaropt_dim_dtype<S: Into<Scalar>>(
+    pub fn f_native_norm_scalaropt_dim_dtype<S: Into<Scalar>>(
         &self,
         p: S,
         dim: impl IntList,
         keepdim: bool,
         dtype: impl Into<Option<Kind>>,
     ) -> Tensor {
-        self.f_native_norm_scalaropt_dim_dtype(p, dim, keepdim, dtype).unwrap()
+        self.native_norm_scalaropt_dim_dtype(p, dim, keepdim, dtype).unwrap()
     }
 
-    pub fn native_norm_scalaropt_dim_dtype_out<S: Into<Scalar>>(
+    pub fn f_native_norm_scalaropt_dim_dtype_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         p: S,
@@ -13138,207 +13159,158 @@ impl Tensor {
         keepdim: bool,
         dtype: impl Into<Option<Kind>>,
     ) -> Tensor {
-        self.f_native_norm_scalaropt_dim_dtype_out(out, p, dim, keepdim, dtype).unwrap()
+        self.native_norm_scalaropt_dim_dtype_out(out, p, dim, keepdim, dtype).unwrap()
     }
 
-    pub fn ne<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_ne(other).unwrap()
+    pub fn f_ne<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.ne(other).unwrap()
     }
 
-    pub fn ne_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_ne_(other).unwrap()
+    pub fn f_ne_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.ne_(other).unwrap()
     }
 
-    pub fn ne_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
-        self.f_ne_scalar_out(out, other).unwrap()
+    pub fn f_ne_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
+        self.ne_scalar_out(out, other).unwrap()
     }
 
-    pub fn ne_tensor(&self, other: &Tensor) -> Tensor {
-        self.f_ne_tensor(other).unwrap()
+    pub fn f_ne_tensor(&self, other: &Tensor) -> Tensor {
+        self.ne_tensor(other).unwrap()
     }
 
-    pub fn ne_tensor_(&mut self, other: &Tensor) -> Tensor {
-        self.f_ne_tensor_(other).unwrap()
+    pub fn f_ne_tensor_(&mut self, other: &Tensor) -> Tensor {
+        self.ne_tensor_(other).unwrap()
     }
 
-    pub fn ne_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_ne_tensor_out(out, other).unwrap()
+    pub fn f_ne_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.ne_tensor_out(out, other).unwrap()
     }
 
-    pub fn neg(&self) -> Tensor {
-        self.f_neg().unwrap()
+    pub fn f_neg(&self) -> Tensor {
+        self.neg().unwrap()
     }
 
-    pub fn neg_(&mut self) -> Tensor {
-        self.f_neg_().unwrap()
+    pub fn f_neg_(&mut self) -> Tensor {
+        self.neg_().unwrap()
     }
 
-    pub fn neg_out(&self, out: &Tensor) -> Tensor {
-        self.f_neg_out(out).unwrap()
+    pub fn f_neg_out(&self, out: &Tensor) -> Tensor {
+        self.neg_out(out).unwrap()
     }
 
-    pub fn negative(&self) -> Tensor {
-        self.f_negative().unwrap()
+    pub fn f_negative(&self) -> Tensor {
+        self.negative().unwrap()
     }
 
-    pub fn negative_(&mut self) -> Tensor {
-        self.f_negative_().unwrap()
+    pub fn f_negative_(&mut self) -> Tensor {
+        self.negative_().unwrap()
     }
 
-    pub fn negative_out(&self, out: &Tensor) -> Tensor {
-        self.f_negative_out(out).unwrap()
+    pub fn f_negative_out(&self, out: &Tensor) -> Tensor {
+        self.negative_out(out).unwrap()
     }
 
-    pub fn nested_to_padded_tensor(&self, padding: f64, output_size: impl IntListOption) -> Tensor {
-        self.f_nested_to_padded_tensor(padding, output_size).unwrap()
+    pub fn f_nested_to_padded_tensor(
+        &self,
+        padding: f64,
+        output_size: impl IntListOption,
+    ) -> Tensor {
+        self.nested_to_padded_tensor(padding, output_size).unwrap()
     }
 
-    pub fn new_empty(&self, size: impl IntList, options: (Kind, Device)) -> Tensor {
-        self.f_new_empty(size, options).unwrap()
+    pub fn f_new_empty(&self, size: impl IntList, options: (Kind, Device)) -> Tensor {
+        self.new_empty(size, options).unwrap()
     }
 
-    pub fn new_empty_out(&self, out: &Tensor, size: impl IntList) -> Tensor {
-        self.f_new_empty_out(out, size).unwrap()
+    pub fn f_new_empty_out(&self, out: &Tensor, size: impl IntList) -> Tensor {
+        self.new_empty_out(out, size).unwrap()
     }
 
-    pub fn new_empty_strided(
+    pub fn f_new_empty_strided(
         &self,
         size: impl IntList,
         stride: impl IntList,
         options: (Kind, Device),
     ) -> Tensor {
-        self.f_new_empty_strided(size, stride, options).unwrap()
+        self.new_empty_strided(size, stride, options).unwrap()
     }
 
-    pub fn new_empty_strided_out(
+    pub fn f_new_empty_strided_out(
         &self,
         out: &Tensor,
         size: impl IntList,
         stride: impl IntList,
     ) -> Tensor {
-        self.f_new_empty_strided_out(out, size, stride).unwrap()
+        self.new_empty_strided_out(out, size, stride).unwrap()
     }
 
-    pub fn new_full<S: Into<Scalar>>(
+    pub fn f_new_full<S: Into<Scalar>>(
         &self,
         size: impl IntList,
         fill_value: S,
         options: (Kind, Device),
     ) -> Tensor {
-        self.f_new_full(size, fill_value, options).unwrap()
+        self.new_full(size, fill_value, options).unwrap()
     }
 
-    pub fn new_full_out<S: Into<Scalar>>(
+    pub fn f_new_full_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         size: impl IntList,
         fill_value: S,
     ) -> Tensor {
-        self.f_new_full_out(out, size, fill_value).unwrap()
+        self.new_full_out(out, size, fill_value).unwrap()
     }
 
-    pub fn new_ones(&self, size: impl IntList, options: (Kind, Device)) -> Tensor {
-        self.f_new_ones(size, options).unwrap()
+    pub fn f_new_ones(&self, size: impl IntList, options: (Kind, Device)) -> Tensor {
+        self.new_ones(size, options).unwrap()
     }
 
-    pub fn new_ones_out(&self, out: &Tensor, size: impl IntList) -> Tensor {
-        self.f_new_ones_out(out, size).unwrap()
+    pub fn f_new_ones_out(&self, out: &Tensor, size: impl IntList) -> Tensor {
+        self.new_ones_out(out, size).unwrap()
     }
 
-    pub fn new_zeros(&self, size: impl IntList, options: (Kind, Device)) -> Tensor {
-        self.f_new_zeros(size, options).unwrap()
+    pub fn f_new_zeros(&self, size: impl IntList, options: (Kind, Device)) -> Tensor {
+        self.new_zeros(size, options).unwrap()
     }
 
-    pub fn new_zeros_out(&self, out: &Tensor, size: impl IntList) -> Tensor {
-        self.f_new_zeros_out(out, size).unwrap()
+    pub fn f_new_zeros_out(&self, out: &Tensor, size: impl IntList) -> Tensor {
+        self.new_zeros_out(out, size).unwrap()
     }
 
-    pub fn nextafter(&self, other: &Tensor) -> Tensor {
-        self.f_nextafter(other).unwrap()
+    pub fn f_nextafter(&self, other: &Tensor) -> Tensor {
+        self.nextafter(other).unwrap()
     }
 
-    pub fn nextafter_(&mut self, other: &Tensor) -> Tensor {
-        self.f_nextafter_(other).unwrap()
+    pub fn f_nextafter_(&mut self, other: &Tensor) -> Tensor {
+        self.nextafter_(other).unwrap()
     }
 
-    pub fn nextafter_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_nextafter_out(out, other).unwrap()
+    pub fn f_nextafter_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.nextafter_out(out, other).unwrap()
     }
 
-    pub fn g_nll_loss<T: Borrow<Tensor>>(
+    pub fn f_nll_loss<T: Borrow<Tensor>>(
         &self,
         target: &Tensor,
         weight: Option<T>,
         reduction: crate::Reduction,
         ignore_index: i64,
     ) -> Tensor {
-        self.f_nll_loss(target, weight, reduction, ignore_index).unwrap()
+        self.g_nll_loss(target, weight, reduction, ignore_index).unwrap()
     }
 
-    pub fn nll_loss2d<T: Borrow<Tensor>>(
+    pub fn f_nll_loss2d<T: Borrow<Tensor>>(
         &self,
         target: &Tensor,
         weight: Option<T>,
         reduction: crate::Reduction,
         ignore_index: i64,
     ) -> Tensor {
-        self.f_nll_loss2d(target, weight, reduction, ignore_index).unwrap()
+        self.nll_loss2d(target, weight, reduction, ignore_index).unwrap()
     }
 
-    pub fn nll_loss2d_backward<T: Borrow<Tensor>>(
-        &self,
-        grad_output: &Tensor,
-        target: &Tensor,
-        weight: Option<T>,
-        reduction: crate::Reduction,
-        ignore_index: i64,
-        total_weight: &Tensor,
-    ) -> Tensor {
-        self.f_nll_loss2d_backward(
-            grad_output,
-            target,
-            weight,
-            reduction,
-            ignore_index,
-            total_weight,
-        )
-        .unwrap()
-    }
-
-    pub fn nll_loss2d_backward_grad_input<T: Borrow<Tensor>>(
-        &self,
-        grad_input: &Tensor,
-        grad_output: &Tensor,
-        target: &Tensor,
-        weight: Option<T>,
-        reduction: crate::Reduction,
-        ignore_index: i64,
-        total_weight: &Tensor,
-    ) -> Tensor {
-        self.f_nll_loss2d_backward_grad_input(
-            grad_input,
-            grad_output,
-            target,
-            weight,
-            reduction,
-            ignore_index,
-            total_weight,
-        )
-        .unwrap()
-    }
-
-    pub fn nll_loss2d_out<T: Borrow<Tensor>>(
-        &self,
-        out: &Tensor,
-        target: &Tensor,
-        weight: Option<T>,
-        reduction: crate::Reduction,
-        ignore_index: i64,
-    ) -> Tensor {
-        self.f_nll_loss2d_out(out, target, weight, reduction, ignore_index).unwrap()
-    }
-
-    pub fn nll_loss_backward<T: Borrow<Tensor>>(
+    pub fn f_nll_loss2d_backward<T: Borrow<Tensor>>(
         &self,
         grad_output: &Tensor,
         target: &Tensor,
@@ -13347,11 +13319,11 @@ impl Tensor {
         ignore_index: i64,
         total_weight: &Tensor,
     ) -> Tensor {
-        self.f_nll_loss_backward(grad_output, target, weight, reduction, ignore_index, total_weight)
+        self.nll_loss2d_backward(grad_output, target, weight, reduction, ignore_index, total_weight)
             .unwrap()
     }
 
-    pub fn nll_loss_backward_grad_input<T: Borrow<Tensor>>(
+    pub fn f_nll_loss2d_backward_grad_input<T: Borrow<Tensor>>(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -13361,7 +13333,7 @@ impl Tensor {
         ignore_index: i64,
         total_weight: &Tensor,
     ) -> Tensor {
-        self.f_nll_loss_backward_grad_input(
+        self.nll_loss2d_backward_grad_input(
             grad_input,
             grad_output,
             target,
@@ -13373,17 +13345,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn nll_loss_nd<T: Borrow<Tensor>>(
-        &self,
-        target: &Tensor,
-        weight: Option<T>,
-        reduction: crate::Reduction,
-        ignore_index: i64,
-    ) -> Tensor {
-        self.f_nll_loss_nd(target, weight, reduction, ignore_index).unwrap()
-    }
-
-    pub fn nll_loss_out<T: Borrow<Tensor>>(
+    pub fn f_nll_loss2d_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         target: &Tensor,
@@ -13391,26 +13353,82 @@ impl Tensor {
         reduction: crate::Reduction,
         ignore_index: i64,
     ) -> Tensor {
-        self.f_nll_loss_out(out, target, weight, reduction, ignore_index).unwrap()
+        self.nll_loss2d_out(out, target, weight, reduction, ignore_index).unwrap()
     }
 
-    pub fn nonzero(&self) -> Tensor {
-        self.f_nonzero().unwrap()
+    pub fn f_nll_loss_backward<T: Borrow<Tensor>>(
+        &self,
+        grad_output: &Tensor,
+        target: &Tensor,
+        weight: Option<T>,
+        reduction: crate::Reduction,
+        ignore_index: i64,
+        total_weight: &Tensor,
+    ) -> Tensor {
+        self.nll_loss_backward(grad_output, target, weight, reduction, ignore_index, total_weight)
+            .unwrap()
     }
 
-    pub fn nonzero_numpy(&self) -> Vec<Tensor> {
-        self.f_nonzero_numpy().unwrap()
+    pub fn f_nll_loss_backward_grad_input<T: Borrow<Tensor>>(
+        &self,
+        grad_input: &Tensor,
+        grad_output: &Tensor,
+        target: &Tensor,
+        weight: Option<T>,
+        reduction: crate::Reduction,
+        ignore_index: i64,
+        total_weight: &Tensor,
+    ) -> Tensor {
+        self.nll_loss_backward_grad_input(
+            grad_input,
+            grad_output,
+            target,
+            weight,
+            reduction,
+            ignore_index,
+            total_weight,
+        )
+        .unwrap()
     }
 
-    pub fn nonzero_out(&self, out: &Tensor) -> Tensor {
-        self.f_nonzero_out(out).unwrap()
+    pub fn f_nll_loss_nd<T: Borrow<Tensor>>(
+        &self,
+        target: &Tensor,
+        weight: Option<T>,
+        reduction: crate::Reduction,
+        ignore_index: i64,
+    ) -> Tensor {
+        self.nll_loss_nd(target, weight, reduction, ignore_index).unwrap()
     }
 
-    pub fn norm(&self) -> Tensor {
-        self.f_norm().unwrap()
+    pub fn f_nll_loss_out<T: Borrow<Tensor>>(
+        &self,
+        out: &Tensor,
+        target: &Tensor,
+        weight: Option<T>,
+        reduction: crate::Reduction,
+        ignore_index: i64,
+    ) -> Tensor {
+        self.nll_loss_out(out, target, weight, reduction, ignore_index).unwrap()
     }
 
-    pub fn norm_dtype_out<S: Into<Scalar>>(
+    pub fn f_nonzero(&self) -> Tensor {
+        self.nonzero().unwrap()
+    }
+
+    pub fn f_nonzero_numpy(&self) -> Vec<Tensor> {
+        self.nonzero_numpy().unwrap()
+    }
+
+    pub fn f_nonzero_out(&self, out: &Tensor) -> Tensor {
+        self.nonzero_out(out).unwrap()
+    }
+
+    pub fn f_norm(&self) -> Tensor {
+        self.norm().unwrap()
+    }
+
+    pub fn f_norm_dtype_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         p: S,
@@ -13418,144 +13436,144 @@ impl Tensor {
         keepdim: bool,
         dtype: Kind,
     ) -> Tensor {
-        self.f_norm_dtype_out(out, p, dim, keepdim, dtype).unwrap()
+        self.norm_dtype_out(out, p, dim, keepdim, dtype).unwrap()
     }
 
-    pub fn norm_except_dim(v: &Tensor, pow: i64, dim: i64) -> Tensor {
-        Tensor::f_norm_except_dim(v, pow, dim).unwrap()
+    pub fn f_norm_except_dim(v: &Tensor, pow: i64, dim: i64) -> Tensor {
+        Tensor::norm_except_dim(v, pow, dim).unwrap()
     }
 
-    pub fn norm_out<S: Into<Scalar>>(
+    pub fn f_norm_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         p: S,
         dim: impl IntList,
         keepdim: bool,
     ) -> Tensor {
-        self.f_norm_out(out, p, dim, keepdim).unwrap()
+        self.norm_out(out, p, dim, keepdim).unwrap()
     }
 
-    pub fn norm_scalar_out(&self, out: &Tensor) -> Tensor {
-        self.f_norm_scalar_out(out).unwrap()
+    pub fn f_norm_scalar_out(&self, out: &Tensor) -> Tensor {
+        self.norm_scalar_out(out).unwrap()
     }
 
-    pub fn norm_scalaropt_dim<S: Into<Scalar>>(
+    pub fn f_norm_scalaropt_dim<S: Into<Scalar>>(
         &self,
         p: S,
         dim: impl IntList,
         keepdim: bool,
     ) -> Tensor {
-        self.f_norm_scalaropt_dim(p, dim, keepdim).unwrap()
+        self.norm_scalaropt_dim(p, dim, keepdim).unwrap()
     }
 
-    pub fn norm_scalaropt_dim_dtype<S: Into<Scalar>>(
+    pub fn f_norm_scalaropt_dim_dtype<S: Into<Scalar>>(
         &self,
         p: S,
         dim: impl IntList,
         keepdim: bool,
         dtype: Kind,
     ) -> Tensor {
-        self.f_norm_scalaropt_dim_dtype(p, dim, keepdim, dtype).unwrap()
+        self.norm_scalaropt_dim_dtype(p, dim, keepdim, dtype).unwrap()
     }
 
-    pub fn norm_scalaropt_dtype<S: Into<Scalar>>(&self, p: S, dtype: Kind) -> Tensor {
-        self.f_norm_scalaropt_dtype(p, dtype).unwrap()
+    pub fn f_norm_scalaropt_dtype<S: Into<Scalar>>(&self, p: S, dtype: Kind) -> Tensor {
+        self.norm_scalaropt_dtype(p, dtype).unwrap()
     }
 
-    pub fn norm_scalaropt_dtype_out<S: Into<Scalar>>(
+    pub fn f_norm_scalaropt_dtype_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         p: S,
         dtype: Kind,
     ) -> Tensor {
-        self.f_norm_scalaropt_dtype_out(out, p, dtype).unwrap()
+        self.norm_scalaropt_dtype_out(out, p, dtype).unwrap()
     }
 
-    pub fn normal_(&mut self, mean: f64, std: f64) -> Tensor {
-        self.f_normal_(mean, std).unwrap()
+    pub fn f_normal_(&mut self, mean: f64, std: f64) -> Tensor {
+        self.normal_(mean, std).unwrap()
     }
 
-    pub fn normal_functional(&self, mean: f64, std: f64) -> Tensor {
-        self.f_normal_functional(mean, std).unwrap()
+    pub fn f_normal_functional(&self, mean: f64, std: f64) -> Tensor {
+        self.normal_functional(mean, std).unwrap()
     }
 
-    pub fn not_equal<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_not_equal(other).unwrap()
+    pub fn f_not_equal<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.not_equal(other).unwrap()
     }
 
-    pub fn not_equal_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_not_equal_(other).unwrap()
+    pub fn f_not_equal_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.not_equal_(other).unwrap()
     }
 
-    pub fn not_equal_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
-        self.f_not_equal_scalar_out(out, other).unwrap()
+    pub fn f_not_equal_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
+        self.not_equal_scalar_out(out, other).unwrap()
     }
 
-    pub fn not_equal_tensor(&self, other: &Tensor) -> Tensor {
-        self.f_not_equal_tensor(other).unwrap()
+    pub fn f_not_equal_tensor(&self, other: &Tensor) -> Tensor {
+        self.not_equal_tensor(other).unwrap()
     }
 
-    pub fn not_equal_tensor_(&mut self, other: &Tensor) -> Tensor {
-        self.f_not_equal_tensor_(other).unwrap()
+    pub fn f_not_equal_tensor_(&mut self, other: &Tensor) -> Tensor {
+        self.not_equal_tensor_(other).unwrap()
     }
 
-    pub fn not_equal_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_not_equal_tensor_out(out, other).unwrap()
+    pub fn f_not_equal_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.not_equal_tensor_out(out, other).unwrap()
     }
 
-    pub fn nuclear_norm(&self, keepdim: bool) -> Tensor {
-        self.f_nuclear_norm(keepdim).unwrap()
+    pub fn f_nuclear_norm(&self, keepdim: bool) -> Tensor {
+        self.nuclear_norm(keepdim).unwrap()
     }
 
-    pub fn nuclear_norm_dim(&self, dim: impl IntList, keepdim: bool) -> Tensor {
-        self.f_nuclear_norm_dim(dim, keepdim).unwrap()
+    pub fn f_nuclear_norm_dim(&self, dim: impl IntList, keepdim: bool) -> Tensor {
+        self.nuclear_norm_dim(dim, keepdim).unwrap()
     }
 
-    pub fn nuclear_norm_dim_out(&self, out: &Tensor, dim: impl IntList, keepdim: bool) -> Tensor {
-        self.f_nuclear_norm_dim_out(out, dim, keepdim).unwrap()
+    pub fn f_nuclear_norm_dim_out(&self, out: &Tensor, dim: impl IntList, keepdim: bool) -> Tensor {
+        self.nuclear_norm_dim_out(out, dim, keepdim).unwrap()
     }
 
-    pub fn nuclear_norm_out(&self, out: &Tensor, keepdim: bool) -> Tensor {
-        self.f_nuclear_norm_out(out, keepdim).unwrap()
+    pub fn f_nuclear_norm_out(&self, out: &Tensor, keepdim: bool) -> Tensor {
+        self.nuclear_norm_out(out, keepdim).unwrap()
     }
 
-    pub fn numpy_t(&self) -> Tensor {
-        self.f_numpy_t().unwrap()
+    pub fn f_numpy_t(&self) -> Tensor {
+        self.numpy_t().unwrap()
     }
 
-    pub fn one_hot(&self, num_classes: i64) -> Tensor {
-        self.f_one_hot(num_classes).unwrap()
+    pub fn f_one_hot(&self, num_classes: i64) -> Tensor {
+        self.one_hot(num_classes).unwrap()
     }
 
-    pub fn ones(size: impl IntList, options: (Kind, Device)) -> Tensor {
-        Tensor::f_ones(size, options).unwrap()
+    pub fn f_ones(size: impl IntList, options: (Kind, Device)) -> Tensor {
+        Tensor::ones(size, options).unwrap()
     }
 
-    pub fn ones_like(&self) -> Tensor {
-        self.f_ones_like().unwrap()
+    pub fn f_ones_like(&self) -> Tensor {
+        self.ones_like().unwrap()
     }
 
-    pub fn ones_like_out(&self, out: &Tensor) -> Tensor {
-        self.f_ones_like_out(out).unwrap()
+    pub fn f_ones_like_out(&self, out: &Tensor) -> Tensor {
+        self.ones_like_out(out).unwrap()
     }
 
-    pub fn ones_out(out: &Tensor, size: impl IntList) -> Tensor {
-        Tensor::f_ones_out(out, size).unwrap()
+    pub fn f_ones_out(out: &Tensor, size: impl IntList) -> Tensor {
+        Tensor::ones_out(out, size).unwrap()
     }
 
-    pub fn orgqr(&self, input2: &Tensor) -> Tensor {
-        self.f_orgqr(input2).unwrap()
+    pub fn f_orgqr(&self, input2: &Tensor) -> Tensor {
+        self.orgqr(input2).unwrap()
     }
 
-    pub fn orgqr_out(&self, out: &Tensor, input2: &Tensor) -> Tensor {
-        self.f_orgqr_out(out, input2).unwrap()
+    pub fn f_orgqr_out(&self, out: &Tensor, input2: &Tensor) -> Tensor {
+        self.orgqr_out(out, input2).unwrap()
     }
 
-    pub fn ormqr(&self, input2: &Tensor, input3: &Tensor, left: bool, transpose: bool) -> Tensor {
-        self.f_ormqr(input2, input3, left, transpose).unwrap()
+    pub fn f_ormqr(&self, input2: &Tensor, input3: &Tensor, left: bool, transpose: bool) -> Tensor {
+        self.ormqr(input2, input3, left, transpose).unwrap()
     }
 
-    pub fn ormqr_out(
+    pub fn f_ormqr_out(
         &self,
         out: &Tensor,
         input2: &Tensor,
@@ -13563,82 +13581,88 @@ impl Tensor {
         left: bool,
         transpose: bool,
     ) -> Tensor {
-        self.f_ormqr_out(out, input2, input3, left, transpose).unwrap()
+        self.ormqr_out(out, input2, input3, left, transpose).unwrap()
     }
 
-    pub fn outer(&self, vec2: &Tensor) -> Tensor {
-        self.f_outer(vec2).unwrap()
+    pub fn f_outer(&self, vec2: &Tensor) -> Tensor {
+        self.outer(vec2).unwrap()
     }
 
-    pub fn outer_out(&self, out: &Tensor, vec2: &Tensor) -> Tensor {
-        self.f_outer_out(out, vec2).unwrap()
+    pub fn f_outer_out(&self, out: &Tensor, vec2: &Tensor) -> Tensor {
+        self.outer_out(out, vec2).unwrap()
     }
 
-    pub fn output_nr(&self) -> i64 {
-        self.f_output_nr().unwrap()
+    pub fn f_output_nr(&self) -> i64 {
+        self.output_nr().unwrap()
     }
 
-    pub fn pad(&self, pad: impl IntList, mode: &str, value: impl Into<Option<f64>>) -> Tensor {
-        self.f_pad(pad, mode, value).unwrap()
+    pub fn f_pad(&self, pad: impl IntList, mode: &str, value: impl Into<Option<f64>>) -> Tensor {
+        self.pad(pad, mode, value).unwrap()
     }
 
-    pub fn pad_sequence<T: Borrow<Tensor>>(
+    pub fn f_pad_sequence<T: Borrow<Tensor>>(
         sequences: &[T],
         batch_first: bool,
         padding_value: f64,
     ) -> Tensor {
-        Tensor::f_pad_sequence(sequences, batch_first, padding_value).unwrap()
+        Tensor::pad_sequence(sequences, batch_first, padding_value).unwrap()
     }
 
-    pub fn pairwise_distance(x1: &Tensor, x2: &Tensor, p: f64, eps: f64, keepdim: bool) -> Tensor {
-        Tensor::f_pairwise_distance(x1, x2, p, eps, keepdim).unwrap()
+    pub fn f_pairwise_distance(
+        x1: &Tensor,
+        x2: &Tensor,
+        p: f64,
+        eps: f64,
+        keepdim: bool,
+    ) -> Tensor {
+        Tensor::pairwise_distance(x1, x2, p, eps, keepdim).unwrap()
     }
 
-    pub fn pdist(&self, p: f64) -> Tensor {
-        self.f_pdist(p).unwrap()
+    pub fn f_pdist(&self, p: f64) -> Tensor {
+        self.pdist(p).unwrap()
     }
 
-    pub fn permute(&self, dims: impl IntList) -> Tensor {
-        self.f_permute(dims).unwrap()
+    pub fn f_permute(&self, dims: impl IntList) -> Tensor {
+        self.permute(dims).unwrap()
     }
 
-    pub fn permute_copy(&self, dims: impl IntList) -> Tensor {
-        self.f_permute_copy(dims).unwrap()
+    pub fn f_permute_copy(&self, dims: impl IntList) -> Tensor {
+        self.permute_copy(dims).unwrap()
     }
 
-    pub fn permute_copy_out(&self, out: &Tensor, dims: impl IntList) -> Tensor {
-        self.f_permute_copy_out(out, dims).unwrap()
+    pub fn f_permute_copy_out(&self, out: &Tensor, dims: impl IntList) -> Tensor {
+        self.permute_copy_out(out, dims).unwrap()
     }
 
-    pub fn pin_memory(&self, device: Device) -> Tensor {
-        self.f_pin_memory(device).unwrap()
+    pub fn f_pin_memory(&self, device: Device) -> Tensor {
+        self.pin_memory(device).unwrap()
     }
 
-    pub fn pinverse(&self, rcond: f64) -> Tensor {
-        self.f_pinverse(rcond).unwrap()
+    pub fn f_pinverse(&self, rcond: f64) -> Tensor {
+        self.pinverse(rcond).unwrap()
     }
 
-    pub fn pixel_shuffle(&self, upscale_factor: i64) -> Tensor {
-        self.f_pixel_shuffle(upscale_factor).unwrap()
+    pub fn f_pixel_shuffle(&self, upscale_factor: i64) -> Tensor {
+        self.pixel_shuffle(upscale_factor).unwrap()
     }
 
-    pub fn pixel_shuffle_out(&self, out: &Tensor, upscale_factor: i64) -> Tensor {
-        self.f_pixel_shuffle_out(out, upscale_factor).unwrap()
+    pub fn f_pixel_shuffle_out(&self, out: &Tensor, upscale_factor: i64) -> Tensor {
+        self.pixel_shuffle_out(out, upscale_factor).unwrap()
     }
 
-    pub fn pixel_unshuffle(&self, downscale_factor: i64) -> Tensor {
-        self.f_pixel_unshuffle(downscale_factor).unwrap()
+    pub fn f_pixel_unshuffle(&self, downscale_factor: i64) -> Tensor {
+        self.pixel_unshuffle(downscale_factor).unwrap()
     }
 
-    pub fn pixel_unshuffle_out(&self, out: &Tensor, downscale_factor: i64) -> Tensor {
-        self.f_pixel_unshuffle_out(out, downscale_factor).unwrap()
+    pub fn f_pixel_unshuffle_out(&self, out: &Tensor, downscale_factor: i64) -> Tensor {
+        self.pixel_unshuffle_out(out, downscale_factor).unwrap()
     }
 
-    pub fn poisson(&self) -> Tensor {
-        self.f_poisson().unwrap()
+    pub fn f_poisson(&self) -> Tensor {
+        self.poisson().unwrap()
     }
 
-    pub fn poisson_nll_loss(
+    pub fn f_poisson_nll_loss(
         &self,
         target: &Tensor,
         log_input: bool,
@@ -13646,164 +13670,169 @@ impl Tensor {
         eps: f64,
         reduction: crate::Reduction,
     ) -> Tensor {
-        self.f_poisson_nll_loss(target, log_input, full, eps, reduction).unwrap()
+        self.poisson_nll_loss(target, log_input, full, eps, reduction).unwrap()
     }
 
-    pub fn poisson_out(&self, out: &Tensor) -> Tensor {
-        self.f_poisson_out(out).unwrap()
+    pub fn f_poisson_out(&self, out: &Tensor) -> Tensor {
+        self.poisson_out(out).unwrap()
     }
 
-    pub fn polar(abs: &Tensor, angle: &Tensor) -> Tensor {
-        Tensor::f_polar(abs, angle).unwrap()
+    pub fn f_polar(abs: &Tensor, angle: &Tensor) -> Tensor {
+        Tensor::polar(abs, angle).unwrap()
     }
 
-    pub fn polar_out(out: &Tensor, abs: &Tensor, angle: &Tensor) -> Tensor {
-        Tensor::f_polar_out(out, abs, angle).unwrap()
+    pub fn f_polar_out(out: &Tensor, abs: &Tensor, angle: &Tensor) -> Tensor {
+        Tensor::polar_out(out, abs, angle).unwrap()
     }
 
-    pub fn polygamma(&self, n: i64) -> Tensor {
-        self.f_polygamma(n).unwrap()
+    pub fn f_polygamma(&self, n: i64) -> Tensor {
+        self.polygamma(n).unwrap()
     }
 
-    pub fn polygamma_(&mut self, n: i64) -> Tensor {
-        self.f_polygamma_(n).unwrap()
+    pub fn f_polygamma_(&mut self, n: i64) -> Tensor {
+        self.polygamma_(n).unwrap()
     }
 
-    pub fn polygamma_out(&self, out: &Tensor, n: i64) -> Tensor {
-        self.f_polygamma_out(out, n).unwrap()
+    pub fn f_polygamma_out(&self, out: &Tensor, n: i64) -> Tensor {
+        self.polygamma_out(out, n).unwrap()
     }
 
-    pub fn positive(&self) -> Tensor {
-        self.f_positive().unwrap()
+    pub fn f_positive(&self) -> Tensor {
+        self.positive().unwrap()
     }
 
-    pub fn pow(&self, exponent: &Tensor) -> Tensor {
-        self.f_pow(exponent).unwrap()
+    pub fn f_pow(&self, exponent: &Tensor) -> Tensor {
+        self.pow(exponent).unwrap()
     }
 
-    pub fn pow_<S: Into<Scalar>>(&mut self, exponent: S) -> Tensor {
-        self.f_pow_(exponent).unwrap()
+    pub fn f_pow_<S: Into<Scalar>>(&mut self, exponent: S) -> Tensor {
+        self.pow_(exponent).unwrap()
     }
 
-    pub fn pow_scalar<S: Into<Scalar>>(self_scalar: S, exponent: &Tensor) -> Tensor {
-        Tensor::f_pow_scalar(self_scalar, exponent).unwrap()
+    pub fn f_pow_scalar<S: Into<Scalar>>(self_scalar: S, exponent: &Tensor) -> Tensor {
+        Tensor::pow_scalar(self_scalar, exponent).unwrap()
     }
 
-    pub fn pow_scalar_out<S: Into<Scalar>>(
+    pub fn f_pow_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         self_scalar: S,
         exponent: &Tensor,
     ) -> Tensor {
-        Tensor::f_pow_scalar_out(out, self_scalar, exponent).unwrap()
+        Tensor::pow_scalar_out(out, self_scalar, exponent).unwrap()
     }
 
-    pub fn pow_tensor_(&mut self, exponent: &Tensor) -> Tensor {
-        self.f_pow_tensor_(exponent).unwrap()
+    pub fn f_pow_tensor_(&mut self, exponent: &Tensor) -> Tensor {
+        self.pow_tensor_(exponent).unwrap()
     }
 
-    pub fn pow_tensor_scalar<S: Into<Scalar>>(&self, exponent: S) -> Tensor {
-        self.f_pow_tensor_scalar(exponent).unwrap()
+    pub fn f_pow_tensor_scalar<S: Into<Scalar>>(&self, exponent: S) -> Tensor {
+        self.pow_tensor_scalar(exponent).unwrap()
     }
 
-    pub fn pow_tensor_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, exponent: S) -> Tensor {
-        self.f_pow_tensor_scalar_out(out, exponent).unwrap()
+    pub fn f_pow_tensor_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, exponent: S) -> Tensor {
+        self.pow_tensor_scalar_out(out, exponent).unwrap()
     }
 
-    pub fn pow_tensor_tensor_out(&self, out: &Tensor, exponent: &Tensor) -> Tensor {
-        self.f_pow_tensor_tensor_out(out, exponent).unwrap()
+    pub fn f_pow_tensor_tensor_out(&self, out: &Tensor, exponent: &Tensor) -> Tensor {
+        self.pow_tensor_tensor_out(out, exponent).unwrap()
     }
 
-    pub fn prelu(&self, weight: &Tensor) -> Tensor {
-        self.f_prelu(weight).unwrap()
+    pub fn f_prelu(&self, weight: &Tensor) -> Tensor {
+        self.prelu(weight).unwrap()
     }
 
-    pub fn prod(&self, dtype: impl Into<Option<Kind>>) -> Tensor {
-        self.f_prod(dtype).unwrap()
+    pub fn f_prod(&self, dtype: impl Into<Option<Kind>>) -> Tensor {
+        self.prod(dtype).unwrap()
     }
 
-    pub fn prod_dim_int(&self, dim: i64, keepdim: bool, dtype: impl Into<Option<Kind>>) -> Tensor {
-        self.f_prod_dim_int(dim, keepdim, dtype).unwrap()
+    pub fn f_prod_dim_int(
+        &self,
+        dim: i64,
+        keepdim: bool,
+        dtype: impl Into<Option<Kind>>,
+    ) -> Tensor {
+        self.prod_dim_int(dim, keepdim, dtype).unwrap()
     }
 
-    pub fn prod_int_out(
+    pub fn f_prod_int_out(
         &self,
         out: &Tensor,
         dim: i64,
         keepdim: bool,
         dtype: impl Into<Option<Kind>>,
     ) -> Tensor {
-        self.f_prod_int_out(out, dim, keepdim, dtype).unwrap()
+        self.prod_int_out(out, dim, keepdim, dtype).unwrap()
     }
 
-    pub fn prod_out(&self, out: &Tensor, dtype: impl Into<Option<Kind>>) -> Tensor {
-        self.f_prod_out(out, dtype).unwrap()
+    pub fn f_prod_out(&self, out: &Tensor, dtype: impl Into<Option<Kind>>) -> Tensor {
+        self.prod_out(out, dtype).unwrap()
     }
 
-    pub fn put(&self, index: &Tensor, source: &Tensor, accumulate: bool) -> Tensor {
-        self.f_put(index, source, accumulate).unwrap()
+    pub fn f_put(&self, index: &Tensor, source: &Tensor, accumulate: bool) -> Tensor {
+        self.put(index, source, accumulate).unwrap()
     }
 
-    pub fn put_(&mut self, index: &Tensor, source: &Tensor, accumulate: bool) -> Tensor {
-        self.f_put_(index, source, accumulate).unwrap()
+    pub fn f_put_(&mut self, index: &Tensor, source: &Tensor, accumulate: bool) -> Tensor {
+        self.put_(index, source, accumulate).unwrap()
     }
 
-    pub fn put_out(
+    pub fn f_put_out(
         &self,
         out: &Tensor,
         index: &Tensor,
         source: &Tensor,
         accumulate: bool,
     ) -> Tensor {
-        self.f_put_out(out, index, source, accumulate).unwrap()
+        self.put_out(out, index, source, accumulate).unwrap()
     }
 
-    pub fn q_per_channel_axis(&self) -> i64 {
-        self.f_q_per_channel_axis().unwrap()
+    pub fn f_q_per_channel_axis(&self) -> i64 {
+        self.q_per_channel_axis().unwrap()
     }
 
-    pub fn q_per_channel_scales(&self) -> Tensor {
-        self.f_q_per_channel_scales().unwrap()
+    pub fn f_q_per_channel_scales(&self) -> Tensor {
+        self.q_per_channel_scales().unwrap()
     }
 
-    pub fn q_per_channel_scales_out(&self, out: &Tensor) -> Tensor {
-        self.f_q_per_channel_scales_out(out).unwrap()
+    pub fn f_q_per_channel_scales_out(&self, out: &Tensor) -> Tensor {
+        self.q_per_channel_scales_out(out).unwrap()
     }
 
-    pub fn q_per_channel_zero_points(&self) -> Tensor {
-        self.f_q_per_channel_zero_points().unwrap()
+    pub fn f_q_per_channel_zero_points(&self) -> Tensor {
+        self.q_per_channel_zero_points().unwrap()
     }
 
-    pub fn q_per_channel_zero_points_out(&self, out: &Tensor) -> Tensor {
-        self.f_q_per_channel_zero_points_out(out).unwrap()
+    pub fn f_q_per_channel_zero_points_out(&self, out: &Tensor) -> Tensor {
+        self.q_per_channel_zero_points_out(out).unwrap()
     }
 
-    pub fn q_scale(&self) -> f64 {
-        self.f_q_scale().unwrap()
+    pub fn f_q_scale(&self) -> f64 {
+        self.q_scale().unwrap()
     }
 
-    pub fn q_zero_point(&self) -> i64 {
-        self.f_q_zero_point().unwrap()
+    pub fn f_q_zero_point(&self) -> i64 {
+        self.q_zero_point().unwrap()
     }
 
-    pub fn qr(&self, some: bool) -> (Tensor, Tensor) {
-        self.f_qr(some).unwrap()
+    pub fn f_qr(&self, some: bool) -> (Tensor, Tensor) {
+        self.qr(some).unwrap()
     }
 
-    pub fn qr_q(&self, q: &Tensor, r: &Tensor, some: bool) -> (Tensor, Tensor) {
-        self.f_qr_q(q, r, some).unwrap()
+    pub fn f_qr_q(&self, q: &Tensor, r: &Tensor, some: bool) -> (Tensor, Tensor) {
+        self.qr_q(q, r, some).unwrap()
     }
 
-    pub fn quantile(
+    pub fn f_quantile(
         &self,
         q: &Tensor,
         dim: impl Into<Option<i64>>,
         keepdim: bool,
         interpolation: &str,
     ) -> Tensor {
-        self.f_quantile(q, dim, keepdim, interpolation).unwrap()
+        self.quantile(q, dim, keepdim, interpolation).unwrap()
     }
 
-    pub fn quantile_out(
+    pub fn f_quantile_out(
         &self,
         out: &Tensor,
         q: &Tensor,
@@ -13811,20 +13840,20 @@ impl Tensor {
         keepdim: bool,
         interpolation: &str,
     ) -> Tensor {
-        self.f_quantile_out(out, q, dim, keepdim, interpolation).unwrap()
+        self.quantile_out(out, q, dim, keepdim, interpolation).unwrap()
     }
 
-    pub fn quantile_scalar(
+    pub fn f_quantile_scalar(
         &self,
         q: f64,
         dim: impl Into<Option<i64>>,
         keepdim: bool,
         interpolation: &str,
     ) -> Tensor {
-        self.f_quantile_scalar(q, dim, keepdim, interpolation).unwrap()
+        self.quantile_scalar(q, dim, keepdim, interpolation).unwrap()
     }
 
-    pub fn quantile_scalar_out(
+    pub fn f_quantile_scalar_out(
         &self,
         out: &Tensor,
         q: f64,
@@ -13832,20 +13861,20 @@ impl Tensor {
         keepdim: bool,
         interpolation: &str,
     ) -> Tensor {
-        self.f_quantile_scalar_out(out, q, dim, keepdim, interpolation).unwrap()
+        self.quantile_scalar_out(out, q, dim, keepdim, interpolation).unwrap()
     }
 
-    pub fn quantize_per_channel(
+    pub fn f_quantize_per_channel(
         &self,
         scales: &Tensor,
         zero_points: &Tensor,
         axis: i64,
         dtype: Kind,
     ) -> Tensor {
-        self.f_quantize_per_channel(scales, zero_points, axis, dtype).unwrap()
+        self.quantize_per_channel(scales, zero_points, axis, dtype).unwrap()
     }
 
-    pub fn quantize_per_channel_out(
+    pub fn f_quantize_per_channel_out(
         &self,
         out: &Tensor,
         scales: &Tensor,
@@ -13853,75 +13882,75 @@ impl Tensor {
         axis: i64,
         dtype: Kind,
     ) -> Tensor {
-        self.f_quantize_per_channel_out(out, scales, zero_points, axis, dtype).unwrap()
+        self.quantize_per_channel_out(out, scales, zero_points, axis, dtype).unwrap()
     }
 
-    pub fn quantize_per_tensor(&self, scale: f64, zero_point: i64, dtype: Kind) -> Tensor {
-        self.f_quantize_per_tensor(scale, zero_point, dtype).unwrap()
+    pub fn f_quantize_per_tensor(&self, scale: f64, zero_point: i64, dtype: Kind) -> Tensor {
+        self.quantize_per_tensor(scale, zero_point, dtype).unwrap()
     }
 
-    pub fn quantize_per_tensor_dynamic(&self, dtype: Kind, reduce_range: bool) -> Tensor {
-        self.f_quantize_per_tensor_dynamic(dtype, reduce_range).unwrap()
+    pub fn f_quantize_per_tensor_dynamic(&self, dtype: Kind, reduce_range: bool) -> Tensor {
+        self.quantize_per_tensor_dynamic(dtype, reduce_range).unwrap()
     }
 
-    pub fn quantize_per_tensor_dynamic_out(
+    pub fn f_quantize_per_tensor_dynamic_out(
         &self,
         out: &Tensor,
         dtype: Kind,
         reduce_range: bool,
     ) -> Tensor {
-        self.f_quantize_per_tensor_dynamic_out(out, dtype, reduce_range).unwrap()
+        self.quantize_per_tensor_dynamic_out(out, dtype, reduce_range).unwrap()
     }
 
-    pub fn quantize_per_tensor_out(
+    pub fn f_quantize_per_tensor_out(
         &self,
         out: &Tensor,
         scale: f64,
         zero_point: i64,
         dtype: Kind,
     ) -> Tensor {
-        self.f_quantize_per_tensor_out(out, scale, zero_point, dtype).unwrap()
+        self.quantize_per_tensor_out(out, scale, zero_point, dtype).unwrap()
     }
 
-    pub fn quantize_per_tensor_tensor_qparams(
+    pub fn f_quantize_per_tensor_tensor_qparams(
         &self,
         scale: &Tensor,
         zero_point: &Tensor,
         dtype: Kind,
     ) -> Tensor {
-        self.f_quantize_per_tensor_tensor_qparams(scale, zero_point, dtype).unwrap()
+        self.quantize_per_tensor_tensor_qparams(scale, zero_point, dtype).unwrap()
     }
 
-    pub fn quantize_per_tensor_tensor_qparams_out(
+    pub fn f_quantize_per_tensor_tensor_qparams_out(
         &self,
         out: &Tensor,
         scale: &Tensor,
         zero_point: &Tensor,
         dtype: Kind,
     ) -> Tensor {
-        self.f_quantize_per_tensor_tensor_qparams_out(out, scale, zero_point, dtype).unwrap()
+        self.quantize_per_tensor_tensor_qparams_out(out, scale, zero_point, dtype).unwrap()
     }
 
-    pub fn quantize_per_tensor_tensors<T: Borrow<Tensor>>(
+    pub fn f_quantize_per_tensor_tensors<T: Borrow<Tensor>>(
         tensors: &[T],
         scales: &Tensor,
         zero_points: &Tensor,
         dtype: Kind,
     ) -> Vec<Tensor> {
-        Tensor::f_quantize_per_tensor_tensors(tensors, scales, zero_points, dtype).unwrap()
+        Tensor::quantize_per_tensor_tensors(tensors, scales, zero_points, dtype).unwrap()
     }
 
-    pub fn quantize_per_tensor_tensors_out<T: Borrow<Tensor>>(
+    pub fn f_quantize_per_tensor_tensors_out<T: Borrow<Tensor>>(
         out: &[T],
         tensors: &[T],
         scales: &Tensor,
         zero_points: &Tensor,
         dtype: Kind,
     ) {
-        Tensor::f_quantize_per_tensor_tensors_out(out, tensors, scales, zero_points, dtype).unwrap()
+        Tensor::quantize_per_tensor_tensors_out(out, tensors, scales, zero_points, dtype).unwrap()
     }
 
-    pub fn quantized_batch_norm<T: Borrow<Tensor>>(
+    pub fn f_quantized_batch_norm<T: Borrow<Tensor>>(
         &self,
         weight: Option<T>,
         bias: Option<T>,
@@ -13931,11 +13960,11 @@ impl Tensor {
         output_scale: f64,
         output_zero_point: i64,
     ) -> Tensor {
-        self.f_quantized_batch_norm(weight, bias, mean, var, eps, output_scale, output_zero_point)
+        self.quantized_batch_norm(weight, bias, mean, var, eps, output_scale, output_zero_point)
             .unwrap()
     }
 
-    pub fn quantized_batch_norm_out<T: Borrow<Tensor>>(
+    pub fn f_quantized_batch_norm_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: Option<T>,
@@ -13946,7 +13975,7 @@ impl Tensor {
         output_scale: f64,
         output_zero_point: i64,
     ) -> Tensor {
-        self.f_quantized_batch_norm_out(
+        self.quantized_batch_norm_out(
             out,
             weight,
             bias,
@@ -13959,7 +13988,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn quantized_gru_cell<S: Into<Scalar>>(
+    pub fn f_quantized_gru_cell<S: Into<Scalar>>(
         &self,
         hx: &Tensor,
         w_ih: &Tensor,
@@ -13975,7 +14004,7 @@ impl Tensor {
         zero_point_ih: S,
         zero_point_hh: S,
     ) -> Tensor {
-        self.f_quantized_gru_cell(
+        self.quantized_gru_cell(
             hx,
             w_ih,
             w_hh,
@@ -13993,7 +14022,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn quantized_lstm_cell<T: Borrow<Tensor>, S: Into<Scalar>>(
+    pub fn f_quantized_lstm_cell<T: Borrow<Tensor>, S: Into<Scalar>>(
         &self,
         hx: &[T],
         w_ih: &Tensor,
@@ -14009,7 +14038,7 @@ impl Tensor {
         zero_point_ih: S,
         zero_point_hh: S,
     ) -> (Tensor, Tensor) {
-        self.f_quantized_lstm_cell(
+        self.quantized_lstm_cell(
             hx,
             w_ih,
             w_hh,
@@ -14027,7 +14056,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn quantized_max_pool1d(
+    pub fn f_quantized_max_pool1d(
         &self,
         kernel_size: impl IntList,
         stride: impl IntList,
@@ -14035,34 +14064,10 @@ impl Tensor {
         dilation: impl IntList,
         ceil_mode: bool,
     ) -> Tensor {
-        self.f_quantized_max_pool1d(kernel_size, stride, padding, dilation, ceil_mode).unwrap()
+        self.quantized_max_pool1d(kernel_size, stride, padding, dilation, ceil_mode).unwrap()
     }
 
-    pub fn quantized_max_pool1d_out(
-        &self,
-        out: &Tensor,
-        kernel_size: impl IntList,
-        stride: impl IntList,
-        padding: impl IntList,
-        dilation: impl IntList,
-        ceil_mode: bool,
-    ) -> Tensor {
-        self.f_quantized_max_pool1d_out(out, kernel_size, stride, padding, dilation, ceil_mode)
-            .unwrap()
-    }
-
-    pub fn quantized_max_pool2d(
-        &self,
-        kernel_size: impl IntList,
-        stride: impl IntList,
-        padding: impl IntList,
-        dilation: impl IntList,
-        ceil_mode: bool,
-    ) -> Tensor {
-        self.f_quantized_max_pool2d(kernel_size, stride, padding, dilation, ceil_mode).unwrap()
-    }
-
-    pub fn quantized_max_pool2d_out(
+    pub fn f_quantized_max_pool1d_out(
         &self,
         out: &Tensor,
         kernel_size: impl IntList,
@@ -14071,11 +14076,35 @@ impl Tensor {
         dilation: impl IntList,
         ceil_mode: bool,
     ) -> Tensor {
-        self.f_quantized_max_pool2d_out(out, kernel_size, stride, padding, dilation, ceil_mode)
+        self.quantized_max_pool1d_out(out, kernel_size, stride, padding, dilation, ceil_mode)
             .unwrap()
     }
 
-    pub fn quantized_rnn_relu_cell<S: Into<Scalar>>(
+    pub fn f_quantized_max_pool2d(
+        &self,
+        kernel_size: impl IntList,
+        stride: impl IntList,
+        padding: impl IntList,
+        dilation: impl IntList,
+        ceil_mode: bool,
+    ) -> Tensor {
+        self.quantized_max_pool2d(kernel_size, stride, padding, dilation, ceil_mode).unwrap()
+    }
+
+    pub fn f_quantized_max_pool2d_out(
+        &self,
+        out: &Tensor,
+        kernel_size: impl IntList,
+        stride: impl IntList,
+        padding: impl IntList,
+        dilation: impl IntList,
+        ceil_mode: bool,
+    ) -> Tensor {
+        self.quantized_max_pool2d_out(out, kernel_size, stride, padding, dilation, ceil_mode)
+            .unwrap()
+    }
+
+    pub fn f_quantized_rnn_relu_cell<S: Into<Scalar>>(
         &self,
         hx: &Tensor,
         w_ih: &Tensor,
@@ -14091,7 +14120,7 @@ impl Tensor {
         zero_point_ih: S,
         zero_point_hh: S,
     ) -> Tensor {
-        self.f_quantized_rnn_relu_cell(
+        self.quantized_rnn_relu_cell(
             hx,
             w_ih,
             w_hh,
@@ -14109,7 +14138,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn quantized_rnn_tanh_cell<S: Into<Scalar>>(
+    pub fn f_quantized_rnn_tanh_cell<S: Into<Scalar>>(
         &self,
         hx: &Tensor,
         w_ih: &Tensor,
@@ -14125,7 +14154,7 @@ impl Tensor {
         zero_point_ih: S,
         zero_point_hh: S,
     ) -> Tensor {
-        self.f_quantized_rnn_tanh_cell(
+        self.quantized_rnn_tanh_cell(
             hx,
             w_ih,
             w_hh,
@@ -14143,467 +14172,490 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn rad2deg(&self) -> Tensor {
-        self.f_rad2deg().unwrap()
+    pub fn f_rad2deg(&self) -> Tensor {
+        self.rad2deg().unwrap()
     }
 
-    pub fn rad2deg_(&mut self) -> Tensor {
-        self.f_rad2deg_().unwrap()
+    pub fn f_rad2deg_(&mut self) -> Tensor {
+        self.rad2deg_().unwrap()
     }
 
-    pub fn rad2deg_out(&self, out: &Tensor) -> Tensor {
-        self.f_rad2deg_out(out).unwrap()
+    pub fn f_rad2deg_out(&self, out: &Tensor) -> Tensor {
+        self.rad2deg_out(out).unwrap()
     }
 
-    pub fn rand(size: impl IntList, options: (Kind, Device)) -> Tensor {
-        Tensor::f_rand(size, options).unwrap()
+    pub fn f_rand(size: impl IntList, options: (Kind, Device)) -> Tensor {
+        Tensor::rand(size, options).unwrap()
     }
 
-    pub fn rand_like(&self) -> Tensor {
-        self.f_rand_like().unwrap()
+    pub fn f_rand_like(&self) -> Tensor {
+        self.rand_like().unwrap()
     }
 
-    pub fn rand_like_out(&self, out: &Tensor) -> Tensor {
-        self.f_rand_like_out(out).unwrap()
+    pub fn f_rand_like_out(&self, out: &Tensor) -> Tensor {
+        self.rand_like_out(out).unwrap()
     }
 
-    pub fn rand_out(out: &Tensor, size: impl IntList) -> Tensor {
-        Tensor::f_rand_out(out, size).unwrap()
+    pub fn f_rand_out(out: &Tensor, size: impl IntList) -> Tensor {
+        Tensor::rand_out(out, size).unwrap()
     }
 
-    pub fn randint(high: i64, size: impl IntList, options: (Kind, Device)) -> Tensor {
-        Tensor::f_randint(high, size, options).unwrap()
+    pub fn f_randint(high: i64, size: impl IntList, options: (Kind, Device)) -> Tensor {
+        Tensor::randint(high, size, options).unwrap()
     }
 
-    pub fn randint_like(&self, high: i64) -> Tensor {
-        self.f_randint_like(high).unwrap()
+    pub fn f_randint_like(&self, high: i64) -> Tensor {
+        self.randint_like(high).unwrap()
     }
 
-    pub fn randint_like_low_dtype(&self, low: i64, high: i64) -> Tensor {
-        self.f_randint_like_low_dtype(low, high).unwrap()
+    pub fn f_randint_like_low_dtype(&self, low: i64, high: i64) -> Tensor {
+        self.randint_like_low_dtype(low, high).unwrap()
     }
 
-    pub fn randint_like_low_dtype_out(&self, out: &Tensor, low: i64, high: i64) -> Tensor {
-        self.f_randint_like_low_dtype_out(out, low, high).unwrap()
+    pub fn f_randint_like_low_dtype_out(&self, out: &Tensor, low: i64, high: i64) -> Tensor {
+        self.randint_like_low_dtype_out(out, low, high).unwrap()
     }
 
-    pub fn randint_like_out(&self, out: &Tensor, high: i64) -> Tensor {
-        self.f_randint_like_out(out, high).unwrap()
+    pub fn f_randint_like_out(&self, out: &Tensor, high: i64) -> Tensor {
+        self.randint_like_out(out, high).unwrap()
     }
 
-    pub fn randint_low(low: i64, high: i64, size: impl IntList, options: (Kind, Device)) -> Tensor {
-        Tensor::f_randint_low(low, high, size, options).unwrap()
+    pub fn f_randint_low(
+        low: i64,
+        high: i64,
+        size: impl IntList,
+        options: (Kind, Device),
+    ) -> Tensor {
+        Tensor::randint_low(low, high, size, options).unwrap()
     }
 
-    pub fn randint_low_out(out: &Tensor, low: i64, high: i64, size: impl IntList) -> Tensor {
-        Tensor::f_randint_low_out(out, low, high, size).unwrap()
+    pub fn f_randint_low_out(out: &Tensor, low: i64, high: i64, size: impl IntList) -> Tensor {
+        Tensor::randint_low_out(out, low, high, size).unwrap()
     }
 
-    pub fn randint_out(out: &Tensor, high: i64, size: impl IntList) -> Tensor {
-        Tensor::f_randint_out(out, high, size).unwrap()
+    pub fn f_randint_out(out: &Tensor, high: i64, size: impl IntList) -> Tensor {
+        Tensor::randint_out(out, high, size).unwrap()
     }
 
-    pub fn randn(size: impl IntList, options: (Kind, Device)) -> Tensor {
-        Tensor::f_randn(size, options).unwrap()
+    pub fn f_randn(size: impl IntList, options: (Kind, Device)) -> Tensor {
+        Tensor::randn(size, options).unwrap()
     }
 
-    pub fn randn_like(&self) -> Tensor {
-        self.f_randn_like().unwrap()
+    pub fn f_randn_like(&self) -> Tensor {
+        self.randn_like().unwrap()
     }
 
-    pub fn randn_like_out(&self, out: &Tensor) -> Tensor {
-        self.f_randn_like_out(out).unwrap()
+    pub fn f_randn_like_out(&self, out: &Tensor) -> Tensor {
+        self.randn_like_out(out).unwrap()
     }
 
-    pub fn randn_out(out: &Tensor, size: impl IntList) -> Tensor {
-        Tensor::f_randn_out(out, size).unwrap()
+    pub fn f_randn_out(out: &Tensor, size: impl IntList) -> Tensor {
+        Tensor::randn_out(out, size).unwrap()
     }
 
-    pub fn random(&self) -> Tensor {
-        self.f_random().unwrap()
+    pub fn f_random(&self) -> Tensor {
+        self.random().unwrap()
     }
 
-    pub fn random_(&mut self) -> Tensor {
-        self.f_random_().unwrap()
+    pub fn f_random_(&mut self) -> Tensor {
+        self.random_().unwrap()
     }
 
-    pub fn random_from(&self, from: i64, to: impl Into<Option<i64>>) -> Tensor {
-        self.f_random_from(from, to).unwrap()
+    pub fn f_random_from(&self, from: i64, to: impl Into<Option<i64>>) -> Tensor {
+        self.random_from(from, to).unwrap()
     }
 
-    pub fn random_from_(&mut self, from: i64, to: impl Into<Option<i64>>) -> Tensor {
-        self.f_random_from_(from, to).unwrap()
+    pub fn f_random_from_(&mut self, from: i64, to: impl Into<Option<i64>>) -> Tensor {
+        self.random_from_(from, to).unwrap()
     }
 
-    pub fn random_from_out(&self, out: &Tensor, from: i64, to: impl Into<Option<i64>>) -> Tensor {
-        self.f_random_from_out(out, from, to).unwrap()
+    pub fn f_random_from_out(&self, out: &Tensor, from: i64, to: impl Into<Option<i64>>) -> Tensor {
+        self.random_from_out(out, from, to).unwrap()
     }
 
-    pub fn random_out(&self, out: &Tensor) -> Tensor {
-        self.f_random_out(out).unwrap()
+    pub fn f_random_out(&self, out: &Tensor) -> Tensor {
+        self.random_out(out).unwrap()
     }
 
-    pub fn random_to(&self, to: i64) -> Tensor {
-        self.f_random_to(to).unwrap()
+    pub fn f_random_to(&self, to: i64) -> Tensor {
+        self.random_to(to).unwrap()
     }
 
-    pub fn random_to_(&mut self, to: i64) -> Tensor {
-        self.f_random_to_(to).unwrap()
+    pub fn f_random_to_(&mut self, to: i64) -> Tensor {
+        self.random_to_(to).unwrap()
     }
 
-    pub fn random_to_out(&self, out: &Tensor, to: i64) -> Tensor {
-        self.f_random_to_out(out, to).unwrap()
+    pub fn f_random_to_out(&self, out: &Tensor, to: i64) -> Tensor {
+        self.random_to_out(out, to).unwrap()
     }
 
-    pub fn randperm(n: i64, options: (Kind, Device)) -> Tensor {
-        Tensor::f_randperm(n, options).unwrap()
+    pub fn f_randperm(n: i64, options: (Kind, Device)) -> Tensor {
+        Tensor::randperm(n, options).unwrap()
     }
 
-    pub fn randperm_out(out: &Tensor, n: i64) -> Tensor {
-        Tensor::f_randperm_out(out, n).unwrap()
+    pub fn f_randperm_out(out: &Tensor, n: i64) -> Tensor {
+        Tensor::randperm_out(out, n).unwrap()
     }
 
-    pub fn range<S: Into<Scalar>>(start: S, end: S, options: (Kind, Device)) -> Tensor {
-        Tensor::f_range(start, end, options).unwrap()
+    pub fn f_range<S: Into<Scalar>>(start: S, end: S, options: (Kind, Device)) -> Tensor {
+        Tensor::range(start, end, options).unwrap()
     }
 
-    pub fn range_out<S: Into<Scalar>>(out: &Tensor, start: S, end: S) -> Tensor {
-        Tensor::f_range_out(out, start, end).unwrap()
+    pub fn f_range_out<S: Into<Scalar>>(out: &Tensor, start: S, end: S) -> Tensor {
+        Tensor::range_out(out, start, end).unwrap()
     }
 
-    pub fn range_out_<S: Into<Scalar>>(out: &Tensor, start: S, end: S) -> Tensor {
-        Tensor::f_range_out_(out, start, end).unwrap()
+    pub fn f_range_out_<S: Into<Scalar>>(out: &Tensor, start: S, end: S) -> Tensor {
+        Tensor::range_out_(out, start, end).unwrap()
     }
 
-    pub fn range_step<S: Into<Scalar>>(start: S, end: S, options: (Kind, Device)) -> Tensor {
-        Tensor::f_range_step(start, end, options).unwrap()
+    pub fn f_range_step<S: Into<Scalar>>(start: S, end: S, options: (Kind, Device)) -> Tensor {
+        Tensor::range_step(start, end, options).unwrap()
     }
 
-    pub fn ravel(&self) -> Tensor {
-        self.f_ravel().unwrap()
+    pub fn f_ravel(&self) -> Tensor {
+        self.ravel().unwrap()
     }
 
-    pub fn real(&self) -> Tensor {
-        self.f_real().unwrap()
+    pub fn f_real(&self) -> Tensor {
+        self.real().unwrap()
     }
 
-    pub fn reciprocal(&self) -> Tensor {
-        self.f_reciprocal().unwrap()
+    pub fn f_reciprocal(&self) -> Tensor {
+        self.reciprocal().unwrap()
     }
 
-    pub fn reciprocal_(&mut self) -> Tensor {
-        self.f_reciprocal_().unwrap()
+    pub fn f_reciprocal_(&mut self) -> Tensor {
+        self.reciprocal_().unwrap()
     }
 
-    pub fn reciprocal_out(&self, out: &Tensor) -> Tensor {
-        self.f_reciprocal_out(out).unwrap()
+    pub fn f_reciprocal_out(&self, out: &Tensor) -> Tensor {
+        self.reciprocal_out(out).unwrap()
     }
 
-    pub fn reflection_pad1d(&self, padding: impl IntList) -> Tensor {
-        self.f_reflection_pad1d(padding).unwrap()
+    pub fn f_reflection_pad1d(&self, padding: impl IntList) -> Tensor {
+        self.reflection_pad1d(padding).unwrap()
     }
 
-    pub fn reflection_pad1d_backward(&self, grad_output: &Tensor, padding: impl IntList) -> Tensor {
-        self.f_reflection_pad1d_backward(grad_output, padding).unwrap()
+    pub fn f_reflection_pad1d_backward(
+        &self,
+        grad_output: &Tensor,
+        padding: impl IntList,
+    ) -> Tensor {
+        self.reflection_pad1d_backward(grad_output, padding).unwrap()
     }
 
-    pub fn reflection_pad1d_backward_grad_input(
+    pub fn f_reflection_pad1d_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
         padding: impl IntList,
     ) -> Tensor {
-        self.f_reflection_pad1d_backward_grad_input(grad_input, grad_output, padding).unwrap()
+        self.reflection_pad1d_backward_grad_input(grad_input, grad_output, padding).unwrap()
     }
 
-    pub fn reflection_pad1d_out(&self, out: &Tensor, padding: impl IntList) -> Tensor {
-        self.f_reflection_pad1d_out(out, padding).unwrap()
+    pub fn f_reflection_pad1d_out(&self, out: &Tensor, padding: impl IntList) -> Tensor {
+        self.reflection_pad1d_out(out, padding).unwrap()
     }
 
-    pub fn reflection_pad2d(&self, padding: impl IntList) -> Tensor {
-        self.f_reflection_pad2d(padding).unwrap()
+    pub fn f_reflection_pad2d(&self, padding: impl IntList) -> Tensor {
+        self.reflection_pad2d(padding).unwrap()
     }
 
-    pub fn reflection_pad2d_backward(&self, grad_output: &Tensor, padding: impl IntList) -> Tensor {
-        self.f_reflection_pad2d_backward(grad_output, padding).unwrap()
+    pub fn f_reflection_pad2d_backward(
+        &self,
+        grad_output: &Tensor,
+        padding: impl IntList,
+    ) -> Tensor {
+        self.reflection_pad2d_backward(grad_output, padding).unwrap()
     }
 
-    pub fn reflection_pad2d_backward_grad_input(
+    pub fn f_reflection_pad2d_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
         padding: impl IntList,
     ) -> Tensor {
-        self.f_reflection_pad2d_backward_grad_input(grad_input, grad_output, padding).unwrap()
+        self.reflection_pad2d_backward_grad_input(grad_input, grad_output, padding).unwrap()
     }
 
-    pub fn reflection_pad2d_out(&self, out: &Tensor, padding: impl IntList) -> Tensor {
-        self.f_reflection_pad2d_out(out, padding).unwrap()
+    pub fn f_reflection_pad2d_out(&self, out: &Tensor, padding: impl IntList) -> Tensor {
+        self.reflection_pad2d_out(out, padding).unwrap()
     }
 
-    pub fn reflection_pad3d(&self, padding: impl IntList) -> Tensor {
-        self.f_reflection_pad3d(padding).unwrap()
+    pub fn f_reflection_pad3d(&self, padding: impl IntList) -> Tensor {
+        self.reflection_pad3d(padding).unwrap()
     }
 
-    pub fn reflection_pad3d_backward(&self, grad_output: &Tensor, padding: impl IntList) -> Tensor {
-        self.f_reflection_pad3d_backward(grad_output, padding).unwrap()
+    pub fn f_reflection_pad3d_backward(
+        &self,
+        grad_output: &Tensor,
+        padding: impl IntList,
+    ) -> Tensor {
+        self.reflection_pad3d_backward(grad_output, padding).unwrap()
     }
 
-    pub fn reflection_pad3d_backward_grad_input(
+    pub fn f_reflection_pad3d_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
         padding: impl IntList,
     ) -> Tensor {
-        self.f_reflection_pad3d_backward_grad_input(grad_input, grad_output, padding).unwrap()
+        self.reflection_pad3d_backward_grad_input(grad_input, grad_output, padding).unwrap()
     }
 
-    pub fn reflection_pad3d_out(&self, out: &Tensor, padding: impl IntList) -> Tensor {
-        self.f_reflection_pad3d_out(out, padding).unwrap()
+    pub fn f_reflection_pad3d_out(&self, out: &Tensor, padding: impl IntList) -> Tensor {
+        self.reflection_pad3d_out(out, padding).unwrap()
     }
 
-    pub fn relu(&self) -> Tensor {
-        self.f_relu().unwrap()
+    pub fn f_relu(&self) -> Tensor {
+        self.relu().unwrap()
     }
 
-    pub fn relu6(&self) -> Tensor {
-        self.f_relu6().unwrap()
+    pub fn f_relu6(&self) -> Tensor {
+        self.relu6().unwrap()
     }
 
-    pub fn relu6_(&mut self) -> Tensor {
-        self.f_relu6_().unwrap()
+    pub fn f_relu6_(&mut self) -> Tensor {
+        self.relu6_().unwrap()
     }
 
-    pub fn relu_(&mut self) -> Tensor {
-        self.f_relu_().unwrap()
+    pub fn f_relu_(&mut self) -> Tensor {
+        self.relu_().unwrap()
     }
 
-    pub fn relu_out(&self, out: &Tensor) -> Tensor {
-        self.f_relu_out(out).unwrap()
+    pub fn f_relu_out(&self, out: &Tensor) -> Tensor {
+        self.relu_out(out).unwrap()
     }
 
-    pub fn remainder<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_remainder(other).unwrap()
+    pub fn f_remainder<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.remainder(other).unwrap()
     }
 
-    pub fn remainder_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_remainder_(other).unwrap()
+    pub fn f_remainder_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.remainder_(other).unwrap()
     }
 
-    pub fn remainder_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
-        self.f_remainder_scalar_out(out, other).unwrap()
+    pub fn f_remainder_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
+        self.remainder_scalar_out(out, other).unwrap()
     }
 
-    pub fn remainder_scalar_tensor<S: Into<Scalar>>(self_scalar: S, other: &Tensor) -> Tensor {
-        Tensor::f_remainder_scalar_tensor(self_scalar, other).unwrap()
+    pub fn f_remainder_scalar_tensor<S: Into<Scalar>>(self_scalar: S, other: &Tensor) -> Tensor {
+        Tensor::remainder_scalar_tensor(self_scalar, other).unwrap()
     }
 
-    pub fn remainder_scalar_tensor_out<S: Into<Scalar>>(
+    pub fn f_remainder_scalar_tensor_out<S: Into<Scalar>>(
         out: &Tensor,
         self_scalar: S,
         other: &Tensor,
     ) -> Tensor {
-        Tensor::f_remainder_scalar_tensor_out(out, self_scalar, other).unwrap()
+        Tensor::remainder_scalar_tensor_out(out, self_scalar, other).unwrap()
     }
 
-    pub fn remainder_tensor(&self, other: &Tensor) -> Tensor {
-        self.f_remainder_tensor(other).unwrap()
+    pub fn f_remainder_tensor(&self, other: &Tensor) -> Tensor {
+        self.remainder_tensor(other).unwrap()
     }
 
-    pub fn remainder_tensor_(&mut self, other: &Tensor) -> Tensor {
-        self.f_remainder_tensor_(other).unwrap()
+    pub fn f_remainder_tensor_(&mut self, other: &Tensor) -> Tensor {
+        self.remainder_tensor_(other).unwrap()
     }
 
-    pub fn remainder_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_remainder_tensor_out(out, other).unwrap()
+    pub fn f_remainder_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.remainder_tensor_out(out, other).unwrap()
     }
 
-    pub fn renorm<S: Into<Scalar>>(&self, p: S, dim: i64, maxnorm: S) -> Tensor {
-        self.f_renorm(p, dim, maxnorm).unwrap()
+    pub fn f_renorm<S: Into<Scalar>>(&self, p: S, dim: i64, maxnorm: S) -> Tensor {
+        self.renorm(p, dim, maxnorm).unwrap()
     }
 
-    pub fn renorm_<S: Into<Scalar>>(&mut self, p: S, dim: i64, maxnorm: S) -> Tensor {
-        self.f_renorm_(p, dim, maxnorm).unwrap()
+    pub fn f_renorm_<S: Into<Scalar>>(&mut self, p: S, dim: i64, maxnorm: S) -> Tensor {
+        self.renorm_(p, dim, maxnorm).unwrap()
     }
 
-    pub fn renorm_out<S: Into<Scalar>>(&self, out: &Tensor, p: S, dim: i64, maxnorm: S) -> Tensor {
-        self.f_renorm_out(out, p, dim, maxnorm).unwrap()
+    pub fn f_renorm_out<S: Into<Scalar>>(
+        &self,
+        out: &Tensor,
+        p: S,
+        dim: i64,
+        maxnorm: S,
+    ) -> Tensor {
+        self.renorm_out(out, p, dim, maxnorm).unwrap()
     }
 
-    pub fn repeat(&self, repeats: impl IntList) -> Tensor {
-        self.f_repeat(repeats).unwrap()
+    pub fn f_repeat(&self, repeats: impl IntList) -> Tensor {
+        self.repeat(repeats).unwrap()
     }
 
-    pub fn repeat_interleave(repeats: &Tensor, output_size: impl Into<Option<i64>>) -> Tensor {
-        Tensor::f_repeat_interleave(repeats, output_size).unwrap()
+    pub fn f_repeat_interleave(repeats: &Tensor, output_size: impl Into<Option<i64>>) -> Tensor {
+        Tensor::repeat_interleave(repeats, output_size).unwrap()
     }
 
-    pub fn repeat_interleave_self_int(
+    pub fn f_repeat_interleave_self_int(
         &self,
         repeats: i64,
         dim: impl Into<Option<i64>>,
         output_size: impl Into<Option<i64>>,
     ) -> Tensor {
-        self.f_repeat_interleave_self_int(repeats, dim, output_size).unwrap()
+        self.repeat_interleave_self_int(repeats, dim, output_size).unwrap()
     }
 
-    pub fn repeat_interleave_self_tensor(
+    pub fn f_repeat_interleave_self_tensor(
         &self,
         repeats: &Tensor,
         dim: impl Into<Option<i64>>,
         output_size: impl Into<Option<i64>>,
     ) -> Tensor {
-        self.f_repeat_interleave_self_tensor(repeats, dim, output_size).unwrap()
+        self.repeat_interleave_self_tensor(repeats, dim, output_size).unwrap()
     }
 
-    pub fn repeat_interleave_tensor_out(
+    pub fn f_repeat_interleave_tensor_out(
         out: &Tensor,
         repeats: &Tensor,
         output_size: impl Into<Option<i64>>,
     ) -> Tensor {
-        Tensor::f_repeat_interleave_tensor_out(out, repeats, output_size).unwrap()
+        Tensor::repeat_interleave_tensor_out(out, repeats, output_size).unwrap()
     }
 
-    pub fn repeat_out(&self, out: &Tensor, repeats: impl IntList) -> Tensor {
-        self.f_repeat_out(out, repeats).unwrap()
+    pub fn f_repeat_out(&self, out: &Tensor, repeats: impl IntList) -> Tensor {
+        self.repeat_out(out, repeats).unwrap()
     }
 
-    pub fn replication_pad1d(&self, padding: impl IntList) -> Tensor {
-        self.f_replication_pad1d(padding).unwrap()
+    pub fn f_replication_pad1d(&self, padding: impl IntList) -> Tensor {
+        self.replication_pad1d(padding).unwrap()
     }
 
-    pub fn replication_pad1d_backward(
+    pub fn f_replication_pad1d_backward(
         &self,
         grad_output: &Tensor,
         padding: impl IntList,
     ) -> Tensor {
-        self.f_replication_pad1d_backward(grad_output, padding).unwrap()
+        self.replication_pad1d_backward(grad_output, padding).unwrap()
     }
 
-    pub fn replication_pad1d_backward_grad_input(
-        &self,
-        grad_input: &Tensor,
-        grad_output: &Tensor,
-        padding: impl IntList,
-    ) -> Tensor {
-        self.f_replication_pad1d_backward_grad_input(grad_input, grad_output, padding).unwrap()
-    }
-
-    pub fn replication_pad1d_out(&self, out: &Tensor, padding: impl IntList) -> Tensor {
-        self.f_replication_pad1d_out(out, padding).unwrap()
-    }
-
-    pub fn replication_pad2d(&self, padding: impl IntList) -> Tensor {
-        self.f_replication_pad2d(padding).unwrap()
-    }
-
-    pub fn replication_pad2d_backward(
-        &self,
-        grad_output: &Tensor,
-        padding: impl IntList,
-    ) -> Tensor {
-        self.f_replication_pad2d_backward(grad_output, padding).unwrap()
-    }
-
-    pub fn replication_pad2d_backward_grad_input(
+    pub fn f_replication_pad1d_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
         padding: impl IntList,
     ) -> Tensor {
-        self.f_replication_pad2d_backward_grad_input(grad_input, grad_output, padding).unwrap()
+        self.replication_pad1d_backward_grad_input(grad_input, grad_output, padding).unwrap()
     }
 
-    pub fn replication_pad2d_out(&self, out: &Tensor, padding: impl IntList) -> Tensor {
-        self.f_replication_pad2d_out(out, padding).unwrap()
+    pub fn f_replication_pad1d_out(&self, out: &Tensor, padding: impl IntList) -> Tensor {
+        self.replication_pad1d_out(out, padding).unwrap()
     }
 
-    pub fn replication_pad3d(&self, padding: impl IntList) -> Tensor {
-        self.f_replication_pad3d(padding).unwrap()
+    pub fn f_replication_pad2d(&self, padding: impl IntList) -> Tensor {
+        self.replication_pad2d(padding).unwrap()
     }
 
-    pub fn replication_pad3d_backward(
+    pub fn f_replication_pad2d_backward(
         &self,
         grad_output: &Tensor,
         padding: impl IntList,
     ) -> Tensor {
-        self.f_replication_pad3d_backward(grad_output, padding).unwrap()
+        self.replication_pad2d_backward(grad_output, padding).unwrap()
     }
 
-    pub fn replication_pad3d_backward_grad_input(
+    pub fn f_replication_pad2d_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
         padding: impl IntList,
     ) -> Tensor {
-        self.f_replication_pad3d_backward_grad_input(grad_input, grad_output, padding).unwrap()
+        self.replication_pad2d_backward_grad_input(grad_input, grad_output, padding).unwrap()
     }
 
-    pub fn replication_pad3d_out(&self, out: &Tensor, padding: impl IntList) -> Tensor {
-        self.f_replication_pad3d_out(out, padding).unwrap()
+    pub fn f_replication_pad2d_out(&self, out: &Tensor, padding: impl IntList) -> Tensor {
+        self.replication_pad2d_out(out, padding).unwrap()
     }
 
-    pub fn requires_grad_(&mut self, requires_grad: bool) -> Tensor {
-        self.f_requires_grad_(requires_grad).unwrap()
+    pub fn f_replication_pad3d(&self, padding: impl IntList) -> Tensor {
+        self.replication_pad3d(padding).unwrap()
     }
 
-    pub fn reshape(&self, shape: impl IntList) -> Tensor {
-        self.f_reshape(shape).unwrap()
+    pub fn f_replication_pad3d_backward(
+        &self,
+        grad_output: &Tensor,
+        padding: impl IntList,
+    ) -> Tensor {
+        self.replication_pad3d_backward(grad_output, padding).unwrap()
     }
 
-    pub fn reshape_as(&self, other: &Tensor) -> Tensor {
-        self.f_reshape_as(other).unwrap()
+    pub fn f_replication_pad3d_backward_grad_input(
+        &self,
+        grad_input: &Tensor,
+        grad_output: &Tensor,
+        padding: impl IntList,
+    ) -> Tensor {
+        self.replication_pad3d_backward_grad_input(grad_input, grad_output, padding).unwrap()
     }
 
-    pub fn resize(&self, size: impl IntList) -> Tensor {
-        self.f_resize(size).unwrap()
+    pub fn f_replication_pad3d_out(&self, out: &Tensor, padding: impl IntList) -> Tensor {
+        self.replication_pad3d_out(out, padding).unwrap()
     }
 
-    pub fn resize_(&mut self, size: impl IntList) -> Tensor {
-        self.f_resize_(size).unwrap()
+    pub fn f_requires_grad_(&mut self, requires_grad: bool) -> Tensor {
+        self.requires_grad_(requires_grad).unwrap()
     }
 
-    pub fn resize_as(&self, the_template: &Tensor) -> Tensor {
-        self.f_resize_as(the_template).unwrap()
+    pub fn f_reshape(&self, shape: impl IntList) -> Tensor {
+        self.reshape(shape).unwrap()
     }
 
-    pub fn resize_as_(&mut self, the_template: &Tensor) -> Tensor {
-        self.f_resize_as_(the_template).unwrap()
+    pub fn f_reshape_as(&self, other: &Tensor) -> Tensor {
+        self.reshape_as(other).unwrap()
     }
 
-    pub fn resize_as_out(&self, out: &Tensor, the_template: &Tensor) -> Tensor {
-        self.f_resize_as_out(out, the_template).unwrap()
+    pub fn f_resize(&self, size: impl IntList) -> Tensor {
+        self.resize(size).unwrap()
     }
 
-    pub fn resize_as_sparse(&self, the_template: &Tensor) -> Tensor {
-        self.f_resize_as_sparse(the_template).unwrap()
+    pub fn f_resize_(&mut self, size: impl IntList) -> Tensor {
+        self.resize_(size).unwrap()
     }
 
-    pub fn resize_as_sparse_(&mut self, the_template: &Tensor) -> Tensor {
-        self.f_resize_as_sparse_(the_template).unwrap()
+    pub fn f_resize_as(&self, the_template: &Tensor) -> Tensor {
+        self.resize_as(the_template).unwrap()
     }
 
-    pub fn resize_as_sparse_out(&self, out: &Tensor, the_template: &Tensor) -> Tensor {
-        self.f_resize_as_sparse_out(out, the_template).unwrap()
+    pub fn f_resize_as_(&mut self, the_template: &Tensor) -> Tensor {
+        self.resize_as_(the_template).unwrap()
     }
 
-    pub fn resize_out(&self, out: &Tensor, size: impl IntList) -> Tensor {
-        self.f_resize_out(out, size).unwrap()
+    pub fn f_resize_as_out(&self, out: &Tensor, the_template: &Tensor) -> Tensor {
+        self.resize_as_out(out, the_template).unwrap()
     }
 
-    pub fn resolve_conj(&self) -> Tensor {
-        self.f_resolve_conj().unwrap()
+    pub fn f_resize_as_sparse(&self, the_template: &Tensor) -> Tensor {
+        self.resize_as_sparse(the_template).unwrap()
     }
 
-    pub fn resolve_neg(&self) -> Tensor {
-        self.f_resolve_neg().unwrap()
+    pub fn f_resize_as_sparse_(&mut self, the_template: &Tensor) -> Tensor {
+        self.resize_as_sparse_(the_template).unwrap()
     }
 
-    pub fn retains_grad(&self) -> bool {
-        self.f_retains_grad().unwrap()
+    pub fn f_resize_as_sparse_out(&self, out: &Tensor, the_template: &Tensor) -> Tensor {
+        self.resize_as_sparse_out(out, the_template).unwrap()
     }
 
-    pub fn rnn_relu<T: Borrow<Tensor>>(
+    pub fn f_resize_out(&self, out: &Tensor, size: impl IntList) -> Tensor {
+        self.resize_out(out, size).unwrap()
+    }
+
+    pub fn f_resolve_conj(&self) -> Tensor {
+        self.resolve_conj().unwrap()
+    }
+
+    pub fn f_resolve_neg(&self) -> Tensor {
+        self.resolve_neg().unwrap()
+    }
+
+    pub fn f_retains_grad(&self) -> bool {
+        self.retains_grad().unwrap()
+    }
+
+    pub fn f_rnn_relu<T: Borrow<Tensor>>(
         &self,
         hx: &Tensor,
         params: &[T],
@@ -14614,7 +14666,7 @@ impl Tensor {
         bidirectional: bool,
         batch_first: bool,
     ) -> (Tensor, Tensor) {
-        self.f_rnn_relu(
+        self.rnn_relu(
             hx,
             params,
             has_biases,
@@ -14627,7 +14679,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn rnn_relu_cell<T: Borrow<Tensor>>(
+    pub fn f_rnn_relu_cell<T: Borrow<Tensor>>(
         &self,
         hx: &Tensor,
         w_ih: &Tensor,
@@ -14635,10 +14687,10 @@ impl Tensor {
         b_ih: Option<T>,
         b_hh: Option<T>,
     ) -> Tensor {
-        self.f_rnn_relu_cell(hx, w_ih, w_hh, b_ih, b_hh).unwrap()
+        self.rnn_relu_cell(hx, w_ih, w_hh, b_ih, b_hh).unwrap()
     }
 
-    pub fn rnn_relu_data<T: Borrow<Tensor>>(
+    pub fn f_rnn_relu_data<T: Borrow<Tensor>>(
         data: &Tensor,
         batch_sizes: &Tensor,
         hx: &Tensor,
@@ -14649,7 +14701,7 @@ impl Tensor {
         train: bool,
         bidirectional: bool,
     ) -> (Tensor, Tensor) {
-        Tensor::f_rnn_relu_data(
+        Tensor::rnn_relu_data(
             data,
             batch_sizes,
             hx,
@@ -14663,7 +14715,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn rnn_tanh<T: Borrow<Tensor>>(
+    pub fn f_rnn_tanh<T: Borrow<Tensor>>(
         &self,
         hx: &Tensor,
         params: &[T],
@@ -14674,7 +14726,7 @@ impl Tensor {
         bidirectional: bool,
         batch_first: bool,
     ) -> (Tensor, Tensor) {
-        self.f_rnn_tanh(
+        self.rnn_tanh(
             hx,
             params,
             has_biases,
@@ -14687,7 +14739,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn rnn_tanh_cell<T: Borrow<Tensor>>(
+    pub fn f_rnn_tanh_cell<T: Borrow<Tensor>>(
         &self,
         hx: &Tensor,
         w_ih: &Tensor,
@@ -14695,10 +14747,10 @@ impl Tensor {
         b_ih: Option<T>,
         b_hh: Option<T>,
     ) -> Tensor {
-        self.f_rnn_tanh_cell(hx, w_ih, w_hh, b_ih, b_hh).unwrap()
+        self.rnn_tanh_cell(hx, w_ih, w_hh, b_ih, b_hh).unwrap()
     }
 
-    pub fn rnn_tanh_data<T: Borrow<Tensor>>(
+    pub fn f_rnn_tanh_data<T: Borrow<Tensor>>(
         data: &Tensor,
         batch_sizes: &Tensor,
         hx: &Tensor,
@@ -14709,7 +14761,7 @@ impl Tensor {
         train: bool,
         bidirectional: bool,
     ) -> (Tensor, Tensor) {
-        Tensor::f_rnn_tanh_data(
+        Tensor::rnn_tanh_data(
             data,
             batch_sizes,
             hx,
@@ -14723,83 +14775,83 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn roll(&self, shifts: impl IntList, dims: impl IntList) -> Tensor {
-        self.f_roll(shifts, dims).unwrap()
+    pub fn f_roll(&self, shifts: impl IntList, dims: impl IntList) -> Tensor {
+        self.roll(shifts, dims).unwrap()
     }
 
-    pub fn roll_out(&self, out: &Tensor, shifts: impl IntList, dims: impl IntList) -> Tensor {
-        self.f_roll_out(out, shifts, dims).unwrap()
+    pub fn f_roll_out(&self, out: &Tensor, shifts: impl IntList, dims: impl IntList) -> Tensor {
+        self.roll_out(out, shifts, dims).unwrap()
     }
 
-    pub fn rot90(&self, k: i64, dims: impl IntList) -> Tensor {
-        self.f_rot90(k, dims).unwrap()
+    pub fn f_rot90(&self, k: i64, dims: impl IntList) -> Tensor {
+        self.rot90(k, dims).unwrap()
     }
 
-    pub fn rot90_out(&self, out: &Tensor, k: i64, dims: impl IntList) -> Tensor {
-        self.f_rot90_out(out, k, dims).unwrap()
+    pub fn f_rot90_out(&self, out: &Tensor, k: i64, dims: impl IntList) -> Tensor {
+        self.rot90_out(out, k, dims).unwrap()
     }
 
-    pub fn round(&self) -> Tensor {
-        self.f_round().unwrap()
+    pub fn f_round(&self) -> Tensor {
+        self.round().unwrap()
     }
 
-    pub fn round_(&mut self) -> Tensor {
-        self.f_round_().unwrap()
+    pub fn f_round_(&mut self) -> Tensor {
+        self.round_().unwrap()
     }
 
-    pub fn round_decimals(&self, decimals: i64) -> Tensor {
-        self.f_round_decimals(decimals).unwrap()
+    pub fn f_round_decimals(&self, decimals: i64) -> Tensor {
+        self.round_decimals(decimals).unwrap()
     }
 
-    pub fn round_decimals_(&mut self, decimals: i64) -> Tensor {
-        self.f_round_decimals_(decimals).unwrap()
+    pub fn f_round_decimals_(&mut self, decimals: i64) -> Tensor {
+        self.round_decimals_(decimals).unwrap()
     }
 
-    pub fn round_decimals_out(&self, out: &Tensor, decimals: i64) -> Tensor {
-        self.f_round_decimals_out(out, decimals).unwrap()
+    pub fn f_round_decimals_out(&self, out: &Tensor, decimals: i64) -> Tensor {
+        self.round_decimals_out(out, decimals).unwrap()
     }
 
-    pub fn round_out(&self, out: &Tensor) -> Tensor {
-        self.f_round_out(out).unwrap()
+    pub fn f_round_out(&self, out: &Tensor) -> Tensor {
+        self.round_out(out).unwrap()
     }
 
-    pub fn row_indices(&self) -> Tensor {
-        self.f_row_indices().unwrap()
+    pub fn f_row_indices(&self) -> Tensor {
+        self.row_indices().unwrap()
     }
 
-    pub fn row_indices_copy(&self) -> Tensor {
-        self.f_row_indices_copy().unwrap()
+    pub fn f_row_indices_copy(&self) -> Tensor {
+        self.row_indices_copy().unwrap()
     }
 
-    pub fn row_indices_copy_out(&self, out: &Tensor) -> Tensor {
-        self.f_row_indices_copy_out(out).unwrap()
+    pub fn f_row_indices_copy_out(&self, out: &Tensor) -> Tensor {
+        self.row_indices_copy_out(out).unwrap()
     }
 
-    pub fn row_stack<T: Borrow<Tensor>>(tensors: &[T]) -> Tensor {
-        Tensor::f_row_stack(tensors).unwrap()
+    pub fn f_row_stack<T: Borrow<Tensor>>(tensors: &[T]) -> Tensor {
+        Tensor::row_stack(tensors).unwrap()
     }
 
-    pub fn row_stack_out<T: Borrow<Tensor>>(out: &Tensor, tensors: &[T]) -> Tensor {
-        Tensor::f_row_stack_out(out, tensors).unwrap()
+    pub fn f_row_stack_out<T: Borrow<Tensor>>(out: &Tensor, tensors: &[T]) -> Tensor {
+        Tensor::row_stack_out(out, tensors).unwrap()
     }
 
-    pub fn rrelu(&self, training: bool) -> Tensor {
-        self.f_rrelu(training).unwrap()
+    pub fn f_rrelu(&self, training: bool) -> Tensor {
+        self.rrelu(training).unwrap()
     }
 
-    pub fn rrelu_(&mut self, training: bool) -> Tensor {
-        self.f_rrelu_(training).unwrap()
+    pub fn f_rrelu_(&mut self, training: bool) -> Tensor {
+        self.rrelu_(training).unwrap()
     }
 
-    pub fn rrelu_with_noise(&self, noise: &Tensor, training: bool) -> Tensor {
-        self.f_rrelu_with_noise(noise, training).unwrap()
+    pub fn f_rrelu_with_noise(&self, noise: &Tensor, training: bool) -> Tensor {
+        self.rrelu_with_noise(noise, training).unwrap()
     }
 
-    pub fn rrelu_with_noise_(&mut self, noise: &Tensor, training: bool) -> Tensor {
-        self.f_rrelu_with_noise_(noise, training).unwrap()
+    pub fn f_rrelu_with_noise_(&mut self, noise: &Tensor, training: bool) -> Tensor {
+        self.rrelu_with_noise_(noise, training).unwrap()
     }
 
-    pub fn rrelu_with_noise_backward<S: Into<Scalar>>(
+    pub fn f_rrelu_with_noise_backward<S: Into<Scalar>>(
         &self,
         grad_output: &Tensor,
         noise: &Tensor,
@@ -14808,11 +14860,11 @@ impl Tensor {
         training: bool,
         self_is_result: bool,
     ) -> Tensor {
-        self.f_rrelu_with_noise_backward(grad_output, noise, lower, upper, training, self_is_result)
+        self.rrelu_with_noise_backward(grad_output, noise, lower, upper, training, self_is_result)
             .unwrap()
     }
 
-    pub fn rrelu_with_noise_backward_out<S: Into<Scalar>>(
+    pub fn f_rrelu_with_noise_backward_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         grad_output: &Tensor,
@@ -14822,7 +14874,7 @@ impl Tensor {
         training: bool,
         self_is_result: bool,
     ) -> Tensor {
-        self.f_rrelu_with_noise_backward_out(
+        self.rrelu_with_noise_backward_out(
             out,
             grad_output,
             noise,
@@ -14834,47 +14886,47 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn rrelu_with_noise_out(&self, out: &Tensor, noise: &Tensor, training: bool) -> Tensor {
-        self.f_rrelu_with_noise_out(out, noise, training).unwrap()
+    pub fn f_rrelu_with_noise_out(&self, out: &Tensor, noise: &Tensor, training: bool) -> Tensor {
+        self.rrelu_with_noise_out(out, noise, training).unwrap()
     }
 
-    pub fn rsqrt(&self) -> Tensor {
-        self.f_rsqrt().unwrap()
+    pub fn f_rsqrt(&self) -> Tensor {
+        self.rsqrt().unwrap()
     }
 
-    pub fn rsqrt_(&mut self) -> Tensor {
-        self.f_rsqrt_().unwrap()
+    pub fn f_rsqrt_(&mut self) -> Tensor {
+        self.rsqrt_().unwrap()
     }
 
-    pub fn rsqrt_out(&self, out: &Tensor) -> Tensor {
-        self.f_rsqrt_out(out).unwrap()
+    pub fn f_rsqrt_out(&self, out: &Tensor) -> Tensor {
+        self.rsqrt_out(out).unwrap()
     }
 
-    pub fn rsub(&self, other: &Tensor) -> Tensor {
-        self.f_rsub(other).unwrap()
+    pub fn f_rsub(&self, other: &Tensor) -> Tensor {
+        self.rsub(other).unwrap()
     }
 
-    pub fn rsub_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_rsub_scalar(other).unwrap()
+    pub fn f_rsub_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.rsub_scalar(other).unwrap()
     }
 
-    pub fn rsub_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
-        self.f_rsub_scalar_out(out, other).unwrap()
+    pub fn f_rsub_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
+        self.rsub_scalar_out(out, other).unwrap()
     }
 
-    pub fn rsub_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_rsub_tensor_out(out, other).unwrap()
+    pub fn f_rsub_tensor_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.rsub_tensor_out(out, other).unwrap()
     }
 
-    pub fn scalar_tensor<S: Into<Scalar>>(s: S, options: (Kind, Device)) -> Tensor {
-        Tensor::f_scalar_tensor(s, options).unwrap()
+    pub fn f_scalar_tensor<S: Into<Scalar>>(s: S, options: (Kind, Device)) -> Tensor {
+        Tensor::scalar_tensor(s, options).unwrap()
     }
 
-    pub fn scalar_tensor_out<S: Into<Scalar>>(out: &Tensor, s: S) -> Tensor {
-        Tensor::f_scalar_tensor_out(out, s).unwrap()
+    pub fn f_scalar_tensor_out<S: Into<Scalar>>(out: &Tensor, s: S) -> Tensor {
+        Tensor::scalar_tensor_out(out, s).unwrap()
     }
 
-    pub fn scaled_dot_product_attention<T: Borrow<Tensor>>(
+    pub fn f_scaled_dot_product_attention<T: Borrow<Tensor>>(
         query: &Tensor,
         key: &Tensor,
         value: &Tensor,
@@ -14882,45 +14934,51 @@ impl Tensor {
         dropout_p: f64,
         is_causal: bool,
     ) -> Tensor {
-        Tensor::f_scaled_dot_product_attention(query, key, value, attn_mask, dropout_p, is_causal)
+        Tensor::scaled_dot_product_attention(query, key, value, attn_mask, dropout_p, is_causal)
             .unwrap()
     }
 
-    pub fn scatter(&self, dim: i64, index: &Tensor, src: &Tensor) -> Tensor {
-        self.f_scatter(dim, index, src).unwrap()
+    pub fn f_scatter(&self, dim: i64, index: &Tensor, src: &Tensor) -> Tensor {
+        self.scatter(dim, index, src).unwrap()
     }
 
-    pub fn scatter_(&mut self, dim: i64, index: &Tensor, src: &Tensor) -> Tensor {
-        self.f_scatter_(dim, index, src).unwrap()
+    pub fn f_scatter_(&mut self, dim: i64, index: &Tensor, src: &Tensor) -> Tensor {
+        self.scatter_(dim, index, src).unwrap()
     }
 
-    pub fn scatter_add(&self, dim: i64, index: &Tensor, src: &Tensor) -> Tensor {
-        self.f_scatter_add(dim, index, src).unwrap()
+    pub fn f_scatter_add(&self, dim: i64, index: &Tensor, src: &Tensor) -> Tensor {
+        self.scatter_add(dim, index, src).unwrap()
     }
 
-    pub fn scatter_add_(&mut self, dim: i64, index: &Tensor, src: &Tensor) -> Tensor {
-        self.f_scatter_add_(dim, index, src).unwrap()
+    pub fn f_scatter_add_(&mut self, dim: i64, index: &Tensor, src: &Tensor) -> Tensor {
+        self.scatter_add_(dim, index, src).unwrap()
     }
 
-    pub fn scatter_add_out(&self, out: &Tensor, dim: i64, index: &Tensor, src: &Tensor) -> Tensor {
-        self.f_scatter_add_out(out, dim, index, src).unwrap()
+    pub fn f_scatter_add_out(
+        &self,
+        out: &Tensor,
+        dim: i64,
+        index: &Tensor,
+        src: &Tensor,
+    ) -> Tensor {
+        self.scatter_add_out(out, dim, index, src).unwrap()
     }
 
-    pub fn scatter_reduce(&self, dim: i64, index: &Tensor, src: &Tensor, reduce: &str) -> Tensor {
-        self.f_scatter_reduce(dim, index, src, reduce).unwrap()
+    pub fn f_scatter_reduce(&self, dim: i64, index: &Tensor, src: &Tensor, reduce: &str) -> Tensor {
+        self.scatter_reduce(dim, index, src, reduce).unwrap()
     }
 
-    pub fn scatter_reduce_(
+    pub fn f_scatter_reduce_(
         &mut self,
         dim: i64,
         index: &Tensor,
         src: &Tensor,
         reduce: &str,
     ) -> Tensor {
-        self.f_scatter_reduce_(dim, index, src, reduce).unwrap()
+        self.scatter_reduce_(dim, index, src, reduce).unwrap()
     }
 
-    pub fn scatter_reduce_out(
+    pub fn f_scatter_reduce_out(
         &self,
         out: &Tensor,
         dim: i64,
@@ -14928,57 +14986,63 @@ impl Tensor {
         src: &Tensor,
         reduce: &str,
     ) -> Tensor {
-        self.f_scatter_reduce_out(out, dim, index, src, reduce).unwrap()
+        self.scatter_reduce_out(out, dim, index, src, reduce).unwrap()
     }
 
-    pub fn scatter_src_out(&self, out: &Tensor, dim: i64, index: &Tensor, src: &Tensor) -> Tensor {
-        self.f_scatter_src_out(out, dim, index, src).unwrap()
+    pub fn f_scatter_src_out(
+        &self,
+        out: &Tensor,
+        dim: i64,
+        index: &Tensor,
+        src: &Tensor,
+    ) -> Tensor {
+        self.scatter_src_out(out, dim, index, src).unwrap()
     }
 
-    pub fn scatter_value<S: Into<Scalar>>(&self, dim: i64, index: &Tensor, value: S) -> Tensor {
-        self.f_scatter_value(dim, index, value).unwrap()
+    pub fn f_scatter_value<S: Into<Scalar>>(&self, dim: i64, index: &Tensor, value: S) -> Tensor {
+        self.scatter_value(dim, index, value).unwrap()
     }
 
-    pub fn scatter_value_<S: Into<Scalar>>(
+    pub fn f_scatter_value_<S: Into<Scalar>>(
         &mut self,
         dim: i64,
         index: &Tensor,
         value: S,
     ) -> Tensor {
-        self.f_scatter_value_(dim, index, value).unwrap()
+        self.scatter_value_(dim, index, value).unwrap()
     }
 
-    pub fn scatter_value_out<S: Into<Scalar>>(
+    pub fn f_scatter_value_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         dim: i64,
         index: &Tensor,
         value: S,
     ) -> Tensor {
-        self.f_scatter_value_out(out, dim, index, value).unwrap()
+        self.scatter_value_out(out, dim, index, value).unwrap()
     }
 
-    pub fn scatter_value_reduce<S: Into<Scalar>>(
+    pub fn f_scatter_value_reduce<S: Into<Scalar>>(
         &self,
         dim: i64,
         index: &Tensor,
         value: S,
         reduce: &str,
     ) -> Tensor {
-        self.f_scatter_value_reduce(dim, index, value, reduce).unwrap()
+        self.scatter_value_reduce(dim, index, value, reduce).unwrap()
     }
 
-    pub fn scatter_value_reduce_<S: Into<Scalar>>(
+    pub fn f_scatter_value_reduce_<S: Into<Scalar>>(
         &mut self,
         dim: i64,
         index: &Tensor,
         value: S,
         reduce: &str,
     ) -> Tensor {
-        self.f_scatter_value_reduce_(dim, index, value, reduce).unwrap()
+        self.scatter_value_reduce_(dim, index, value, reduce).unwrap()
     }
 
-    pub fn scatter_value_reduce_out<S: Into<Scalar>>(
+    pub fn f_scatter_value_reduce_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         dim: i64,
@@ -14986,10 +15050,10 @@ impl Tensor {
         value: S,
         reduce: &str,
     ) -> Tensor {
-        self.f_scatter_value_reduce_out(out, dim, index, value, reduce).unwrap()
+        self.scatter_value_reduce_out(out, dim, index, value, reduce).unwrap()
     }
 
-    pub fn searchsorted<T: Borrow<Tensor>>(
+    pub fn f_searchsorted<T: Borrow<Tensor>>(
         &self,
         sorted_sequence: &Tensor,
         out_int32: bool,
@@ -14997,10 +15061,10 @@ impl Tensor {
         side: &str,
         sorter: Option<T>,
     ) -> Tensor {
-        self.f_searchsorted(sorted_sequence, out_int32, right, side, sorter).unwrap()
+        self.searchsorted(sorted_sequence, out_int32, right, side, sorter).unwrap()
     }
 
-    pub fn searchsorted_scalar<T: Borrow<Tensor>, S: Into<Scalar>>(
+    pub fn f_searchsorted_scalar<T: Borrow<Tensor>, S: Into<Scalar>>(
         sorted_sequence: &Tensor,
         self_scalar: S,
         out_int32: bool,
@@ -15008,11 +15072,11 @@ impl Tensor {
         side: &str,
         sorter: Option<T>,
     ) -> Tensor {
-        Tensor::f_searchsorted_scalar(sorted_sequence, self_scalar, out_int32, right, side, sorter)
+        Tensor::searchsorted_scalar(sorted_sequence, self_scalar, out_int32, right, side, sorter)
             .unwrap()
     }
 
-    pub fn searchsorted_scalar_out<T: Borrow<Tensor>, S: Into<Scalar>>(
+    pub fn f_searchsorted_scalar_out<T: Borrow<Tensor>, S: Into<Scalar>>(
         out: &Tensor,
         sorted_sequence: &Tensor,
         self_scalar: S,
@@ -15021,7 +15085,7 @@ impl Tensor {
         side: &str,
         sorter: Option<T>,
     ) -> Tensor {
-        Tensor::f_searchsorted_scalar_out(
+        Tensor::searchsorted_scalar_out(
             out,
             sorted_sequence,
             self_scalar,
@@ -15033,7 +15097,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn searchsorted_tensor_out<T: Borrow<Tensor>>(
+    pub fn f_searchsorted_tensor_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         sorted_sequence: &Tensor,
@@ -15042,11 +15106,10 @@ impl Tensor {
         side: &str,
         sorter: Option<T>,
     ) -> Tensor {
-        self.f_searchsorted_tensor_out(out, sorted_sequence, out_int32, right, side, sorter)
-            .unwrap()
+        self.searchsorted_tensor_out(out, sorted_sequence, out_int32, right, side, sorter).unwrap()
     }
 
-    pub fn segment_reduce<T: Borrow<Tensor>, S: Into<Scalar>>(
+    pub fn f_segment_reduce<T: Borrow<Tensor>, S: Into<Scalar>>(
         data: &Tensor,
         reduce: &str,
         lengths: Option<T>,
@@ -15056,11 +15119,11 @@ impl Tensor {
         unsafe_: bool,
         initial: S,
     ) -> Tensor {
-        Tensor::f_segment_reduce(data, reduce, lengths, indices, offsets, axis, unsafe_, initial)
+        Tensor::segment_reduce(data, reduce, lengths, indices, offsets, axis, unsafe_, initial)
             .unwrap()
     }
 
-    pub fn segment_reduce_out<T: Borrow<Tensor>, S: Into<Scalar>>(
+    pub fn f_segment_reduce_out<T: Borrow<Tensor>, S: Into<Scalar>>(
         out: &Tensor,
         data: &Tensor,
         reduce: &str,
@@ -15071,224 +15134,224 @@ impl Tensor {
         unsafe_: bool,
         initial: S,
     ) -> Tensor {
-        Tensor::f_segment_reduce_out(
+        Tensor::segment_reduce_out(
             out, data, reduce, lengths, indices, offsets, axis, unsafe_, initial,
         )
         .unwrap()
     }
 
-    pub fn select(&self, dim: i64, index: i64) -> Tensor {
-        self.f_select(dim, index).unwrap()
+    pub fn f_select(&self, dim: i64, index: i64) -> Tensor {
+        self.select(dim, index).unwrap()
     }
 
-    pub fn select_backward(
+    pub fn f_select_backward(
         grad_output: &Tensor,
         input_sizes: impl IntList,
         dim: i64,
         index: i64,
     ) -> Tensor {
-        Tensor::f_select_backward(grad_output, input_sizes, dim, index).unwrap()
+        Tensor::select_backward(grad_output, input_sizes, dim, index).unwrap()
     }
 
-    pub fn select_backward_out(
+    pub fn f_select_backward_out(
         out: &Tensor,
         grad_output: &Tensor,
         input_sizes: impl IntList,
         dim: i64,
         index: i64,
     ) -> Tensor {
-        Tensor::f_select_backward_out(out, grad_output, input_sizes, dim, index).unwrap()
+        Tensor::select_backward_out(out, grad_output, input_sizes, dim, index).unwrap()
     }
 
-    pub fn select_copy(&self, dim: i64, index: i64) -> Tensor {
-        self.f_select_copy(dim, index).unwrap()
+    pub fn f_select_copy(&self, dim: i64, index: i64) -> Tensor {
+        self.select_copy(dim, index).unwrap()
     }
 
-    pub fn select_copy_int_out(&self, out: &Tensor, dim: i64, index: i64) -> Tensor {
-        self.f_select_copy_int_out(out, dim, index).unwrap()
+    pub fn f_select_copy_int_out(&self, out: &Tensor, dim: i64, index: i64) -> Tensor {
+        self.select_copy_int_out(out, dim, index).unwrap()
     }
 
-    pub fn select_scatter(&self, src: &Tensor, dim: i64, index: i64) -> Tensor {
-        self.f_select_scatter(src, dim, index).unwrap()
+    pub fn f_select_scatter(&self, src: &Tensor, dim: i64, index: i64) -> Tensor {
+        self.select_scatter(src, dim, index).unwrap()
     }
 
-    pub fn select_scatter_out(&self, out: &Tensor, src: &Tensor, dim: i64, index: i64) -> Tensor {
-        self.f_select_scatter_out(out, src, dim, index).unwrap()
+    pub fn f_select_scatter_out(&self, out: &Tensor, src: &Tensor, dim: i64, index: i64) -> Tensor {
+        self.select_scatter_out(out, src, dim, index).unwrap()
     }
 
-    pub fn selu(&self) -> Tensor {
-        self.f_selu().unwrap()
+    pub fn f_selu(&self) -> Tensor {
+        self.selu().unwrap()
     }
 
-    pub fn selu_(&mut self) -> Tensor {
-        self.f_selu_().unwrap()
+    pub fn f_selu_(&mut self) -> Tensor {
+        self.selu_().unwrap()
     }
 
-    pub fn set(&self) -> Tensor {
-        self.f_set().unwrap()
+    pub fn f_set(&self) -> Tensor {
+        self.set().unwrap()
     }
 
-    pub fn set_(&mut self) -> Tensor {
-        self.f_set_().unwrap()
+    pub fn f_set_(&mut self) -> Tensor {
+        self.set_().unwrap()
     }
 
-    pub fn set_data(&mut self, new_data: &Tensor) {
-        self.f_set_data(new_data).unwrap()
+    pub fn f_set_data(&mut self, new_data: &Tensor) {
+        self.set_data(new_data).unwrap()
     }
 
-    pub fn set_out(&self, out: &Tensor) -> Tensor {
-        self.f_set_out(out).unwrap()
+    pub fn f_set_out(&self, out: &Tensor) -> Tensor {
+        self.set_out(out).unwrap()
     }
 
-    pub fn set_requires_grad(&self, r: bool) -> Tensor {
-        self.f_set_requires_grad(r).unwrap()
+    pub fn f_set_requires_grad(&self, r: bool) -> Tensor {
+        self.set_requires_grad(r).unwrap()
     }
 
-    pub fn set_source_tensor(&self, source: &Tensor) -> Tensor {
-        self.f_set_source_tensor(source).unwrap()
+    pub fn f_set_source_tensor(&self, source: &Tensor) -> Tensor {
+        self.set_source_tensor(source).unwrap()
     }
 
-    pub fn set_source_tensor_(&mut self, source: &Tensor) -> Tensor {
-        self.f_set_source_tensor_(source).unwrap()
+    pub fn f_set_source_tensor_(&mut self, source: &Tensor) -> Tensor {
+        self.set_source_tensor_(source).unwrap()
     }
 
-    pub fn set_source_tensor_out(&self, out: &Tensor, source: &Tensor) -> Tensor {
-        self.f_set_source_tensor_out(out, source).unwrap()
+    pub fn f_set_source_tensor_out(&self, out: &Tensor, source: &Tensor) -> Tensor {
+        self.set_source_tensor_out(out, source).unwrap()
     }
 
-    pub fn set_source_tensor_storage_offset_(
+    pub fn f_set_source_tensor_storage_offset_(
         &mut self,
         source: &Tensor,
         storage_offset: i64,
         size: impl IntList,
         stride: impl IntList,
     ) -> Tensor {
-        self.f_set_source_tensor_storage_offset_(source, storage_offset, size, stride).unwrap()
+        self.set_source_tensor_storage_offset_(source, storage_offset, size, stride).unwrap()
     }
 
-    pub fn sgn(&self) -> Tensor {
-        self.f_sgn().unwrap()
+    pub fn f_sgn(&self) -> Tensor {
+        self.sgn().unwrap()
     }
 
-    pub fn sgn_(&mut self) -> Tensor {
-        self.f_sgn_().unwrap()
+    pub fn f_sgn_(&mut self) -> Tensor {
+        self.sgn_().unwrap()
     }
 
-    pub fn sgn_out(&self, out: &Tensor) -> Tensor {
-        self.f_sgn_out(out).unwrap()
+    pub fn f_sgn_out(&self, out: &Tensor) -> Tensor {
+        self.sgn_out(out).unwrap()
     }
 
-    pub fn sigmoid(&self) -> Tensor {
-        self.f_sigmoid().unwrap()
+    pub fn f_sigmoid(&self) -> Tensor {
+        self.sigmoid().unwrap()
     }
 
-    pub fn sigmoid_(&mut self) -> Tensor {
-        self.f_sigmoid_().unwrap()
+    pub fn f_sigmoid_(&mut self) -> Tensor {
+        self.sigmoid_().unwrap()
     }
 
-    pub fn sigmoid_backward(grad_output: &Tensor, output: &Tensor) -> Tensor {
-        Tensor::f_sigmoid_backward(grad_output, output).unwrap()
+    pub fn f_sigmoid_backward(grad_output: &Tensor, output: &Tensor) -> Tensor {
+        Tensor::sigmoid_backward(grad_output, output).unwrap()
     }
 
-    pub fn sigmoid_backward_grad_input(
+    pub fn f_sigmoid_backward_grad_input(
         grad_input: &Tensor,
         grad_output: &Tensor,
         output: &Tensor,
     ) -> Tensor {
-        Tensor::f_sigmoid_backward_grad_input(grad_input, grad_output, output).unwrap()
+        Tensor::sigmoid_backward_grad_input(grad_input, grad_output, output).unwrap()
     }
 
-    pub fn sigmoid_out(&self, out: &Tensor) -> Tensor {
-        self.f_sigmoid_out(out).unwrap()
+    pub fn f_sigmoid_out(&self, out: &Tensor) -> Tensor {
+        self.sigmoid_out(out).unwrap()
     }
 
-    pub fn sign(&self) -> Tensor {
-        self.f_sign().unwrap()
+    pub fn f_sign(&self) -> Tensor {
+        self.sign().unwrap()
     }
 
-    pub fn sign_(&mut self) -> Tensor {
-        self.f_sign_().unwrap()
+    pub fn f_sign_(&mut self) -> Tensor {
+        self.sign_().unwrap()
     }
 
-    pub fn sign_out(&self, out: &Tensor) -> Tensor {
-        self.f_sign_out(out).unwrap()
+    pub fn f_sign_out(&self, out: &Tensor) -> Tensor {
+        self.sign_out(out).unwrap()
     }
 
-    pub fn signbit(&self) -> Tensor {
-        self.f_signbit().unwrap()
+    pub fn f_signbit(&self) -> Tensor {
+        self.signbit().unwrap()
     }
 
-    pub fn signbit_out(&self, out: &Tensor) -> Tensor {
-        self.f_signbit_out(out).unwrap()
+    pub fn f_signbit_out(&self, out: &Tensor) -> Tensor {
+        self.signbit_out(out).unwrap()
     }
 
-    pub fn silu(&self) -> Tensor {
-        self.f_silu().unwrap()
+    pub fn f_silu(&self) -> Tensor {
+        self.silu().unwrap()
     }
 
-    pub fn silu_(&mut self) -> Tensor {
-        self.f_silu_().unwrap()
+    pub fn f_silu_(&mut self) -> Tensor {
+        self.silu_().unwrap()
     }
 
-    pub fn silu_backward(&self, grad_output: &Tensor) -> Tensor {
-        self.f_silu_backward(grad_output).unwrap()
+    pub fn f_silu_backward(&self, grad_output: &Tensor) -> Tensor {
+        self.silu_backward(grad_output).unwrap()
     }
 
-    pub fn silu_backward_grad_input(&self, grad_input: &Tensor, grad_output: &Tensor) -> Tensor {
-        self.f_silu_backward_grad_input(grad_input, grad_output).unwrap()
+    pub fn f_silu_backward_grad_input(&self, grad_input: &Tensor, grad_output: &Tensor) -> Tensor {
+        self.silu_backward_grad_input(grad_input, grad_output).unwrap()
     }
 
-    pub fn silu_out(&self, out: &Tensor) -> Tensor {
-        self.f_silu_out(out).unwrap()
+    pub fn f_silu_out(&self, out: &Tensor) -> Tensor {
+        self.silu_out(out).unwrap()
     }
 
-    pub fn sin(&self) -> Tensor {
-        self.f_sin().unwrap()
+    pub fn f_sin(&self) -> Tensor {
+        self.sin().unwrap()
     }
 
-    pub fn sin_(&mut self) -> Tensor {
-        self.f_sin_().unwrap()
+    pub fn f_sin_(&mut self) -> Tensor {
+        self.sin_().unwrap()
     }
 
-    pub fn sin_out(&self, out: &Tensor) -> Tensor {
-        self.f_sin_out(out).unwrap()
+    pub fn f_sin_out(&self, out: &Tensor) -> Tensor {
+        self.sin_out(out).unwrap()
     }
 
-    pub fn sinc(&self) -> Tensor {
-        self.f_sinc().unwrap()
+    pub fn f_sinc(&self) -> Tensor {
+        self.sinc().unwrap()
     }
 
-    pub fn sinc_(&mut self) -> Tensor {
-        self.f_sinc_().unwrap()
+    pub fn f_sinc_(&mut self) -> Tensor {
+        self.sinc_().unwrap()
     }
 
-    pub fn sinc_out(&self, out: &Tensor) -> Tensor {
-        self.f_sinc_out(out).unwrap()
+    pub fn f_sinc_out(&self, out: &Tensor) -> Tensor {
+        self.sinc_out(out).unwrap()
     }
 
-    pub fn sinh(&self) -> Tensor {
-        self.f_sinh().unwrap()
+    pub fn f_sinh(&self) -> Tensor {
+        self.sinh().unwrap()
     }
 
-    pub fn sinh_(&mut self) -> Tensor {
-        self.f_sinh_().unwrap()
+    pub fn f_sinh_(&mut self) -> Tensor {
+        self.sinh_().unwrap()
     }
 
-    pub fn sinh_out(&self, out: &Tensor) -> Tensor {
-        self.f_sinh_out(out).unwrap()
+    pub fn f_sinh_out(&self, out: &Tensor) -> Tensor {
+        self.sinh_out(out).unwrap()
     }
 
-    pub fn slice(
+    pub fn f_slice(
         &self,
         dim: i64,
         start: impl Into<Option<i64>>,
         end: impl Into<Option<i64>>,
         step: i64,
     ) -> Tensor {
-        self.f_slice(dim, start, end, step).unwrap()
+        self.slice(dim, start, end, step).unwrap()
     }
 
-    pub fn slice_backward(
+    pub fn f_slice_backward(
         grad_output: &Tensor,
         input_sizes: impl IntList,
         dim: i64,
@@ -15296,10 +15359,10 @@ impl Tensor {
         end: i64,
         step: i64,
     ) -> Tensor {
-        Tensor::f_slice_backward(grad_output, input_sizes, dim, start, end, step).unwrap()
+        Tensor::slice_backward(grad_output, input_sizes, dim, start, end, step).unwrap()
     }
 
-    pub fn slice_backward_out(
+    pub fn f_slice_backward_out(
         out: &Tensor,
         grad_output: &Tensor,
         input_sizes: impl IntList,
@@ -15308,20 +15371,20 @@ impl Tensor {
         end: i64,
         step: i64,
     ) -> Tensor {
-        Tensor::f_slice_backward_out(out, grad_output, input_sizes, dim, start, end, step).unwrap()
+        Tensor::slice_backward_out(out, grad_output, input_sizes, dim, start, end, step).unwrap()
     }
 
-    pub fn slice_copy(
+    pub fn f_slice_copy(
         &self,
         dim: i64,
         start: impl Into<Option<i64>>,
         end: impl Into<Option<i64>>,
         step: i64,
     ) -> Tensor {
-        self.f_slice_copy(dim, start, end, step).unwrap()
+        self.slice_copy(dim, start, end, step).unwrap()
     }
 
-    pub fn slice_copy_tensor_out(
+    pub fn f_slice_copy_tensor_out(
         &self,
         out: &Tensor,
         dim: i64,
@@ -15329,10 +15392,10 @@ impl Tensor {
         end: impl Into<Option<i64>>,
         step: i64,
     ) -> Tensor {
-        self.f_slice_copy_tensor_out(out, dim, start, end, step).unwrap()
+        self.slice_copy_tensor_out(out, dim, start, end, step).unwrap()
     }
 
-    pub fn slice_scatter(
+    pub fn f_slice_scatter(
         &self,
         src: &Tensor,
         dim: i64,
@@ -15340,10 +15403,10 @@ impl Tensor {
         end: impl Into<Option<i64>>,
         step: i64,
     ) -> Tensor {
-        self.f_slice_scatter(src, dim, start, end, step).unwrap()
+        self.slice_scatter(src, dim, start, end, step).unwrap()
     }
 
-    pub fn slice_scatter_out(
+    pub fn f_slice_scatter_out(
         &self,
         out: &Tensor,
         src: &Tensor,
@@ -15352,18 +15415,18 @@ impl Tensor {
         end: impl Into<Option<i64>>,
         step: i64,
     ) -> Tensor {
-        self.f_slice_scatter_out(out, src, dim, start, end, step).unwrap()
+        self.slice_scatter_out(out, src, dim, start, end, step).unwrap()
     }
 
-    pub fn slogdet(&self) -> (Tensor, Tensor) {
-        self.f_slogdet().unwrap()
+    pub fn f_slogdet(&self) -> (Tensor, Tensor) {
+        self.slogdet().unwrap()
     }
 
-    pub fn slogdet_out(&self, sign: &Tensor, logabsdet: &Tensor) -> (Tensor, Tensor) {
-        self.f_slogdet_out(sign, logabsdet).unwrap()
+    pub fn f_slogdet_out(&self, sign: &Tensor, logabsdet: &Tensor) -> (Tensor, Tensor) {
+        self.slogdet_out(sign, logabsdet).unwrap()
     }
 
-    pub fn slow_conv3d<T: Borrow<Tensor>>(
+    pub fn f_slow_conv3d<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         kernel_size: impl IntList,
@@ -15371,10 +15434,10 @@ impl Tensor {
         stride: impl IntList,
         padding: impl IntList,
     ) -> Tensor {
-        self.f_slow_conv3d(weight, kernel_size, bias, stride, padding).unwrap()
+        self.slow_conv3d(weight, kernel_size, bias, stride, padding).unwrap()
     }
 
-    pub fn slow_conv3d_out<T: Borrow<Tensor>>(
+    pub fn f_slow_conv3d_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -15383,10 +15446,10 @@ impl Tensor {
         stride: impl IntList,
         padding: impl IntList,
     ) -> Tensor {
-        self.f_slow_conv3d_out(out, weight, kernel_size, bias, stride, padding).unwrap()
+        self.slow_conv3d_out(out, weight, kernel_size, bias, stride, padding).unwrap()
     }
 
-    pub fn slow_conv_dilated2d<T: Borrow<Tensor>>(
+    pub fn f_slow_conv_dilated2d<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         kernel_size: impl IntList,
@@ -15395,10 +15458,10 @@ impl Tensor {
         padding: impl IntList,
         dilation: impl IntList,
     ) -> Tensor {
-        self.f_slow_conv_dilated2d(weight, kernel_size, bias, stride, padding, dilation).unwrap()
+        self.slow_conv_dilated2d(weight, kernel_size, bias, stride, padding, dilation).unwrap()
     }
 
-    pub fn slow_conv_dilated2d_out<T: Borrow<Tensor>>(
+    pub fn f_slow_conv_dilated2d_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -15408,11 +15471,11 @@ impl Tensor {
         padding: impl IntList,
         dilation: impl IntList,
     ) -> Tensor {
-        self.f_slow_conv_dilated2d_out(out, weight, kernel_size, bias, stride, padding, dilation)
+        self.slow_conv_dilated2d_out(out, weight, kernel_size, bias, stride, padding, dilation)
             .unwrap()
     }
 
-    pub fn slow_conv_dilated3d<T: Borrow<Tensor>>(
+    pub fn f_slow_conv_dilated3d<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         kernel_size: impl IntList,
@@ -15421,10 +15484,10 @@ impl Tensor {
         padding: impl IntList,
         dilation: impl IntList,
     ) -> Tensor {
-        self.f_slow_conv_dilated3d(weight, kernel_size, bias, stride, padding, dilation).unwrap()
+        self.slow_conv_dilated3d(weight, kernel_size, bias, stride, padding, dilation).unwrap()
     }
 
-    pub fn slow_conv_dilated3d_out<T: Borrow<Tensor>>(
+    pub fn f_slow_conv_dilated3d_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -15434,11 +15497,11 @@ impl Tensor {
         padding: impl IntList,
         dilation: impl IntList,
     ) -> Tensor {
-        self.f_slow_conv_dilated3d_out(out, weight, kernel_size, bias, stride, padding, dilation)
+        self.slow_conv_dilated3d_out(out, weight, kernel_size, bias, stride, padding, dilation)
             .unwrap()
     }
 
-    pub fn slow_conv_transpose2d<T: Borrow<Tensor>>(
+    pub fn f_slow_conv_transpose2d<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         kernel_size: impl IntList,
@@ -15448,7 +15511,7 @@ impl Tensor {
         output_padding: impl IntList,
         dilation: impl IntList,
     ) -> Tensor {
-        self.f_slow_conv_transpose2d(
+        self.slow_conv_transpose2d(
             weight,
             kernel_size,
             bias,
@@ -15460,7 +15523,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn slow_conv_transpose2d_out<T: Borrow<Tensor>>(
+    pub fn f_slow_conv_transpose2d_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -15471,7 +15534,7 @@ impl Tensor {
         output_padding: impl IntList,
         dilation: impl IntList,
     ) -> Tensor {
-        self.f_slow_conv_transpose2d_out(
+        self.slow_conv_transpose2d_out(
             out,
             weight,
             kernel_size,
@@ -15484,7 +15547,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn slow_conv_transpose3d<T: Borrow<Tensor>>(
+    pub fn f_slow_conv_transpose3d<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,
         kernel_size: impl IntList,
@@ -15494,7 +15557,7 @@ impl Tensor {
         output_padding: impl IntList,
         dilation: impl IntList,
     ) -> Tensor {
-        self.f_slow_conv_transpose3d(
+        self.slow_conv_transpose3d(
             weight,
             kernel_size,
             bias,
@@ -15506,7 +15569,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn slow_conv_transpose3d_out<T: Borrow<Tensor>>(
+    pub fn f_slow_conv_transpose3d_out<T: Borrow<Tensor>>(
         &self,
         out: &Tensor,
         weight: &Tensor,
@@ -15517,7 +15580,7 @@ impl Tensor {
         output_padding: impl IntList,
         dilation: impl IntList,
     ) -> Tensor {
-        self.f_slow_conv_transpose3d_out(
+        self.slow_conv_transpose3d_out(
             out,
             weight,
             kernel_size,
@@ -15530,30 +15593,30 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn smm(&self, mat2: &Tensor) -> Tensor {
-        self.f_smm(mat2).unwrap()
+    pub fn f_smm(&self, mat2: &Tensor) -> Tensor {
+        self.smm(mat2).unwrap()
     }
 
-    pub fn smooth_l1_loss(
+    pub fn f_smooth_l1_loss(
         &self,
         target: &Tensor,
         reduction: crate::Reduction,
         beta: f64,
     ) -> Tensor {
-        self.f_smooth_l1_loss(target, reduction, beta).unwrap()
+        self.smooth_l1_loss(target, reduction, beta).unwrap()
     }
 
-    pub fn smooth_l1_loss_backward(
+    pub fn f_smooth_l1_loss_backward(
         &self,
         grad_output: &Tensor,
         target: &Tensor,
         reduction: crate::Reduction,
         beta: f64,
     ) -> Tensor {
-        self.f_smooth_l1_loss_backward(grad_output, target, reduction, beta).unwrap()
+        self.smooth_l1_loss_backward(grad_output, target, reduction, beta).unwrap()
     }
 
-    pub fn smooth_l1_loss_backward_grad_input(
+    pub fn f_smooth_l1_loss_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
@@ -15561,133 +15624,133 @@ impl Tensor {
         reduction: crate::Reduction,
         beta: f64,
     ) -> Tensor {
-        self.f_smooth_l1_loss_backward_grad_input(grad_input, grad_output, target, reduction, beta)
+        self.smooth_l1_loss_backward_grad_input(grad_input, grad_output, target, reduction, beta)
             .unwrap()
     }
 
-    pub fn smooth_l1_loss_out(
+    pub fn f_smooth_l1_loss_out(
         &self,
         out: &Tensor,
         target: &Tensor,
         reduction: crate::Reduction,
         beta: f64,
     ) -> Tensor {
-        self.f_smooth_l1_loss_out(out, target, reduction, beta).unwrap()
+        self.smooth_l1_loss_out(out, target, reduction, beta).unwrap()
     }
 
-    pub fn soft_margin_loss(&self, target: &Tensor, reduction: crate::Reduction) -> Tensor {
-        self.f_soft_margin_loss(target, reduction).unwrap()
+    pub fn f_soft_margin_loss(&self, target: &Tensor, reduction: crate::Reduction) -> Tensor {
+        self.soft_margin_loss(target, reduction).unwrap()
     }
 
-    pub fn soft_margin_loss_backward(
+    pub fn f_soft_margin_loss_backward(
         &self,
         grad_output: &Tensor,
         target: &Tensor,
         reduction: crate::Reduction,
     ) -> Tensor {
-        self.f_soft_margin_loss_backward(grad_output, target, reduction).unwrap()
+        self.soft_margin_loss_backward(grad_output, target, reduction).unwrap()
     }
 
-    pub fn soft_margin_loss_backward_grad_input(
+    pub fn f_soft_margin_loss_backward_grad_input(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
         target: &Tensor,
         reduction: crate::Reduction,
     ) -> Tensor {
-        self.f_soft_margin_loss_backward_grad_input(grad_input, grad_output, target, reduction)
+        self.soft_margin_loss_backward_grad_input(grad_input, grad_output, target, reduction)
             .unwrap()
     }
 
-    pub fn soft_margin_loss_out(
+    pub fn f_soft_margin_loss_out(
         &self,
         out: &Tensor,
         target: &Tensor,
         reduction: crate::Reduction,
     ) -> Tensor {
-        self.f_soft_margin_loss_out(out, target, reduction).unwrap()
+        self.soft_margin_loss_out(out, target, reduction).unwrap()
     }
 
-    pub fn softmax(&self, dim: i64, dtype: impl Into<Option<Kind>>) -> Tensor {
-        self.f_softmax(dim, dtype).unwrap()
+    pub fn f_softmax(&self, dim: i64, dtype: impl Into<Option<Kind>>) -> Tensor {
+        self.softmax(dim, dtype).unwrap()
     }
 
-    pub fn softmax_int_out(
+    pub fn f_softmax_int_out(
         &self,
         out: &Tensor,
         dim: i64,
         dtype: impl Into<Option<Kind>>,
     ) -> Tensor {
-        self.f_softmax_int_out(out, dim, dtype).unwrap()
+        self.softmax_int_out(out, dim, dtype).unwrap()
     }
 
-    pub fn softplus(&self) -> Tensor {
-        self.f_softplus().unwrap()
+    pub fn f_softplus(&self) -> Tensor {
+        self.softplus().unwrap()
     }
 
-    pub fn softplus_backward<S: Into<Scalar>>(
+    pub fn f_softplus_backward<S: Into<Scalar>>(
         &self,
         grad_output: &Tensor,
         beta: S,
         threshold: S,
     ) -> Tensor {
-        self.f_softplus_backward(grad_output, beta, threshold).unwrap()
+        self.softplus_backward(grad_output, beta, threshold).unwrap()
     }
 
-    pub fn softplus_backward_grad_input<S: Into<Scalar>>(
+    pub fn f_softplus_backward_grad_input<S: Into<Scalar>>(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
         beta: S,
         threshold: S,
     ) -> Tensor {
-        self.f_softplus_backward_grad_input(grad_input, grad_output, beta, threshold).unwrap()
+        self.softplus_backward_grad_input(grad_input, grad_output, beta, threshold).unwrap()
     }
 
-    pub fn softplus_out(&self, out: &Tensor) -> Tensor {
-        self.f_softplus_out(out).unwrap()
+    pub fn f_softplus_out(&self, out: &Tensor) -> Tensor {
+        self.softplus_out(out).unwrap()
     }
 
-    pub fn softshrink(&self) -> Tensor {
-        self.f_softshrink().unwrap()
+    pub fn f_softshrink(&self) -> Tensor {
+        self.softshrink().unwrap()
     }
 
-    pub fn softshrink_backward<S: Into<Scalar>>(&self, grad_output: &Tensor, lambd: S) -> Tensor {
-        self.f_softshrink_backward(grad_output, lambd).unwrap()
+    pub fn f_softshrink_backward<S: Into<Scalar>>(&self, grad_output: &Tensor, lambd: S) -> Tensor {
+        self.softshrink_backward(grad_output, lambd).unwrap()
     }
 
-    pub fn softshrink_backward_grad_input<S: Into<Scalar>>(
+    pub fn f_softshrink_backward_grad_input<S: Into<Scalar>>(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
         lambd: S,
     ) -> Tensor {
-        self.f_softshrink_backward_grad_input(grad_input, grad_output, lambd).unwrap()
+        self.softshrink_backward_grad_input(grad_input, grad_output, lambd).unwrap()
     }
 
-    pub fn softshrink_out(&self, out: &Tensor) -> Tensor {
-        self.f_softshrink_out(out).unwrap()
+    pub fn f_softshrink_out(&self, out: &Tensor) -> Tensor {
+        self.softshrink_out(out).unwrap()
     }
 
-    pub fn sort(&self, dim: i64, descending: bool) -> (Tensor, Tensor) {
-        self.f_sort(dim, descending).unwrap()
+    pub fn f_sort(&self, dim: i64, descending: bool) -> (Tensor, Tensor) {
+        self.sort(dim, descending).unwrap()
     }
 
-    pub fn sort_stable(&self, stable: bool, dim: i64, descending: bool) -> (Tensor, Tensor) {
-        self.f_sort_stable(stable, dim, descending).unwrap()
+    pub fn f_sort_stable(&self, stable: bool, dim: i64, descending: bool) -> (Tensor, Tensor) {
+        self.sort_stable(stable, dim, descending).unwrap()
     }
 
-    pub fn sort_values(
+    pub fn f_sort_values(
         &self,
         values: &Tensor,
         indices: &Tensor,
         dim: i64,
         descending: bool,
     ) -> (Tensor, Tensor) {
-        self.f_sort_values(values, indices, dim, descending).unwrap()
+        self.sort_values(values, indices, dim, descending).unwrap()
     }
 
-    pub fn sort_values_stable(
+    pub fn f_sort_values_stable(
         &self,
         values: &Tensor,
         indices: &Tensor,
@@ -15695,26 +15758,26 @@ impl Tensor {
         dim: i64,
         descending: bool,
     ) -> (Tensor, Tensor) {
-        self.f_sort_values_stable(values, indices, stable, dim, descending).unwrap()
+        self.sort_values_stable(values, indices, stable, dim, descending).unwrap()
     }
 
-    pub fn sparse_bsc_tensor(
+    pub fn f_sparse_bsc_tensor(
         ccol_indices: &Tensor,
         row_indices: &Tensor,
         values: &Tensor,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_sparse_bsc_tensor(ccol_indices, row_indices, values, options).unwrap()
+        Tensor::sparse_bsc_tensor(ccol_indices, row_indices, values, options).unwrap()
     }
 
-    pub fn sparse_bsc_tensor_ccol_row_value_size(
+    pub fn f_sparse_bsc_tensor_ccol_row_value_size(
         ccol_indices: &Tensor,
         row_indices: &Tensor,
         values: &Tensor,
         size: impl IntList,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_sparse_bsc_tensor_ccol_row_value_size(
+        Tensor::sparse_bsc_tensor_ccol_row_value_size(
             ccol_indices,
             row_indices,
             values,
@@ -15724,23 +15787,23 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn sparse_bsr_tensor(
+    pub fn f_sparse_bsr_tensor(
         crow_indices: &Tensor,
         col_indices: &Tensor,
         values: &Tensor,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_sparse_bsr_tensor(crow_indices, col_indices, values, options).unwrap()
+        Tensor::sparse_bsr_tensor(crow_indices, col_indices, values, options).unwrap()
     }
 
-    pub fn sparse_bsr_tensor_crow_col_value_size(
+    pub fn f_sparse_bsr_tensor_crow_col_value_size(
         crow_indices: &Tensor,
         col_indices: &Tensor,
         values: &Tensor,
         size: impl IntList,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_sparse_bsr_tensor_crow_col_value_size(
+        Tensor::sparse_bsr_tensor_crow_col_value_size(
             crow_indices,
             col_indices,
             values,
@@ -15750,24 +15813,24 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn sparse_compressed_tensor(
+    pub fn f_sparse_compressed_tensor(
         compressed_indices: &Tensor,
         plain_indices: &Tensor,
         values: &Tensor,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_sparse_compressed_tensor(compressed_indices, plain_indices, values, options)
+        Tensor::sparse_compressed_tensor(compressed_indices, plain_indices, values, options)
             .unwrap()
     }
 
-    pub fn sparse_compressed_tensor_comp_plain_value_size(
+    pub fn f_sparse_compressed_tensor_comp_plain_value_size(
         compressed_indices: &Tensor,
         plain_indices: &Tensor,
         values: &Tensor,
         size: impl IntList,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_sparse_compressed_tensor_comp_plain_value_size(
+        Tensor::sparse_compressed_tensor_comp_plain_value_size(
             compressed_indices,
             plain_indices,
             values,
@@ -15777,48 +15840,48 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn sparse_coo_tensor(size: impl IntList, options: (Kind, Device)) -> Tensor {
-        Tensor::f_sparse_coo_tensor(size, options).unwrap()
+    pub fn f_sparse_coo_tensor(size: impl IntList, options: (Kind, Device)) -> Tensor {
+        Tensor::sparse_coo_tensor(size, options).unwrap()
     }
 
-    pub fn sparse_coo_tensor_indices(
+    pub fn f_sparse_coo_tensor_indices(
         indices: &Tensor,
         values: &Tensor,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_sparse_coo_tensor_indices(indices, values, options).unwrap()
+        Tensor::sparse_coo_tensor_indices(indices, values, options).unwrap()
     }
 
-    pub fn sparse_coo_tensor_indices_size(
+    pub fn f_sparse_coo_tensor_indices_size(
         indices: &Tensor,
         values: &Tensor,
         size: impl IntList,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_sparse_coo_tensor_indices_size(indices, values, size, options).unwrap()
+        Tensor::sparse_coo_tensor_indices_size(indices, values, size, options).unwrap()
     }
 
-    pub fn sparse_coo_tensor_size_out(out: &Tensor, size: impl IntList) -> Tensor {
-        Tensor::f_sparse_coo_tensor_size_out(out, size).unwrap()
+    pub fn f_sparse_coo_tensor_size_out(out: &Tensor, size: impl IntList) -> Tensor {
+        Tensor::sparse_coo_tensor_size_out(out, size).unwrap()
     }
 
-    pub fn sparse_csc_tensor(
+    pub fn f_sparse_csc_tensor(
         ccol_indices: &Tensor,
         row_indices: &Tensor,
         values: &Tensor,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_sparse_csc_tensor(ccol_indices, row_indices, values, options).unwrap()
+        Tensor::sparse_csc_tensor(ccol_indices, row_indices, values, options).unwrap()
     }
 
-    pub fn sparse_csc_tensor_ccol_row_value_size(
+    pub fn f_sparse_csc_tensor_ccol_row_value_size(
         ccol_indices: &Tensor,
         row_indices: &Tensor,
         values: &Tensor,
         size: impl IntList,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_sparse_csc_tensor_ccol_row_value_size(
+        Tensor::sparse_csc_tensor_ccol_row_value_size(
             ccol_indices,
             row_indices,
             values,
@@ -15828,23 +15891,23 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn sparse_csr_tensor(
+    pub fn f_sparse_csr_tensor(
         crow_indices: &Tensor,
         col_indices: &Tensor,
         values: &Tensor,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_sparse_csr_tensor(crow_indices, col_indices, values, options).unwrap()
+        Tensor::sparse_csr_tensor(crow_indices, col_indices, values, options).unwrap()
     }
 
-    pub fn sparse_csr_tensor_crow_col_value_size(
+    pub fn f_sparse_csr_tensor_crow_col_value_size(
         crow_indices: &Tensor,
         col_indices: &Tensor,
         values: &Tensor,
         size: impl IntList,
         options: (Kind, Device),
     ) -> Tensor {
-        Tensor::f_sparse_csr_tensor_crow_col_value_size(
+        Tensor::sparse_csr_tensor_crow_col_value_size(
             crow_indices,
             col_indices,
             values,
@@ -15854,1075 +15917,1087 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn sparse_dim(&self) -> i64 {
-        self.f_sparse_dim().unwrap()
+    pub fn f_sparse_dim(&self) -> i64 {
+        self.sparse_dim().unwrap()
     }
 
-    pub fn sparse_mask(&self, mask: &Tensor) -> Tensor {
-        self.f_sparse_mask(mask).unwrap()
+    pub fn f_sparse_mask(&self, mask: &Tensor) -> Tensor {
+        self.sparse_mask(mask).unwrap()
     }
 
-    pub fn sparse_mask_out(&self, out: &Tensor, mask: &Tensor) -> Tensor {
-        self.f_sparse_mask_out(out, mask).unwrap()
+    pub fn f_sparse_mask_out(&self, out: &Tensor, mask: &Tensor) -> Tensor {
+        self.sparse_mask_out(out, mask).unwrap()
     }
 
-    pub fn sparse_resize(&self, size: impl IntList, sparse_dim: i64, dense_dim: i64) -> Tensor {
-        self.f_sparse_resize(size, sparse_dim, dense_dim).unwrap()
+    pub fn f_sparse_resize(&self, size: impl IntList, sparse_dim: i64, dense_dim: i64) -> Tensor {
+        self.sparse_resize(size, sparse_dim, dense_dim).unwrap()
     }
 
-    pub fn sparse_resize_(
+    pub fn f_sparse_resize_(
         &mut self,
         size: impl IntList,
         sparse_dim: i64,
         dense_dim: i64,
     ) -> Tensor {
-        self.f_sparse_resize_(size, sparse_dim, dense_dim).unwrap()
+        self.sparse_resize_(size, sparse_dim, dense_dim).unwrap()
     }
 
-    pub fn sparse_resize_and_clear(
+    pub fn f_sparse_resize_and_clear(
         &self,
         size: impl IntList,
         sparse_dim: i64,
         dense_dim: i64,
     ) -> Tensor {
-        self.f_sparse_resize_and_clear(size, sparse_dim, dense_dim).unwrap()
+        self.sparse_resize_and_clear(size, sparse_dim, dense_dim).unwrap()
     }
 
-    pub fn sparse_resize_and_clear_(
+    pub fn f_sparse_resize_and_clear_(
         &mut self,
         size: impl IntList,
         sparse_dim: i64,
         dense_dim: i64,
     ) -> Tensor {
-        self.f_sparse_resize_and_clear_(size, sparse_dim, dense_dim).unwrap()
+        self.sparse_resize_and_clear_(size, sparse_dim, dense_dim).unwrap()
     }
 
-    pub fn sparse_resize_and_clear_out(
+    pub fn f_sparse_resize_and_clear_out(
         &self,
         out: &Tensor,
         size: impl IntList,
         sparse_dim: i64,
         dense_dim: i64,
     ) -> Tensor {
-        self.f_sparse_resize_and_clear_out(out, size, sparse_dim, dense_dim).unwrap()
+        self.sparse_resize_and_clear_out(out, size, sparse_dim, dense_dim).unwrap()
     }
 
-    pub fn sparse_resize_out(
+    pub fn f_sparse_resize_out(
         &self,
         out: &Tensor,
         size: impl IntList,
         sparse_dim: i64,
         dense_dim: i64,
     ) -> Tensor {
-        self.f_sparse_resize_out(out, size, sparse_dim, dense_dim).unwrap()
+        self.sparse_resize_out(out, size, sparse_dim, dense_dim).unwrap()
     }
 
-    pub fn sparse_sampled_addmm(&self, mat1: &Tensor, mat2: &Tensor) -> Tensor {
-        self.f_sparse_sampled_addmm(mat1, mat2).unwrap()
+    pub fn f_sparse_sampled_addmm(&self, mat1: &Tensor, mat2: &Tensor) -> Tensor {
+        self.sparse_sampled_addmm(mat1, mat2).unwrap()
     }
 
-    pub fn sparse_sampled_addmm_out(&self, out: &Tensor, mat1: &Tensor, mat2: &Tensor) -> Tensor {
-        self.f_sparse_sampled_addmm_out(out, mat1, mat2).unwrap()
+    pub fn f_sparse_sampled_addmm_out(&self, out: &Tensor, mat1: &Tensor, mat2: &Tensor) -> Tensor {
+        self.sparse_sampled_addmm_out(out, mat1, mat2).unwrap()
     }
 
-    pub fn special_airy_ai(x: &Tensor) -> Tensor {
-        Tensor::f_special_airy_ai(x).unwrap()
+    pub fn f_special_airy_ai(x: &Tensor) -> Tensor {
+        Tensor::special_airy_ai(x).unwrap()
     }
 
-    pub fn special_airy_ai_out(out: &Tensor, x: &Tensor) -> Tensor {
-        Tensor::f_special_airy_ai_out(out, x).unwrap()
+    pub fn f_special_airy_ai_out(out: &Tensor, x: &Tensor) -> Tensor {
+        Tensor::special_airy_ai_out(out, x).unwrap()
     }
 
-    pub fn special_bessel_j0(&self) -> Tensor {
-        self.f_special_bessel_j0().unwrap()
+    pub fn f_special_bessel_j0(&self) -> Tensor {
+        self.special_bessel_j0().unwrap()
     }
 
-    pub fn special_bessel_j0_out(&self, out: &Tensor) -> Tensor {
-        self.f_special_bessel_j0_out(out).unwrap()
+    pub fn f_special_bessel_j0_out(&self, out: &Tensor) -> Tensor {
+        self.special_bessel_j0_out(out).unwrap()
     }
 
-    pub fn special_bessel_j1(&self) -> Tensor {
-        self.f_special_bessel_j1().unwrap()
+    pub fn f_special_bessel_j1(&self) -> Tensor {
+        self.special_bessel_j1().unwrap()
     }
 
-    pub fn special_bessel_j1_out(&self, out: &Tensor) -> Tensor {
-        self.f_special_bessel_j1_out(out).unwrap()
+    pub fn f_special_bessel_j1_out(&self, out: &Tensor) -> Tensor {
+        self.special_bessel_j1_out(out).unwrap()
     }
 
-    pub fn special_bessel_y0(&self) -> Tensor {
-        self.f_special_bessel_y0().unwrap()
+    pub fn f_special_bessel_y0(&self) -> Tensor {
+        self.special_bessel_y0().unwrap()
     }
 
-    pub fn special_bessel_y0_out(&self, out: &Tensor) -> Tensor {
-        self.f_special_bessel_y0_out(out).unwrap()
+    pub fn f_special_bessel_y0_out(&self, out: &Tensor) -> Tensor {
+        self.special_bessel_y0_out(out).unwrap()
     }
 
-    pub fn special_bessel_y1(&self) -> Tensor {
-        self.f_special_bessel_y1().unwrap()
+    pub fn f_special_bessel_y1(&self) -> Tensor {
+        self.special_bessel_y1().unwrap()
     }
 
-    pub fn special_bessel_y1_out(&self, out: &Tensor) -> Tensor {
-        self.f_special_bessel_y1_out(out).unwrap()
+    pub fn f_special_bessel_y1_out(&self, out: &Tensor) -> Tensor {
+        self.special_bessel_y1_out(out).unwrap()
     }
 
-    pub fn special_chebyshev_polynomial_t(x: &Tensor, n: &Tensor) -> Tensor {
-        Tensor::f_special_chebyshev_polynomial_t(x, n).unwrap()
+    pub fn f_special_chebyshev_polynomial_t(x: &Tensor, n: &Tensor) -> Tensor {
+        Tensor::special_chebyshev_polynomial_t(x, n).unwrap()
     }
 
-    pub fn special_chebyshev_polynomial_t_n_scalar<S: Into<Scalar>>(x: &Tensor, n: S) -> Tensor {
-        Tensor::f_special_chebyshev_polynomial_t_n_scalar(x, n).unwrap()
+    pub fn f_special_chebyshev_polynomial_t_n_scalar<S: Into<Scalar>>(x: &Tensor, n: S) -> Tensor {
+        Tensor::special_chebyshev_polynomial_t_n_scalar(x, n).unwrap()
     }
 
-    pub fn special_chebyshev_polynomial_t_n_scalar_out<S: Into<Scalar>>(
+    pub fn f_special_chebyshev_polynomial_t_n_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: &Tensor,
         n: S,
     ) -> Tensor {
-        Tensor::f_special_chebyshev_polynomial_t_n_scalar_out(out, x, n).unwrap()
+        Tensor::special_chebyshev_polynomial_t_n_scalar_out(out, x, n).unwrap()
     }
 
-    pub fn special_chebyshev_polynomial_t_out(out: &Tensor, x: &Tensor, n: &Tensor) -> Tensor {
-        Tensor::f_special_chebyshev_polynomial_t_out(out, x, n).unwrap()
+    pub fn f_special_chebyshev_polynomial_t_out(out: &Tensor, x: &Tensor, n: &Tensor) -> Tensor {
+        Tensor::special_chebyshev_polynomial_t_out(out, x, n).unwrap()
     }
 
-    pub fn special_chebyshev_polynomial_t_x_scalar<S: Into<Scalar>>(x: S, n: &Tensor) -> Tensor {
-        Tensor::f_special_chebyshev_polynomial_t_x_scalar(x, n).unwrap()
+    pub fn f_special_chebyshev_polynomial_t_x_scalar<S: Into<Scalar>>(x: S, n: &Tensor) -> Tensor {
+        Tensor::special_chebyshev_polynomial_t_x_scalar(x, n).unwrap()
     }
 
-    pub fn special_chebyshev_polynomial_t_x_scalar_out<S: Into<Scalar>>(
+    pub fn f_special_chebyshev_polynomial_t_x_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: S,
         n: &Tensor,
     ) -> Tensor {
-        Tensor::f_special_chebyshev_polynomial_t_x_scalar_out(out, x, n).unwrap()
+        Tensor::special_chebyshev_polynomial_t_x_scalar_out(out, x, n).unwrap()
     }
 
-    pub fn special_chebyshev_polynomial_u(x: &Tensor, n: &Tensor) -> Tensor {
-        Tensor::f_special_chebyshev_polynomial_u(x, n).unwrap()
+    pub fn f_special_chebyshev_polynomial_u(x: &Tensor, n: &Tensor) -> Tensor {
+        Tensor::special_chebyshev_polynomial_u(x, n).unwrap()
     }
 
-    pub fn special_chebyshev_polynomial_u_n_scalar<S: Into<Scalar>>(x: &Tensor, n: S) -> Tensor {
-        Tensor::f_special_chebyshev_polynomial_u_n_scalar(x, n).unwrap()
+    pub fn f_special_chebyshev_polynomial_u_n_scalar<S: Into<Scalar>>(x: &Tensor, n: S) -> Tensor {
+        Tensor::special_chebyshev_polynomial_u_n_scalar(x, n).unwrap()
     }
 
-    pub fn special_chebyshev_polynomial_u_n_scalar_out<S: Into<Scalar>>(
+    pub fn f_special_chebyshev_polynomial_u_n_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: &Tensor,
         n: S,
     ) -> Tensor {
-        Tensor::f_special_chebyshev_polynomial_u_n_scalar_out(out, x, n).unwrap()
+        Tensor::special_chebyshev_polynomial_u_n_scalar_out(out, x, n).unwrap()
     }
 
-    pub fn special_chebyshev_polynomial_u_out(out: &Tensor, x: &Tensor, n: &Tensor) -> Tensor {
-        Tensor::f_special_chebyshev_polynomial_u_out(out, x, n).unwrap()
+    pub fn f_special_chebyshev_polynomial_u_out(out: &Tensor, x: &Tensor, n: &Tensor) -> Tensor {
+        Tensor::special_chebyshev_polynomial_u_out(out, x, n).unwrap()
     }
 
-    pub fn special_chebyshev_polynomial_u_x_scalar<S: Into<Scalar>>(x: S, n: &Tensor) -> Tensor {
-        Tensor::f_special_chebyshev_polynomial_u_x_scalar(x, n).unwrap()
+    pub fn f_special_chebyshev_polynomial_u_x_scalar<S: Into<Scalar>>(x: S, n: &Tensor) -> Tensor {
+        Tensor::special_chebyshev_polynomial_u_x_scalar(x, n).unwrap()
     }
 
-    pub fn special_chebyshev_polynomial_u_x_scalar_out<S: Into<Scalar>>(
+    pub fn f_special_chebyshev_polynomial_u_x_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: S,
         n: &Tensor,
     ) -> Tensor {
-        Tensor::f_special_chebyshev_polynomial_u_x_scalar_out(out, x, n).unwrap()
+        Tensor::special_chebyshev_polynomial_u_x_scalar_out(out, x, n).unwrap()
     }
 
-    pub fn special_chebyshev_polynomial_v(x: &Tensor, n: &Tensor) -> Tensor {
-        Tensor::f_special_chebyshev_polynomial_v(x, n).unwrap()
+    pub fn f_special_chebyshev_polynomial_v(x: &Tensor, n: &Tensor) -> Tensor {
+        Tensor::special_chebyshev_polynomial_v(x, n).unwrap()
     }
 
-    pub fn special_chebyshev_polynomial_v_n_scalar<S: Into<Scalar>>(x: &Tensor, n: S) -> Tensor {
-        Tensor::f_special_chebyshev_polynomial_v_n_scalar(x, n).unwrap()
+    pub fn f_special_chebyshev_polynomial_v_n_scalar<S: Into<Scalar>>(x: &Tensor, n: S) -> Tensor {
+        Tensor::special_chebyshev_polynomial_v_n_scalar(x, n).unwrap()
     }
 
-    pub fn special_chebyshev_polynomial_v_n_scalar_out<S: Into<Scalar>>(
+    pub fn f_special_chebyshev_polynomial_v_n_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: &Tensor,
         n: S,
     ) -> Tensor {
-        Tensor::f_special_chebyshev_polynomial_v_n_scalar_out(out, x, n).unwrap()
+        Tensor::special_chebyshev_polynomial_v_n_scalar_out(out, x, n).unwrap()
     }
 
-    pub fn special_chebyshev_polynomial_v_out(out: &Tensor, x: &Tensor, n: &Tensor) -> Tensor {
-        Tensor::f_special_chebyshev_polynomial_v_out(out, x, n).unwrap()
+    pub fn f_special_chebyshev_polynomial_v_out(out: &Tensor, x: &Tensor, n: &Tensor) -> Tensor {
+        Tensor::special_chebyshev_polynomial_v_out(out, x, n).unwrap()
     }
 
-    pub fn special_chebyshev_polynomial_v_x_scalar<S: Into<Scalar>>(x: S, n: &Tensor) -> Tensor {
-        Tensor::f_special_chebyshev_polynomial_v_x_scalar(x, n).unwrap()
+    pub fn f_special_chebyshev_polynomial_v_x_scalar<S: Into<Scalar>>(x: S, n: &Tensor) -> Tensor {
+        Tensor::special_chebyshev_polynomial_v_x_scalar(x, n).unwrap()
     }
 
-    pub fn special_chebyshev_polynomial_v_x_scalar_out<S: Into<Scalar>>(
+    pub fn f_special_chebyshev_polynomial_v_x_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: S,
         n: &Tensor,
     ) -> Tensor {
-        Tensor::f_special_chebyshev_polynomial_v_x_scalar_out(out, x, n).unwrap()
+        Tensor::special_chebyshev_polynomial_v_x_scalar_out(out, x, n).unwrap()
     }
 
-    pub fn special_chebyshev_polynomial_w(x: &Tensor, n: &Tensor) -> Tensor {
-        Tensor::f_special_chebyshev_polynomial_w(x, n).unwrap()
+    pub fn f_special_chebyshev_polynomial_w(x: &Tensor, n: &Tensor) -> Tensor {
+        Tensor::special_chebyshev_polynomial_w(x, n).unwrap()
     }
 
-    pub fn special_chebyshev_polynomial_w_n_scalar<S: Into<Scalar>>(x: &Tensor, n: S) -> Tensor {
-        Tensor::f_special_chebyshev_polynomial_w_n_scalar(x, n).unwrap()
+    pub fn f_special_chebyshev_polynomial_w_n_scalar<S: Into<Scalar>>(x: &Tensor, n: S) -> Tensor {
+        Tensor::special_chebyshev_polynomial_w_n_scalar(x, n).unwrap()
     }
 
-    pub fn special_chebyshev_polynomial_w_n_scalar_out<S: Into<Scalar>>(
+    pub fn f_special_chebyshev_polynomial_w_n_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: &Tensor,
         n: S,
     ) -> Tensor {
-        Tensor::f_special_chebyshev_polynomial_w_n_scalar_out(out, x, n).unwrap()
+        Tensor::special_chebyshev_polynomial_w_n_scalar_out(out, x, n).unwrap()
     }
 
-    pub fn special_chebyshev_polynomial_w_out(out: &Tensor, x: &Tensor, n: &Tensor) -> Tensor {
-        Tensor::f_special_chebyshev_polynomial_w_out(out, x, n).unwrap()
+    pub fn f_special_chebyshev_polynomial_w_out(out: &Tensor, x: &Tensor, n: &Tensor) -> Tensor {
+        Tensor::special_chebyshev_polynomial_w_out(out, x, n).unwrap()
     }
 
-    pub fn special_chebyshev_polynomial_w_x_scalar<S: Into<Scalar>>(x: S, n: &Tensor) -> Tensor {
-        Tensor::f_special_chebyshev_polynomial_w_x_scalar(x, n).unwrap()
+    pub fn f_special_chebyshev_polynomial_w_x_scalar<S: Into<Scalar>>(x: S, n: &Tensor) -> Tensor {
+        Tensor::special_chebyshev_polynomial_w_x_scalar(x, n).unwrap()
     }
 
-    pub fn special_chebyshev_polynomial_w_x_scalar_out<S: Into<Scalar>>(
+    pub fn f_special_chebyshev_polynomial_w_x_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: S,
         n: &Tensor,
     ) -> Tensor {
-        Tensor::f_special_chebyshev_polynomial_w_x_scalar_out(out, x, n).unwrap()
+        Tensor::special_chebyshev_polynomial_w_x_scalar_out(out, x, n).unwrap()
     }
 
-    pub fn special_digamma(&self) -> Tensor {
-        self.f_special_digamma().unwrap()
+    pub fn f_special_digamma(&self) -> Tensor {
+        self.special_digamma().unwrap()
     }
 
-    pub fn special_digamma_out(&self, out: &Tensor) -> Tensor {
-        self.f_special_digamma_out(out).unwrap()
+    pub fn f_special_digamma_out(&self, out: &Tensor) -> Tensor {
+        self.special_digamma_out(out).unwrap()
     }
 
-    pub fn special_entr(&self) -> Tensor {
-        self.f_special_entr().unwrap()
+    pub fn f_special_entr(&self) -> Tensor {
+        self.special_entr().unwrap()
     }
 
-    pub fn special_entr_out(&self, out: &Tensor) -> Tensor {
-        self.f_special_entr_out(out).unwrap()
+    pub fn f_special_entr_out(&self, out: &Tensor) -> Tensor {
+        self.special_entr_out(out).unwrap()
     }
 
-    pub fn special_erf(&self) -> Tensor {
-        self.f_special_erf().unwrap()
+    pub fn f_special_erf(&self) -> Tensor {
+        self.special_erf().unwrap()
     }
 
-    pub fn special_erf_out(&self, out: &Tensor) -> Tensor {
-        self.f_special_erf_out(out).unwrap()
+    pub fn f_special_erf_out(&self, out: &Tensor) -> Tensor {
+        self.special_erf_out(out).unwrap()
     }
 
-    pub fn special_erfc(&self) -> Tensor {
-        self.f_special_erfc().unwrap()
+    pub fn f_special_erfc(&self) -> Tensor {
+        self.special_erfc().unwrap()
     }
 
-    pub fn special_erfc_out(&self, out: &Tensor) -> Tensor {
-        self.f_special_erfc_out(out).unwrap()
+    pub fn f_special_erfc_out(&self, out: &Tensor) -> Tensor {
+        self.special_erfc_out(out).unwrap()
     }
 
-    pub fn special_erfcx(&self) -> Tensor {
-        self.f_special_erfcx().unwrap()
+    pub fn f_special_erfcx(&self) -> Tensor {
+        self.special_erfcx().unwrap()
     }
 
-    pub fn special_erfcx_out(&self, out: &Tensor) -> Tensor {
-        self.f_special_erfcx_out(out).unwrap()
+    pub fn f_special_erfcx_out(&self, out: &Tensor) -> Tensor {
+        self.special_erfcx_out(out).unwrap()
     }
 
-    pub fn special_erfinv(&self) -> Tensor {
-        self.f_special_erfinv().unwrap()
+    pub fn f_special_erfinv(&self) -> Tensor {
+        self.special_erfinv().unwrap()
     }
 
-    pub fn special_erfinv_out(&self, out: &Tensor) -> Tensor {
-        self.f_special_erfinv_out(out).unwrap()
+    pub fn f_special_erfinv_out(&self, out: &Tensor) -> Tensor {
+        self.special_erfinv_out(out).unwrap()
     }
 
-    pub fn special_exp2(&self) -> Tensor {
-        self.f_special_exp2().unwrap()
+    pub fn f_special_exp2(&self) -> Tensor {
+        self.special_exp2().unwrap()
     }
 
-    pub fn special_exp2_out(&self, out: &Tensor) -> Tensor {
-        self.f_special_exp2_out(out).unwrap()
+    pub fn f_special_exp2_out(&self, out: &Tensor) -> Tensor {
+        self.special_exp2_out(out).unwrap()
     }
 
-    pub fn special_expit(&self) -> Tensor {
-        self.f_special_expit().unwrap()
+    pub fn f_special_expit(&self) -> Tensor {
+        self.special_expit().unwrap()
     }
 
-    pub fn special_expit_out(&self, out: &Tensor) -> Tensor {
-        self.f_special_expit_out(out).unwrap()
+    pub fn f_special_expit_out(&self, out: &Tensor) -> Tensor {
+        self.special_expit_out(out).unwrap()
     }
 
-    pub fn special_expm1(&self) -> Tensor {
-        self.f_special_expm1().unwrap()
+    pub fn f_special_expm1(&self) -> Tensor {
+        self.special_expm1().unwrap()
     }
 
-    pub fn special_expm1_out(&self, out: &Tensor) -> Tensor {
-        self.f_special_expm1_out(out).unwrap()
+    pub fn f_special_expm1_out(&self, out: &Tensor) -> Tensor {
+        self.special_expm1_out(out).unwrap()
     }
 
-    pub fn special_gammainc(&self, other: &Tensor) -> Tensor {
-        self.f_special_gammainc(other).unwrap()
+    pub fn f_special_gammainc(&self, other: &Tensor) -> Tensor {
+        self.special_gammainc(other).unwrap()
     }
 
-    pub fn special_gammainc_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_special_gammainc_out(out, other).unwrap()
+    pub fn f_special_gammainc_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.special_gammainc_out(out, other).unwrap()
     }
 
-    pub fn special_gammaincc(&self, other: &Tensor) -> Tensor {
-        self.f_special_gammaincc(other).unwrap()
+    pub fn f_special_gammaincc(&self, other: &Tensor) -> Tensor {
+        self.special_gammaincc(other).unwrap()
     }
 
-    pub fn special_gammaincc_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_special_gammaincc_out(out, other).unwrap()
+    pub fn f_special_gammaincc_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.special_gammaincc_out(out, other).unwrap()
     }
 
-    pub fn special_gammaln(&self) -> Tensor {
-        self.f_special_gammaln().unwrap()
+    pub fn f_special_gammaln(&self) -> Tensor {
+        self.special_gammaln().unwrap()
     }
 
-    pub fn special_gammaln_out(&self, out: &Tensor) -> Tensor {
-        self.f_special_gammaln_out(out).unwrap()
+    pub fn f_special_gammaln_out(&self, out: &Tensor) -> Tensor {
+        self.special_gammaln_out(out).unwrap()
     }
 
-    pub fn special_hermite_polynomial_h(x: &Tensor, n: &Tensor) -> Tensor {
-        Tensor::f_special_hermite_polynomial_h(x, n).unwrap()
+    pub fn f_special_hermite_polynomial_h(x: &Tensor, n: &Tensor) -> Tensor {
+        Tensor::special_hermite_polynomial_h(x, n).unwrap()
     }
 
-    pub fn special_hermite_polynomial_h_n_scalar<S: Into<Scalar>>(x: &Tensor, n: S) -> Tensor {
-        Tensor::f_special_hermite_polynomial_h_n_scalar(x, n).unwrap()
+    pub fn f_special_hermite_polynomial_h_n_scalar<S: Into<Scalar>>(x: &Tensor, n: S) -> Tensor {
+        Tensor::special_hermite_polynomial_h_n_scalar(x, n).unwrap()
     }
 
-    pub fn special_hermite_polynomial_h_n_scalar_out<S: Into<Scalar>>(
+    pub fn f_special_hermite_polynomial_h_n_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: &Tensor,
         n: S,
     ) -> Tensor {
-        Tensor::f_special_hermite_polynomial_h_n_scalar_out(out, x, n).unwrap()
+        Tensor::special_hermite_polynomial_h_n_scalar_out(out, x, n).unwrap()
     }
 
-    pub fn special_hermite_polynomial_h_out(out: &Tensor, x: &Tensor, n: &Tensor) -> Tensor {
-        Tensor::f_special_hermite_polynomial_h_out(out, x, n).unwrap()
+    pub fn f_special_hermite_polynomial_h_out(out: &Tensor, x: &Tensor, n: &Tensor) -> Tensor {
+        Tensor::special_hermite_polynomial_h_out(out, x, n).unwrap()
     }
 
-    pub fn special_hermite_polynomial_h_x_scalar<S: Into<Scalar>>(x: S, n: &Tensor) -> Tensor {
-        Tensor::f_special_hermite_polynomial_h_x_scalar(x, n).unwrap()
+    pub fn f_special_hermite_polynomial_h_x_scalar<S: Into<Scalar>>(x: S, n: &Tensor) -> Tensor {
+        Tensor::special_hermite_polynomial_h_x_scalar(x, n).unwrap()
     }
 
-    pub fn special_hermite_polynomial_h_x_scalar_out<S: Into<Scalar>>(
+    pub fn f_special_hermite_polynomial_h_x_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: S,
         n: &Tensor,
     ) -> Tensor {
-        Tensor::f_special_hermite_polynomial_h_x_scalar_out(out, x, n).unwrap()
+        Tensor::special_hermite_polynomial_h_x_scalar_out(out, x, n).unwrap()
     }
 
-    pub fn special_hermite_polynomial_he(x: &Tensor, n: &Tensor) -> Tensor {
-        Tensor::f_special_hermite_polynomial_he(x, n).unwrap()
+    pub fn f_special_hermite_polynomial_he(x: &Tensor, n: &Tensor) -> Tensor {
+        Tensor::special_hermite_polynomial_he(x, n).unwrap()
     }
 
-    pub fn special_hermite_polynomial_he_n_scalar<S: Into<Scalar>>(x: &Tensor, n: S) -> Tensor {
-        Tensor::f_special_hermite_polynomial_he_n_scalar(x, n).unwrap()
+    pub fn f_special_hermite_polynomial_he_n_scalar<S: Into<Scalar>>(x: &Tensor, n: S) -> Tensor {
+        Tensor::special_hermite_polynomial_he_n_scalar(x, n).unwrap()
     }
 
-    pub fn special_hermite_polynomial_he_n_scalar_out<S: Into<Scalar>>(
+    pub fn f_special_hermite_polynomial_he_n_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: &Tensor,
         n: S,
     ) -> Tensor {
-        Tensor::f_special_hermite_polynomial_he_n_scalar_out(out, x, n).unwrap()
+        Tensor::special_hermite_polynomial_he_n_scalar_out(out, x, n).unwrap()
     }
 
-    pub fn special_hermite_polynomial_he_out(out: &Tensor, x: &Tensor, n: &Tensor) -> Tensor {
-        Tensor::f_special_hermite_polynomial_he_out(out, x, n).unwrap()
+    pub fn f_special_hermite_polynomial_he_out(out: &Tensor, x: &Tensor, n: &Tensor) -> Tensor {
+        Tensor::special_hermite_polynomial_he_out(out, x, n).unwrap()
     }
 
-    pub fn special_hermite_polynomial_he_x_scalar<S: Into<Scalar>>(x: S, n: &Tensor) -> Tensor {
-        Tensor::f_special_hermite_polynomial_he_x_scalar(x, n).unwrap()
+    pub fn f_special_hermite_polynomial_he_x_scalar<S: Into<Scalar>>(x: S, n: &Tensor) -> Tensor {
+        Tensor::special_hermite_polynomial_he_x_scalar(x, n).unwrap()
     }
 
-    pub fn special_hermite_polynomial_he_x_scalar_out<S: Into<Scalar>>(
+    pub fn f_special_hermite_polynomial_he_x_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: S,
         n: &Tensor,
     ) -> Tensor {
-        Tensor::f_special_hermite_polynomial_he_x_scalar_out(out, x, n).unwrap()
+        Tensor::special_hermite_polynomial_he_x_scalar_out(out, x, n).unwrap()
     }
 
-    pub fn special_i0(&self) -> Tensor {
-        self.f_special_i0().unwrap()
+    pub fn f_special_i0(&self) -> Tensor {
+        self.special_i0().unwrap()
     }
 
-    pub fn special_i0_out(&self, out: &Tensor) -> Tensor {
-        self.f_special_i0_out(out).unwrap()
+    pub fn f_special_i0_out(&self, out: &Tensor) -> Tensor {
+        self.special_i0_out(out).unwrap()
     }
 
-    pub fn special_i0e(&self) -> Tensor {
-        self.f_special_i0e().unwrap()
+    pub fn f_special_i0e(&self) -> Tensor {
+        self.special_i0e().unwrap()
     }
 
-    pub fn special_i0e_out(&self, out: &Tensor) -> Tensor {
-        self.f_special_i0e_out(out).unwrap()
+    pub fn f_special_i0e_out(&self, out: &Tensor) -> Tensor {
+        self.special_i0e_out(out).unwrap()
     }
 
-    pub fn special_i1(&self) -> Tensor {
-        self.f_special_i1().unwrap()
+    pub fn f_special_i1(&self) -> Tensor {
+        self.special_i1().unwrap()
     }
 
-    pub fn special_i1_out(&self, out: &Tensor) -> Tensor {
-        self.f_special_i1_out(out).unwrap()
+    pub fn f_special_i1_out(&self, out: &Tensor) -> Tensor {
+        self.special_i1_out(out).unwrap()
     }
 
-    pub fn special_i1e(&self) -> Tensor {
-        self.f_special_i1e().unwrap()
+    pub fn f_special_i1e(&self) -> Tensor {
+        self.special_i1e().unwrap()
     }
 
-    pub fn special_i1e_out(&self, out: &Tensor) -> Tensor {
-        self.f_special_i1e_out(out).unwrap()
+    pub fn f_special_i1e_out(&self, out: &Tensor) -> Tensor {
+        self.special_i1e_out(out).unwrap()
     }
 
-    pub fn special_laguerre_polynomial_l(x: &Tensor, n: &Tensor) -> Tensor {
-        Tensor::f_special_laguerre_polynomial_l(x, n).unwrap()
+    pub fn f_special_laguerre_polynomial_l(x: &Tensor, n: &Tensor) -> Tensor {
+        Tensor::special_laguerre_polynomial_l(x, n).unwrap()
     }
 
-    pub fn special_laguerre_polynomial_l_n_scalar<S: Into<Scalar>>(x: &Tensor, n: S) -> Tensor {
-        Tensor::f_special_laguerre_polynomial_l_n_scalar(x, n).unwrap()
+    pub fn f_special_laguerre_polynomial_l_n_scalar<S: Into<Scalar>>(x: &Tensor, n: S) -> Tensor {
+        Tensor::special_laguerre_polynomial_l_n_scalar(x, n).unwrap()
     }
 
-    pub fn special_laguerre_polynomial_l_n_scalar_out<S: Into<Scalar>>(
+    pub fn f_special_laguerre_polynomial_l_n_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: &Tensor,
         n: S,
     ) -> Tensor {
-        Tensor::f_special_laguerre_polynomial_l_n_scalar_out(out, x, n).unwrap()
+        Tensor::special_laguerre_polynomial_l_n_scalar_out(out, x, n).unwrap()
     }
 
-    pub fn special_laguerre_polynomial_l_out(out: &Tensor, x: &Tensor, n: &Tensor) -> Tensor {
-        Tensor::f_special_laguerre_polynomial_l_out(out, x, n).unwrap()
+    pub fn f_special_laguerre_polynomial_l_out(out: &Tensor, x: &Tensor, n: &Tensor) -> Tensor {
+        Tensor::special_laguerre_polynomial_l_out(out, x, n).unwrap()
     }
 
-    pub fn special_laguerre_polynomial_l_x_scalar<S: Into<Scalar>>(x: S, n: &Tensor) -> Tensor {
-        Tensor::f_special_laguerre_polynomial_l_x_scalar(x, n).unwrap()
+    pub fn f_special_laguerre_polynomial_l_x_scalar<S: Into<Scalar>>(x: S, n: &Tensor) -> Tensor {
+        Tensor::special_laguerre_polynomial_l_x_scalar(x, n).unwrap()
     }
 
-    pub fn special_laguerre_polynomial_l_x_scalar_out<S: Into<Scalar>>(
+    pub fn f_special_laguerre_polynomial_l_x_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: S,
         n: &Tensor,
     ) -> Tensor {
-        Tensor::f_special_laguerre_polynomial_l_x_scalar_out(out, x, n).unwrap()
+        Tensor::special_laguerre_polynomial_l_x_scalar_out(out, x, n).unwrap()
     }
 
-    pub fn special_legendre_polynomial_p(x: &Tensor, n: &Tensor) -> Tensor {
-        Tensor::f_special_legendre_polynomial_p(x, n).unwrap()
+    pub fn f_special_legendre_polynomial_p(x: &Tensor, n: &Tensor) -> Tensor {
+        Tensor::special_legendre_polynomial_p(x, n).unwrap()
     }
 
-    pub fn special_legendre_polynomial_p_n_scalar<S: Into<Scalar>>(x: &Tensor, n: S) -> Tensor {
-        Tensor::f_special_legendre_polynomial_p_n_scalar(x, n).unwrap()
+    pub fn f_special_legendre_polynomial_p_n_scalar<S: Into<Scalar>>(x: &Tensor, n: S) -> Tensor {
+        Tensor::special_legendre_polynomial_p_n_scalar(x, n).unwrap()
     }
 
-    pub fn special_legendre_polynomial_p_n_scalar_out<S: Into<Scalar>>(
+    pub fn f_special_legendre_polynomial_p_n_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: &Tensor,
         n: S,
     ) -> Tensor {
-        Tensor::f_special_legendre_polynomial_p_n_scalar_out(out, x, n).unwrap()
+        Tensor::special_legendre_polynomial_p_n_scalar_out(out, x, n).unwrap()
     }
 
-    pub fn special_legendre_polynomial_p_out(out: &Tensor, x: &Tensor, n: &Tensor) -> Tensor {
-        Tensor::f_special_legendre_polynomial_p_out(out, x, n).unwrap()
+    pub fn f_special_legendre_polynomial_p_out(out: &Tensor, x: &Tensor, n: &Tensor) -> Tensor {
+        Tensor::special_legendre_polynomial_p_out(out, x, n).unwrap()
     }
 
-    pub fn special_legendre_polynomial_p_x_scalar<S: Into<Scalar>>(x: S, n: &Tensor) -> Tensor {
-        Tensor::f_special_legendre_polynomial_p_x_scalar(x, n).unwrap()
+    pub fn f_special_legendre_polynomial_p_x_scalar<S: Into<Scalar>>(x: S, n: &Tensor) -> Tensor {
+        Tensor::special_legendre_polynomial_p_x_scalar(x, n).unwrap()
     }
 
-    pub fn special_legendre_polynomial_p_x_scalar_out<S: Into<Scalar>>(
+    pub fn f_special_legendre_polynomial_p_x_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: S,
         n: &Tensor,
     ) -> Tensor {
-        Tensor::f_special_legendre_polynomial_p_x_scalar_out(out, x, n).unwrap()
+        Tensor::special_legendre_polynomial_p_x_scalar_out(out, x, n).unwrap()
     }
 
-    pub fn special_log1p(&self) -> Tensor {
-        self.f_special_log1p().unwrap()
+    pub fn f_special_log1p(&self) -> Tensor {
+        self.special_log1p().unwrap()
     }
 
-    pub fn special_log1p_out(&self, out: &Tensor) -> Tensor {
-        self.f_special_log1p_out(out).unwrap()
+    pub fn f_special_log1p_out(&self, out: &Tensor) -> Tensor {
+        self.special_log1p_out(out).unwrap()
     }
 
-    pub fn special_log_ndtr(&self) -> Tensor {
-        self.f_special_log_ndtr().unwrap()
+    pub fn f_special_log_ndtr(&self) -> Tensor {
+        self.special_log_ndtr().unwrap()
     }
 
-    pub fn special_log_ndtr_out(&self, out: &Tensor) -> Tensor {
-        self.f_special_log_ndtr_out(out).unwrap()
+    pub fn f_special_log_ndtr_out(&self, out: &Tensor) -> Tensor {
+        self.special_log_ndtr_out(out).unwrap()
     }
 
-    pub fn special_log_softmax(&self, dim: i64, dtype: impl Into<Option<Kind>>) -> Tensor {
-        self.f_special_log_softmax(dim, dtype).unwrap()
+    pub fn f_special_log_softmax(&self, dim: i64, dtype: impl Into<Option<Kind>>) -> Tensor {
+        self.special_log_softmax(dim, dtype).unwrap()
     }
 
-    pub fn special_logit(&self, eps: impl Into<Option<f64>>) -> Tensor {
-        self.f_special_logit(eps).unwrap()
+    pub fn f_special_logit(&self, eps: impl Into<Option<f64>>) -> Tensor {
+        self.special_logit(eps).unwrap()
     }
 
-    pub fn special_logit_out(&self, out: &Tensor, eps: impl Into<Option<f64>>) -> Tensor {
-        self.f_special_logit_out(out, eps).unwrap()
+    pub fn f_special_logit_out(&self, out: &Tensor, eps: impl Into<Option<f64>>) -> Tensor {
+        self.special_logit_out(out, eps).unwrap()
     }
 
-    pub fn special_logsumexp(&self, dim: impl IntList, keepdim: bool) -> Tensor {
-        self.f_special_logsumexp(dim, keepdim).unwrap()
+    pub fn f_special_logsumexp(&self, dim: impl IntList, keepdim: bool) -> Tensor {
+        self.special_logsumexp(dim, keepdim).unwrap()
     }
 
-    pub fn special_logsumexp_out(&self, out: &Tensor, dim: impl IntList, keepdim: bool) -> Tensor {
-        self.f_special_logsumexp_out(out, dim, keepdim).unwrap()
+    pub fn f_special_logsumexp_out(
+        &self,
+        out: &Tensor,
+        dim: impl IntList,
+        keepdim: bool,
+    ) -> Tensor {
+        self.special_logsumexp_out(out, dim, keepdim).unwrap()
     }
 
-    pub fn special_modified_bessel_i0(&self) -> Tensor {
-        self.f_special_modified_bessel_i0().unwrap()
+    pub fn f_special_modified_bessel_i0(&self) -> Tensor {
+        self.special_modified_bessel_i0().unwrap()
     }
 
-    pub fn special_modified_bessel_i0_out(&self, out: &Tensor) -> Tensor {
-        self.f_special_modified_bessel_i0_out(out).unwrap()
+    pub fn f_special_modified_bessel_i0_out(&self, out: &Tensor) -> Tensor {
+        self.special_modified_bessel_i0_out(out).unwrap()
     }
 
-    pub fn special_modified_bessel_i1(&self) -> Tensor {
-        self.f_special_modified_bessel_i1().unwrap()
+    pub fn f_special_modified_bessel_i1(&self) -> Tensor {
+        self.special_modified_bessel_i1().unwrap()
     }
 
-    pub fn special_modified_bessel_i1_out(&self, out: &Tensor) -> Tensor {
-        self.f_special_modified_bessel_i1_out(out).unwrap()
+    pub fn f_special_modified_bessel_i1_out(&self, out: &Tensor) -> Tensor {
+        self.special_modified_bessel_i1_out(out).unwrap()
     }
 
-    pub fn special_modified_bessel_k0(&self) -> Tensor {
-        self.f_special_modified_bessel_k0().unwrap()
+    pub fn f_special_modified_bessel_k0(&self) -> Tensor {
+        self.special_modified_bessel_k0().unwrap()
     }
 
-    pub fn special_modified_bessel_k0_out(&self, out: &Tensor) -> Tensor {
-        self.f_special_modified_bessel_k0_out(out).unwrap()
+    pub fn f_special_modified_bessel_k0_out(&self, out: &Tensor) -> Tensor {
+        self.special_modified_bessel_k0_out(out).unwrap()
     }
 
-    pub fn special_modified_bessel_k1(&self) -> Tensor {
-        self.f_special_modified_bessel_k1().unwrap()
+    pub fn f_special_modified_bessel_k1(&self) -> Tensor {
+        self.special_modified_bessel_k1().unwrap()
     }
 
-    pub fn special_modified_bessel_k1_out(&self, out: &Tensor) -> Tensor {
-        self.f_special_modified_bessel_k1_out(out).unwrap()
+    pub fn f_special_modified_bessel_k1_out(&self, out: &Tensor) -> Tensor {
+        self.special_modified_bessel_k1_out(out).unwrap()
     }
 
-    pub fn special_multigammaln(&self, p: i64) -> Tensor {
-        self.f_special_multigammaln(p).unwrap()
+    pub fn f_special_multigammaln(&self, p: i64) -> Tensor {
+        self.special_multigammaln(p).unwrap()
     }
 
-    pub fn special_multigammaln_out(&self, out: &Tensor, p: i64) -> Tensor {
-        self.f_special_multigammaln_out(out, p).unwrap()
+    pub fn f_special_multigammaln_out(&self, out: &Tensor, p: i64) -> Tensor {
+        self.special_multigammaln_out(out, p).unwrap()
     }
 
-    pub fn special_ndtr(&self) -> Tensor {
-        self.f_special_ndtr().unwrap()
+    pub fn f_special_ndtr(&self) -> Tensor {
+        self.special_ndtr().unwrap()
     }
 
-    pub fn special_ndtr_out(&self, out: &Tensor) -> Tensor {
-        self.f_special_ndtr_out(out).unwrap()
+    pub fn f_special_ndtr_out(&self, out: &Tensor) -> Tensor {
+        self.special_ndtr_out(out).unwrap()
     }
 
-    pub fn special_ndtri(&self) -> Tensor {
-        self.f_special_ndtri().unwrap()
+    pub fn f_special_ndtri(&self) -> Tensor {
+        self.special_ndtri().unwrap()
     }
 
-    pub fn special_ndtri_out(&self, out: &Tensor) -> Tensor {
-        self.f_special_ndtri_out(out).unwrap()
+    pub fn f_special_ndtri_out(&self, out: &Tensor) -> Tensor {
+        self.special_ndtri_out(out).unwrap()
     }
 
-    pub fn special_polygamma(&self, n: i64) -> Tensor {
-        self.f_special_polygamma(n).unwrap()
+    pub fn f_special_polygamma(&self, n: i64) -> Tensor {
+        self.special_polygamma(n).unwrap()
     }
 
-    pub fn special_polygamma_out(&self, out: &Tensor, n: i64) -> Tensor {
-        self.f_special_polygamma_out(out, n).unwrap()
+    pub fn f_special_polygamma_out(&self, out: &Tensor, n: i64) -> Tensor {
+        self.special_polygamma_out(out, n).unwrap()
     }
 
-    pub fn special_psi(&self) -> Tensor {
-        self.f_special_psi().unwrap()
+    pub fn f_special_psi(&self) -> Tensor {
+        self.special_psi().unwrap()
     }
 
-    pub fn special_psi_out(&self, out: &Tensor) -> Tensor {
-        self.f_special_psi_out(out).unwrap()
+    pub fn f_special_psi_out(&self, out: &Tensor) -> Tensor {
+        self.special_psi_out(out).unwrap()
     }
 
-    pub fn special_round(&self, decimals: i64) -> Tensor {
-        self.f_special_round(decimals).unwrap()
+    pub fn f_special_round(&self, decimals: i64) -> Tensor {
+        self.special_round(decimals).unwrap()
     }
 
-    pub fn special_round_out(&self, out: &Tensor, decimals: i64) -> Tensor {
-        self.f_special_round_out(out, decimals).unwrap()
+    pub fn f_special_round_out(&self, out: &Tensor, decimals: i64) -> Tensor {
+        self.special_round_out(out, decimals).unwrap()
     }
 
-    pub fn special_scaled_modified_bessel_k0(x: &Tensor) -> Tensor {
-        Tensor::f_special_scaled_modified_bessel_k0(x).unwrap()
+    pub fn f_special_scaled_modified_bessel_k0(x: &Tensor) -> Tensor {
+        Tensor::special_scaled_modified_bessel_k0(x).unwrap()
     }
 
-    pub fn special_scaled_modified_bessel_k0_out(out: &Tensor, x: &Tensor) -> Tensor {
-        Tensor::f_special_scaled_modified_bessel_k0_out(out, x).unwrap()
+    pub fn f_special_scaled_modified_bessel_k0_out(out: &Tensor, x: &Tensor) -> Tensor {
+        Tensor::special_scaled_modified_bessel_k0_out(out, x).unwrap()
     }
 
-    pub fn special_scaled_modified_bessel_k1(x: &Tensor) -> Tensor {
-        Tensor::f_special_scaled_modified_bessel_k1(x).unwrap()
+    pub fn f_special_scaled_modified_bessel_k1(x: &Tensor) -> Tensor {
+        Tensor::special_scaled_modified_bessel_k1(x).unwrap()
     }
 
-    pub fn special_scaled_modified_bessel_k1_out(out: &Tensor, x: &Tensor) -> Tensor {
-        Tensor::f_special_scaled_modified_bessel_k1_out(out, x).unwrap()
+    pub fn f_special_scaled_modified_bessel_k1_out(out: &Tensor, x: &Tensor) -> Tensor {
+        Tensor::special_scaled_modified_bessel_k1_out(out, x).unwrap()
     }
 
-    pub fn special_shifted_chebyshev_polynomial_t(x: &Tensor, n: &Tensor) -> Tensor {
-        Tensor::f_special_shifted_chebyshev_polynomial_t(x, n).unwrap()
+    pub fn f_special_shifted_chebyshev_polynomial_t(x: &Tensor, n: &Tensor) -> Tensor {
+        Tensor::special_shifted_chebyshev_polynomial_t(x, n).unwrap()
     }
 
-    pub fn special_shifted_chebyshev_polynomial_t_n_scalar<S: Into<Scalar>>(
+    pub fn f_special_shifted_chebyshev_polynomial_t_n_scalar<S: Into<Scalar>>(
         x: &Tensor,
         n: S,
     ) -> Tensor {
-        Tensor::f_special_shifted_chebyshev_polynomial_t_n_scalar(x, n).unwrap()
+        Tensor::special_shifted_chebyshev_polynomial_t_n_scalar(x, n).unwrap()
     }
 
-    pub fn special_shifted_chebyshev_polynomial_t_n_scalar_out<S: Into<Scalar>>(
-        out: &Tensor,
-        x: &Tensor,
-        n: S,
-    ) -> Tensor {
-        Tensor::f_special_shifted_chebyshev_polynomial_t_n_scalar_out(out, x, n).unwrap()
-    }
-
-    pub fn special_shifted_chebyshev_polynomial_t_out(
-        out: &Tensor,
-        x: &Tensor,
-        n: &Tensor,
-    ) -> Tensor {
-        Tensor::f_special_shifted_chebyshev_polynomial_t_out(out, x, n).unwrap()
-    }
-
-    pub fn special_shifted_chebyshev_polynomial_t_x_scalar<S: Into<Scalar>>(
-        x: S,
-        n: &Tensor,
-    ) -> Tensor {
-        Tensor::f_special_shifted_chebyshev_polynomial_t_x_scalar(x, n).unwrap()
-    }
-
-    pub fn special_shifted_chebyshev_polynomial_t_x_scalar_out<S: Into<Scalar>>(
-        out: &Tensor,
-        x: S,
-        n: &Tensor,
-    ) -> Tensor {
-        Tensor::f_special_shifted_chebyshev_polynomial_t_x_scalar_out(out, x, n).unwrap()
-    }
-
-    pub fn special_shifted_chebyshev_polynomial_u(x: &Tensor, n: &Tensor) -> Tensor {
-        Tensor::f_special_shifted_chebyshev_polynomial_u(x, n).unwrap()
-    }
-
-    pub fn special_shifted_chebyshev_polynomial_u_n_scalar<S: Into<Scalar>>(
-        x: &Tensor,
-        n: S,
-    ) -> Tensor {
-        Tensor::f_special_shifted_chebyshev_polynomial_u_n_scalar(x, n).unwrap()
-    }
-
-    pub fn special_shifted_chebyshev_polynomial_u_n_scalar_out<S: Into<Scalar>>(
+    pub fn f_special_shifted_chebyshev_polynomial_t_n_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: &Tensor,
         n: S,
     ) -> Tensor {
-        Tensor::f_special_shifted_chebyshev_polynomial_u_n_scalar_out(out, x, n).unwrap()
+        Tensor::special_shifted_chebyshev_polynomial_t_n_scalar_out(out, x, n).unwrap()
     }
 
-    pub fn special_shifted_chebyshev_polynomial_u_out(
+    pub fn f_special_shifted_chebyshev_polynomial_t_out(
         out: &Tensor,
         x: &Tensor,
         n: &Tensor,
     ) -> Tensor {
-        Tensor::f_special_shifted_chebyshev_polynomial_u_out(out, x, n).unwrap()
+        Tensor::special_shifted_chebyshev_polynomial_t_out(out, x, n).unwrap()
     }
 
-    pub fn special_shifted_chebyshev_polynomial_u_x_scalar<S: Into<Scalar>>(
+    pub fn f_special_shifted_chebyshev_polynomial_t_x_scalar<S: Into<Scalar>>(
         x: S,
         n: &Tensor,
     ) -> Tensor {
-        Tensor::f_special_shifted_chebyshev_polynomial_u_x_scalar(x, n).unwrap()
+        Tensor::special_shifted_chebyshev_polynomial_t_x_scalar(x, n).unwrap()
     }
 
-    pub fn special_shifted_chebyshev_polynomial_u_x_scalar_out<S: Into<Scalar>>(
+    pub fn f_special_shifted_chebyshev_polynomial_t_x_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: S,
         n: &Tensor,
     ) -> Tensor {
-        Tensor::f_special_shifted_chebyshev_polynomial_u_x_scalar_out(out, x, n).unwrap()
+        Tensor::special_shifted_chebyshev_polynomial_t_x_scalar_out(out, x, n).unwrap()
     }
 
-    pub fn special_shifted_chebyshev_polynomial_v(x: &Tensor, n: &Tensor) -> Tensor {
-        Tensor::f_special_shifted_chebyshev_polynomial_v(x, n).unwrap()
+    pub fn f_special_shifted_chebyshev_polynomial_u(x: &Tensor, n: &Tensor) -> Tensor {
+        Tensor::special_shifted_chebyshev_polynomial_u(x, n).unwrap()
     }
 
-    pub fn special_shifted_chebyshev_polynomial_v_n_scalar<S: Into<Scalar>>(
+    pub fn f_special_shifted_chebyshev_polynomial_u_n_scalar<S: Into<Scalar>>(
         x: &Tensor,
         n: S,
     ) -> Tensor {
-        Tensor::f_special_shifted_chebyshev_polynomial_v_n_scalar(x, n).unwrap()
+        Tensor::special_shifted_chebyshev_polynomial_u_n_scalar(x, n).unwrap()
     }
 
-    pub fn special_shifted_chebyshev_polynomial_v_n_scalar_out<S: Into<Scalar>>(
-        out: &Tensor,
-        x: &Tensor,
-        n: S,
-    ) -> Tensor {
-        Tensor::f_special_shifted_chebyshev_polynomial_v_n_scalar_out(out, x, n).unwrap()
-    }
-
-    pub fn special_shifted_chebyshev_polynomial_v_out(
-        out: &Tensor,
-        x: &Tensor,
-        n: &Tensor,
-    ) -> Tensor {
-        Tensor::f_special_shifted_chebyshev_polynomial_v_out(out, x, n).unwrap()
-    }
-
-    pub fn special_shifted_chebyshev_polynomial_v_x_scalar<S: Into<Scalar>>(
-        x: S,
-        n: &Tensor,
-    ) -> Tensor {
-        Tensor::f_special_shifted_chebyshev_polynomial_v_x_scalar(x, n).unwrap()
-    }
-
-    pub fn special_shifted_chebyshev_polynomial_v_x_scalar_out<S: Into<Scalar>>(
-        out: &Tensor,
-        x: S,
-        n: &Tensor,
-    ) -> Tensor {
-        Tensor::f_special_shifted_chebyshev_polynomial_v_x_scalar_out(out, x, n).unwrap()
-    }
-
-    pub fn special_shifted_chebyshev_polynomial_w(x: &Tensor, n: &Tensor) -> Tensor {
-        Tensor::f_special_shifted_chebyshev_polynomial_w(x, n).unwrap()
-    }
-
-    pub fn special_shifted_chebyshev_polynomial_w_n_scalar<S: Into<Scalar>>(
-        x: &Tensor,
-        n: S,
-    ) -> Tensor {
-        Tensor::f_special_shifted_chebyshev_polynomial_w_n_scalar(x, n).unwrap()
-    }
-
-    pub fn special_shifted_chebyshev_polynomial_w_n_scalar_out<S: Into<Scalar>>(
+    pub fn f_special_shifted_chebyshev_polynomial_u_n_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: &Tensor,
         n: S,
     ) -> Tensor {
-        Tensor::f_special_shifted_chebyshev_polynomial_w_n_scalar_out(out, x, n).unwrap()
+        Tensor::special_shifted_chebyshev_polynomial_u_n_scalar_out(out, x, n).unwrap()
     }
 
-    pub fn special_shifted_chebyshev_polynomial_w_out(
+    pub fn f_special_shifted_chebyshev_polynomial_u_out(
         out: &Tensor,
         x: &Tensor,
         n: &Tensor,
     ) -> Tensor {
-        Tensor::f_special_shifted_chebyshev_polynomial_w_out(out, x, n).unwrap()
+        Tensor::special_shifted_chebyshev_polynomial_u_out(out, x, n).unwrap()
     }
 
-    pub fn special_shifted_chebyshev_polynomial_w_x_scalar<S: Into<Scalar>>(
+    pub fn f_special_shifted_chebyshev_polynomial_u_x_scalar<S: Into<Scalar>>(
         x: S,
         n: &Tensor,
     ) -> Tensor {
-        Tensor::f_special_shifted_chebyshev_polynomial_w_x_scalar(x, n).unwrap()
+        Tensor::special_shifted_chebyshev_polynomial_u_x_scalar(x, n).unwrap()
     }
 
-    pub fn special_shifted_chebyshev_polynomial_w_x_scalar_out<S: Into<Scalar>>(
+    pub fn f_special_shifted_chebyshev_polynomial_u_x_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         x: S,
         n: &Tensor,
     ) -> Tensor {
-        Tensor::f_special_shifted_chebyshev_polynomial_w_x_scalar_out(out, x, n).unwrap()
+        Tensor::special_shifted_chebyshev_polynomial_u_x_scalar_out(out, x, n).unwrap()
     }
 
-    pub fn special_sinc(&self) -> Tensor {
-        self.f_special_sinc().unwrap()
+    pub fn f_special_shifted_chebyshev_polynomial_v(x: &Tensor, n: &Tensor) -> Tensor {
+        Tensor::special_shifted_chebyshev_polynomial_v(x, n).unwrap()
     }
 
-    pub fn special_sinc_out(&self, out: &Tensor) -> Tensor {
-        self.f_special_sinc_out(out).unwrap()
+    pub fn f_special_shifted_chebyshev_polynomial_v_n_scalar<S: Into<Scalar>>(
+        x: &Tensor,
+        n: S,
+    ) -> Tensor {
+        Tensor::special_shifted_chebyshev_polynomial_v_n_scalar(x, n).unwrap()
     }
 
-    pub fn special_softmax(&self, dim: i64, dtype: impl Into<Option<Kind>>) -> Tensor {
-        self.f_special_softmax(dim, dtype).unwrap()
+    pub fn f_special_shifted_chebyshev_polynomial_v_n_scalar_out<S: Into<Scalar>>(
+        out: &Tensor,
+        x: &Tensor,
+        n: S,
+    ) -> Tensor {
+        Tensor::special_shifted_chebyshev_polynomial_v_n_scalar_out(out, x, n).unwrap()
     }
 
-    pub fn special_spherical_bessel_j0(x: &Tensor) -> Tensor {
-        Tensor::f_special_spherical_bessel_j0(x).unwrap()
+    pub fn f_special_shifted_chebyshev_polynomial_v_out(
+        out: &Tensor,
+        x: &Tensor,
+        n: &Tensor,
+    ) -> Tensor {
+        Tensor::special_shifted_chebyshev_polynomial_v_out(out, x, n).unwrap()
     }
 
-    pub fn special_spherical_bessel_j0_out(out: &Tensor, x: &Tensor) -> Tensor {
-        Tensor::f_special_spherical_bessel_j0_out(out, x).unwrap()
+    pub fn f_special_shifted_chebyshev_polynomial_v_x_scalar<S: Into<Scalar>>(
+        x: S,
+        n: &Tensor,
+    ) -> Tensor {
+        Tensor::special_shifted_chebyshev_polynomial_v_x_scalar(x, n).unwrap()
     }
 
-    pub fn special_xlog1py(&self, other: &Tensor) -> Tensor {
-        self.f_special_xlog1py(other).unwrap()
+    pub fn f_special_shifted_chebyshev_polynomial_v_x_scalar_out<S: Into<Scalar>>(
+        out: &Tensor,
+        x: S,
+        n: &Tensor,
+    ) -> Tensor {
+        Tensor::special_shifted_chebyshev_polynomial_v_x_scalar_out(out, x, n).unwrap()
     }
 
-    pub fn special_xlog1py_other_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_special_xlog1py_other_scalar(other).unwrap()
+    pub fn f_special_shifted_chebyshev_polynomial_w(x: &Tensor, n: &Tensor) -> Tensor {
+        Tensor::special_shifted_chebyshev_polynomial_w(x, n).unwrap()
     }
 
-    pub fn special_xlog1py_other_scalar_out<S: Into<Scalar>>(
+    pub fn f_special_shifted_chebyshev_polynomial_w_n_scalar<S: Into<Scalar>>(
+        x: &Tensor,
+        n: S,
+    ) -> Tensor {
+        Tensor::special_shifted_chebyshev_polynomial_w_n_scalar(x, n).unwrap()
+    }
+
+    pub fn f_special_shifted_chebyshev_polynomial_w_n_scalar_out<S: Into<Scalar>>(
+        out: &Tensor,
+        x: &Tensor,
+        n: S,
+    ) -> Tensor {
+        Tensor::special_shifted_chebyshev_polynomial_w_n_scalar_out(out, x, n).unwrap()
+    }
+
+    pub fn f_special_shifted_chebyshev_polynomial_w_out(
+        out: &Tensor,
+        x: &Tensor,
+        n: &Tensor,
+    ) -> Tensor {
+        Tensor::special_shifted_chebyshev_polynomial_w_out(out, x, n).unwrap()
+    }
+
+    pub fn f_special_shifted_chebyshev_polynomial_w_x_scalar<S: Into<Scalar>>(
+        x: S,
+        n: &Tensor,
+    ) -> Tensor {
+        Tensor::special_shifted_chebyshev_polynomial_w_x_scalar(x, n).unwrap()
+    }
+
+    pub fn f_special_shifted_chebyshev_polynomial_w_x_scalar_out<S: Into<Scalar>>(
+        out: &Tensor,
+        x: S,
+        n: &Tensor,
+    ) -> Tensor {
+        Tensor::special_shifted_chebyshev_polynomial_w_x_scalar_out(out, x, n).unwrap()
+    }
+
+    pub fn f_special_sinc(&self) -> Tensor {
+        self.special_sinc().unwrap()
+    }
+
+    pub fn f_special_sinc_out(&self, out: &Tensor) -> Tensor {
+        self.special_sinc_out(out).unwrap()
+    }
+
+    pub fn f_special_softmax(&self, dim: i64, dtype: impl Into<Option<Kind>>) -> Tensor {
+        self.special_softmax(dim, dtype).unwrap()
+    }
+
+    pub fn f_special_spherical_bessel_j0(x: &Tensor) -> Tensor {
+        Tensor::special_spherical_bessel_j0(x).unwrap()
+    }
+
+    pub fn f_special_spherical_bessel_j0_out(out: &Tensor, x: &Tensor) -> Tensor {
+        Tensor::special_spherical_bessel_j0_out(out, x).unwrap()
+    }
+
+    pub fn f_special_xlog1py(&self, other: &Tensor) -> Tensor {
+        self.special_xlog1py(other).unwrap()
+    }
+
+    pub fn f_special_xlog1py_other_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.special_xlog1py_other_scalar(other).unwrap()
+    }
+
+    pub fn f_special_xlog1py_other_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
     ) -> Tensor {
-        self.f_special_xlog1py_other_scalar_out(out, other).unwrap()
+        self.special_xlog1py_other_scalar_out(out, other).unwrap()
     }
 
-    pub fn special_xlog1py_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_special_xlog1py_out(out, other).unwrap()
+    pub fn f_special_xlog1py_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.special_xlog1py_out(out, other).unwrap()
     }
 
-    pub fn special_xlog1py_self_scalar<S: Into<Scalar>>(self_scalar: S, other: &Tensor) -> Tensor {
-        Tensor::f_special_xlog1py_self_scalar(self_scalar, other).unwrap()
+    pub fn f_special_xlog1py_self_scalar<S: Into<Scalar>>(
+        self_scalar: S,
+        other: &Tensor,
+    ) -> Tensor {
+        Tensor::special_xlog1py_self_scalar(self_scalar, other).unwrap()
     }
 
-    pub fn special_xlog1py_self_scalar_out<S: Into<Scalar>>(
+    pub fn f_special_xlog1py_self_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         self_scalar: S,
         other: &Tensor,
     ) -> Tensor {
-        Tensor::f_special_xlog1py_self_scalar_out(out, self_scalar, other).unwrap()
+        Tensor::special_xlog1py_self_scalar_out(out, self_scalar, other).unwrap()
     }
 
-    pub fn special_xlogy(&self, other: &Tensor) -> Tensor {
-        self.f_special_xlogy(other).unwrap()
+    pub fn f_special_xlogy(&self, other: &Tensor) -> Tensor {
+        self.special_xlogy(other).unwrap()
     }
 
-    pub fn special_xlogy_other_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_special_xlogy_other_scalar(other).unwrap()
+    pub fn f_special_xlogy_other_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.special_xlogy_other_scalar(other).unwrap()
     }
 
-    pub fn special_xlogy_other_scalar_out<S: Into<Scalar>>(
+    pub fn f_special_xlogy_other_scalar_out<S: Into<Scalar>>(
         &self,
         out: &Tensor,
         other: S,
     ) -> Tensor {
-        self.f_special_xlogy_other_scalar_out(out, other).unwrap()
+        self.special_xlogy_other_scalar_out(out, other).unwrap()
     }
 
-    pub fn special_xlogy_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_special_xlogy_out(out, other).unwrap()
+    pub fn f_special_xlogy_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.special_xlogy_out(out, other).unwrap()
     }
 
-    pub fn special_xlogy_self_scalar<S: Into<Scalar>>(self_scalar: S, other: &Tensor) -> Tensor {
-        Tensor::f_special_xlogy_self_scalar(self_scalar, other).unwrap()
+    pub fn f_special_xlogy_self_scalar<S: Into<Scalar>>(self_scalar: S, other: &Tensor) -> Tensor {
+        Tensor::special_xlogy_self_scalar(self_scalar, other).unwrap()
     }
 
-    pub fn special_xlogy_self_scalar_out<S: Into<Scalar>>(
+    pub fn f_special_xlogy_self_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         self_scalar: S,
         other: &Tensor,
     ) -> Tensor {
-        Tensor::f_special_xlogy_self_scalar_out(out, self_scalar, other).unwrap()
+        Tensor::special_xlogy_self_scalar_out(out, self_scalar, other).unwrap()
     }
 
-    pub fn special_zeta(&self, other: &Tensor) -> Tensor {
-        self.f_special_zeta(other).unwrap()
+    pub fn f_special_zeta(&self, other: &Tensor) -> Tensor {
+        self.special_zeta(other).unwrap()
     }
 
-    pub fn special_zeta_other_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_special_zeta_other_scalar(other).unwrap()
+    pub fn f_special_zeta_other_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.special_zeta_other_scalar(other).unwrap()
     }
 
-    pub fn special_zeta_other_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
-        self.f_special_zeta_other_scalar_out(out, other).unwrap()
+    pub fn f_special_zeta_other_scalar_out<S: Into<Scalar>>(
+        &self,
+        out: &Tensor,
+        other: S,
+    ) -> Tensor {
+        self.special_zeta_other_scalar_out(out, other).unwrap()
     }
 
-    pub fn special_zeta_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_special_zeta_out(out, other).unwrap()
+    pub fn f_special_zeta_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.special_zeta_out(out, other).unwrap()
     }
 
-    pub fn special_zeta_self_scalar<S: Into<Scalar>>(self_scalar: S, other: &Tensor) -> Tensor {
-        Tensor::f_special_zeta_self_scalar(self_scalar, other).unwrap()
+    pub fn f_special_zeta_self_scalar<S: Into<Scalar>>(self_scalar: S, other: &Tensor) -> Tensor {
+        Tensor::special_zeta_self_scalar(self_scalar, other).unwrap()
     }
 
-    pub fn special_zeta_self_scalar_out<S: Into<Scalar>>(
+    pub fn f_special_zeta_self_scalar_out<S: Into<Scalar>>(
         out: &Tensor,
         self_scalar: S,
         other: &Tensor,
     ) -> Tensor {
-        Tensor::f_special_zeta_self_scalar_out(out, self_scalar, other).unwrap()
+        Tensor::special_zeta_self_scalar_out(out, self_scalar, other).unwrap()
     }
 
-    pub fn split(&self, split_size: i64, dim: i64) -> Vec<Tensor> {
-        self.f_split(split_size, dim).unwrap()
+    pub fn f_split(&self, split_size: i64, dim: i64) -> Vec<Tensor> {
+        self.split(split_size, dim).unwrap()
     }
 
-    pub fn split_copy(&self, split_size: i64, dim: i64) -> Vec<Tensor> {
-        self.f_split_copy(split_size, dim).unwrap()
+    pub fn f_split_copy(&self, split_size: i64, dim: i64) -> Vec<Tensor> {
+        self.split_copy(split_size, dim).unwrap()
     }
 
-    pub fn split_copy_tensor_out<T: Borrow<Tensor>>(&self, out: &[T], split_size: i64, dim: i64) {
-        self.f_split_copy_tensor_out(out, split_size, dim).unwrap()
+    pub fn f_split_copy_tensor_out<T: Borrow<Tensor>>(&self, out: &[T], split_size: i64, dim: i64) {
+        self.split_copy_tensor_out(out, split_size, dim).unwrap()
     }
 
-    pub fn split_sizes(&self, split_size: impl IntList, dim: i64) -> Vec<Tensor> {
-        self.f_split_sizes(split_size, dim).unwrap()
+    pub fn f_split_sizes(&self, split_size: impl IntList, dim: i64) -> Vec<Tensor> {
+        self.split_sizes(split_size, dim).unwrap()
     }
 
-    pub fn split_with_sizes(&self, split_sizes: impl IntList, dim: i64) -> Vec<Tensor> {
-        self.f_split_with_sizes(split_sizes, dim).unwrap()
+    pub fn f_split_with_sizes(&self, split_sizes: impl IntList, dim: i64) -> Vec<Tensor> {
+        self.split_with_sizes(split_sizes, dim).unwrap()
     }
 
-    pub fn split_with_sizes_copy(&self, split_sizes: impl IntList, dim: i64) -> Vec<Tensor> {
-        self.f_split_with_sizes_copy(split_sizes, dim).unwrap()
+    pub fn f_split_with_sizes_copy(&self, split_sizes: impl IntList, dim: i64) -> Vec<Tensor> {
+        self.split_with_sizes_copy(split_sizes, dim).unwrap()
     }
 
-    pub fn split_with_sizes_copy_out<T: Borrow<Tensor>>(
+    pub fn f_split_with_sizes_copy_out<T: Borrow<Tensor>>(
         &self,
         out: &[T],
         split_sizes: impl IntList,
         dim: i64,
     ) {
-        self.f_split_with_sizes_copy_out(out, split_sizes, dim).unwrap()
+        self.split_with_sizes_copy_out(out, split_sizes, dim).unwrap()
     }
 
-    pub fn sqrt(&self) -> Tensor {
-        self.f_sqrt().unwrap()
+    pub fn f_sqrt(&self) -> Tensor {
+        self.sqrt().unwrap()
     }
 
-    pub fn sqrt_(&mut self) -> Tensor {
-        self.f_sqrt_().unwrap()
+    pub fn f_sqrt_(&mut self) -> Tensor {
+        self.sqrt_().unwrap()
     }
 
-    pub fn sqrt_out(&self, out: &Tensor) -> Tensor {
-        self.f_sqrt_out(out).unwrap()
+    pub fn f_sqrt_out(&self, out: &Tensor) -> Tensor {
+        self.sqrt_out(out).unwrap()
     }
 
-    pub fn square(&self) -> Tensor {
-        self.f_square().unwrap()
+    pub fn f_square(&self) -> Tensor {
+        self.square().unwrap()
     }
 
-    pub fn square_(&mut self) -> Tensor {
-        self.f_square_().unwrap()
+    pub fn f_square_(&mut self) -> Tensor {
+        self.square_().unwrap()
     }
 
-    pub fn square_out(&self, out: &Tensor) -> Tensor {
-        self.f_square_out(out).unwrap()
+    pub fn f_square_out(&self, out: &Tensor) -> Tensor {
+        self.square_out(out).unwrap()
     }
 
-    pub fn squeeze(&self) -> Tensor {
-        self.f_squeeze().unwrap()
+    pub fn f_squeeze(&self) -> Tensor {
+        self.squeeze().unwrap()
     }
 
-    pub fn squeeze_(&mut self) -> Tensor {
-        self.f_squeeze_().unwrap()
+    pub fn f_squeeze_(&mut self) -> Tensor {
+        self.squeeze_().unwrap()
     }
 
-    pub fn squeeze_copy(&self) -> Tensor {
-        self.f_squeeze_copy().unwrap()
+    pub fn f_squeeze_copy(&self) -> Tensor {
+        self.squeeze_copy().unwrap()
     }
 
-    pub fn squeeze_copy_dim(&self, dim: i64) -> Tensor {
-        self.f_squeeze_copy_dim(dim).unwrap()
+    pub fn f_squeeze_copy_dim(&self, dim: i64) -> Tensor {
+        self.squeeze_copy_dim(dim).unwrap()
     }
 
-    pub fn squeeze_copy_dim_out(&self, out: &Tensor, dim: i64) -> Tensor {
-        self.f_squeeze_copy_dim_out(out, dim).unwrap()
+    pub fn f_squeeze_copy_dim_out(&self, out: &Tensor, dim: i64) -> Tensor {
+        self.squeeze_copy_dim_out(out, dim).unwrap()
     }
 
-    pub fn squeeze_copy_dims(&self, dim: impl IntList) -> Tensor {
-        self.f_squeeze_copy_dims(dim).unwrap()
+    pub fn f_squeeze_copy_dims(&self, dim: impl IntList) -> Tensor {
+        self.squeeze_copy_dims(dim).unwrap()
     }
 
-    pub fn squeeze_copy_dims_out(&self, out: &Tensor, dim: impl IntList) -> Tensor {
-        self.f_squeeze_copy_dims_out(out, dim).unwrap()
+    pub fn f_squeeze_copy_dims_out(&self, out: &Tensor, dim: impl IntList) -> Tensor {
+        self.squeeze_copy_dims_out(out, dim).unwrap()
     }
 
-    pub fn squeeze_copy_out(&self, out: &Tensor) -> Tensor {
-        self.f_squeeze_copy_out(out).unwrap()
+    pub fn f_squeeze_copy_out(&self, out: &Tensor) -> Tensor {
+        self.squeeze_copy_out(out).unwrap()
     }
 
-    pub fn squeeze_dim(&self, dim: i64) -> Tensor {
-        self.f_squeeze_dim(dim).unwrap()
+    pub fn f_squeeze_dim(&self, dim: i64) -> Tensor {
+        self.squeeze_dim(dim).unwrap()
     }
 
-    pub fn squeeze_dim_(&mut self, dim: i64) -> Tensor {
-        self.f_squeeze_dim_(dim).unwrap()
+    pub fn f_squeeze_dim_(&mut self, dim: i64) -> Tensor {
+        self.squeeze_dim_(dim).unwrap()
     }
 
-    pub fn squeeze_dims(&self, dim: impl IntList) -> Tensor {
-        self.f_squeeze_dims(dim).unwrap()
+    pub fn f_squeeze_dims(&self, dim: impl IntList) -> Tensor {
+        self.squeeze_dims(dim).unwrap()
     }
 
-    pub fn squeeze_dims_(&mut self, dim: impl IntList) -> Tensor {
-        self.f_squeeze_dims_(dim).unwrap()
+    pub fn f_squeeze_dims_(&mut self, dim: impl IntList) -> Tensor {
+        self.squeeze_dims_(dim).unwrap()
     }
 
-    pub fn sspaddmm(&self, mat1: &Tensor, mat2: &Tensor) -> Tensor {
-        self.f_sspaddmm(mat1, mat2).unwrap()
+    pub fn f_sspaddmm(&self, mat1: &Tensor, mat2: &Tensor) -> Tensor {
+        self.sspaddmm(mat1, mat2).unwrap()
     }
 
-    pub fn sspaddmm_out(&self, out: &Tensor, mat1: &Tensor, mat2: &Tensor) -> Tensor {
-        self.f_sspaddmm_out(out, mat1, mat2).unwrap()
+    pub fn f_sspaddmm_out(&self, out: &Tensor, mat1: &Tensor, mat2: &Tensor) -> Tensor {
+        self.sspaddmm_out(out, mat1, mat2).unwrap()
     }
 
-    pub fn stack<T: Borrow<Tensor>>(tensors: &[T], dim: i64) -> Tensor {
-        Tensor::f_stack(tensors, dim).unwrap()
+    pub fn f_stack<T: Borrow<Tensor>>(tensors: &[T], dim: i64) -> Tensor {
+        Tensor::stack(tensors, dim).unwrap()
     }
 
-    pub fn stack_out<T: Borrow<Tensor>>(out: &Tensor, tensors: &[T], dim: i64) -> Tensor {
-        Tensor::f_stack_out(out, tensors, dim).unwrap()
+    pub fn f_stack_out<T: Borrow<Tensor>>(out: &Tensor, tensors: &[T], dim: i64) -> Tensor {
+        Tensor::stack_out(out, tensors, dim).unwrap()
     }
 
-    pub fn std(&self, unbiased: bool) -> Tensor {
-        self.f_std(unbiased).unwrap()
+    pub fn f_std(&self, unbiased: bool) -> Tensor {
+        self.std(unbiased).unwrap()
     }
 
-    pub fn std_correction(
+    pub fn f_std_correction(
         &self,
         dim: impl IntListOption,
         correction: impl Into<Option<i64>>,
         keepdim: bool,
     ) -> Tensor {
-        self.f_std_correction(dim, correction, keepdim).unwrap()
+        self.std_correction(dim, correction, keepdim).unwrap()
     }
 
-    pub fn std_correction_out(
+    pub fn f_std_correction_out(
         &self,
         out: &Tensor,
         dim: impl IntListOption,
         correction: impl Into<Option<i64>>,
         keepdim: bool,
     ) -> Tensor {
-        self.f_std_correction_out(out, dim, correction, keepdim).unwrap()
+        self.std_correction_out(out, dim, correction, keepdim).unwrap()
     }
 
-    pub fn std_dim(&self, dim: impl IntListOption, unbiased: bool, keepdim: bool) -> Tensor {
-        self.f_std_dim(dim, unbiased, keepdim).unwrap()
+    pub fn f_std_dim(&self, dim: impl IntListOption, unbiased: bool, keepdim: bool) -> Tensor {
+        self.std_dim(dim, unbiased, keepdim).unwrap()
     }
 
-    pub fn std_mean(&self, unbiased: bool) -> (Tensor, Tensor) {
-        self.f_std_mean(unbiased).unwrap()
+    pub fn f_std_mean(&self, unbiased: bool) -> (Tensor, Tensor) {
+        self.std_mean(unbiased).unwrap()
     }
 
-    pub fn std_mean_correction(
+    pub fn f_std_mean_correction(
         &self,
         dim: impl IntListOption,
         correction: impl Into<Option<i64>>,
         keepdim: bool,
     ) -> (Tensor, Tensor) {
-        self.f_std_mean_correction(dim, correction, keepdim).unwrap()
+        self.std_mean_correction(dim, correction, keepdim).unwrap()
     }
 
-    pub fn std_mean_correction_out(
+    pub fn f_std_mean_correction_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -16930,29 +17005,29 @@ impl Tensor {
         correction: impl Into<Option<i64>>,
         keepdim: bool,
     ) -> (Tensor, Tensor) {
-        self.f_std_mean_correction_out(out0, out1, dim, correction, keepdim).unwrap()
+        self.std_mean_correction_out(out0, out1, dim, correction, keepdim).unwrap()
     }
 
-    pub fn std_mean_dim(
+    pub fn f_std_mean_dim(
         &self,
         dim: impl IntListOption,
         unbiased: bool,
         keepdim: bool,
     ) -> (Tensor, Tensor) {
-        self.f_std_mean_dim(dim, unbiased, keepdim).unwrap()
+        self.std_mean_dim(dim, unbiased, keepdim).unwrap()
     }
 
-    pub fn std_out(
+    pub fn f_std_out(
         &self,
         out: &Tensor,
         dim: impl IntListOption,
         unbiased: bool,
         keepdim: bool,
     ) -> Tensor {
-        self.f_std_out(out, dim, unbiased, keepdim).unwrap()
+        self.std_out(out, dim, unbiased, keepdim).unwrap()
     }
 
-    pub fn stft<T: Borrow<Tensor>>(
+    pub fn f_stft<T: Borrow<Tensor>>(
         &self,
         n_fft: i64,
         hop_length: impl Into<Option<i64>>,
@@ -16962,11 +17037,11 @@ impl Tensor {
         onesided: bool,
         return_complex: bool,
     ) -> Tensor {
-        self.f_stft(n_fft, hop_length, win_length, window, normalized, onesided, return_complex)
+        self.stft(n_fft, hop_length, win_length, window, normalized, onesided, return_complex)
             .unwrap()
     }
 
-    pub fn stft_center<T: Borrow<Tensor>>(
+    pub fn f_stft_center<T: Borrow<Tensor>>(
         &self,
         n_fft: i64,
         hop_length: impl Into<Option<i64>>,
@@ -16978,7 +17053,7 @@ impl Tensor {
         onesided: bool,
         return_complex: bool,
     ) -> Tensor {
-        self.f_stft_center(
+        self.stft_center(
             n_fft,
             hop_length,
             win_length,
@@ -16992,86 +17067,86 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn g_sub(&self, other: &Tensor) -> Tensor {
-        self.f_sub(other).unwrap()
+    pub fn f_sub(&self, other: &Tensor) -> Tensor {
+        self.g_sub(other).unwrap()
     }
 
-    pub fn g_sub_(&mut self, other: &Tensor) -> Tensor {
-        self.f_sub_(other).unwrap()
+    pub fn f_sub_(&mut self, other: &Tensor) -> Tensor {
+        self.g_sub_(other).unwrap()
     }
 
-    pub fn sub_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_sub_out(out, other).unwrap()
+    pub fn f_sub_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.sub_out(out, other).unwrap()
     }
 
-    pub fn g_sub_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_sub_scalar(other).unwrap()
+    pub fn f_sub_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.g_sub_scalar(other).unwrap()
     }
 
-    pub fn g_sub_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_sub_scalar_(other).unwrap()
+    pub fn f_sub_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.g_sub_scalar_(other).unwrap()
     }
 
-    pub fn sub_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
-        self.f_sub_scalar_out(out, other).unwrap()
+    pub fn f_sub_scalar_out<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
+        self.sub_scalar_out(out, other).unwrap()
     }
 
-    pub fn subtract(&self, other: &Tensor) -> Tensor {
-        self.f_subtract(other).unwrap()
+    pub fn f_subtract(&self, other: &Tensor) -> Tensor {
+        self.subtract(other).unwrap()
     }
 
-    pub fn subtract_(&mut self, other: &Tensor) -> Tensor {
-        self.f_subtract_(other).unwrap()
+    pub fn f_subtract_(&mut self, other: &Tensor) -> Tensor {
+        self.subtract_(other).unwrap()
     }
 
-    pub fn subtract_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_subtract_out(out, other).unwrap()
+    pub fn f_subtract_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.subtract_out(out, other).unwrap()
     }
 
-    pub fn subtract_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_subtract_scalar(other).unwrap()
+    pub fn f_subtract_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.subtract_scalar(other).unwrap()
     }
 
-    pub fn subtract_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_subtract_scalar_(other).unwrap()
+    pub fn f_subtract_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.subtract_scalar_(other).unwrap()
     }
 
-    pub fn sum(&self, dtype: impl Into<Option<Kind>>) -> Tensor {
-        self.f_sum(dtype).unwrap()
+    pub fn f_sum(&self, dtype: impl Into<Option<Kind>>) -> Tensor {
+        self.sum(dtype).unwrap()
     }
 
-    pub fn sum_dim_intlist(
+    pub fn f_sum_dim_intlist(
         &self,
         dim: impl IntListOption,
         keepdim: bool,
         dtype: impl Into<Option<Kind>>,
     ) -> Tensor {
-        self.f_sum_dim_intlist(dim, keepdim, dtype).unwrap()
+        self.sum_dim_intlist(dim, keepdim, dtype).unwrap()
     }
 
-    pub fn sum_intlist_out(
+    pub fn f_sum_intlist_out(
         &self,
         out: &Tensor,
         dim: impl IntListOption,
         keepdim: bool,
         dtype: impl Into<Option<Kind>>,
     ) -> Tensor {
-        self.f_sum_intlist_out(out, dim, keepdim, dtype).unwrap()
+        self.sum_intlist_out(out, dim, keepdim, dtype).unwrap()
     }
 
-    pub fn sum_out(&self, out: &Tensor, dtype: impl Into<Option<Kind>>) -> Tensor {
-        self.f_sum_out(out, dtype).unwrap()
+    pub fn f_sum_out(&self, out: &Tensor, dtype: impl Into<Option<Kind>>) -> Tensor {
+        self.sum_out(out, dtype).unwrap()
     }
 
-    pub fn sum_to_size(&self, size: impl IntList) -> Tensor {
-        self.f_sum_to_size(size).unwrap()
+    pub fn f_sum_to_size(&self, size: impl IntList) -> Tensor {
+        self.sum_to_size(size).unwrap()
     }
 
-    pub fn svd(&self, some: bool, compute_uv: bool) -> (Tensor, Tensor, Tensor) {
-        self.f_svd(some, compute_uv).unwrap()
+    pub fn f_svd(&self, some: bool, compute_uv: bool) -> (Tensor, Tensor, Tensor) {
+        self.svd(some, compute_uv).unwrap()
     }
 
-    pub fn svd_u(
+    pub fn f_svd_u(
         &self,
         u: &Tensor,
         s: &Tensor,
@@ -17079,312 +17154,312 @@ impl Tensor {
         some: bool,
         compute_uv: bool,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_svd_u(u, s, v, some, compute_uv).unwrap()
+        self.svd_u(u, s, v, some, compute_uv).unwrap()
     }
 
-    pub fn swapaxes(&self, axis0: i64, axis1: i64) -> Tensor {
-        self.f_swapaxes(axis0, axis1).unwrap()
+    pub fn f_swapaxes(&self, axis0: i64, axis1: i64) -> Tensor {
+        self.swapaxes(axis0, axis1).unwrap()
     }
 
-    pub fn swapaxes_(&mut self, axis0: i64, axis1: i64) -> Tensor {
-        self.f_swapaxes_(axis0, axis1).unwrap()
+    pub fn f_swapaxes_(&mut self, axis0: i64, axis1: i64) -> Tensor {
+        self.swapaxes_(axis0, axis1).unwrap()
     }
 
-    pub fn swapdims(&self, dim0: i64, dim1: i64) -> Tensor {
-        self.f_swapdims(dim0, dim1).unwrap()
+    pub fn f_swapdims(&self, dim0: i64, dim1: i64) -> Tensor {
+        self.swapdims(dim0, dim1).unwrap()
     }
 
-    pub fn swapdims_(&mut self, dim0: i64, dim1: i64) -> Tensor {
-        self.f_swapdims_(dim0, dim1).unwrap()
+    pub fn f_swapdims_(&mut self, dim0: i64, dim1: i64) -> Tensor {
+        self.swapdims_(dim0, dim1).unwrap()
     }
 
-    pub fn tr(&self) -> Tensor {
-        self.f_tr().unwrap()
+    pub fn f_tr(&self) -> Tensor {
+        self.tr().unwrap()
     }
 
-    pub fn t_(&mut self) -> Tensor {
-        self.f_t_().unwrap()
+    pub fn f_t_(&mut self) -> Tensor {
+        self.t_().unwrap()
     }
 
-    pub fn t_copy(&self) -> Tensor {
-        self.f_t_copy().unwrap()
+    pub fn f_t_copy(&self) -> Tensor {
+        self.t_copy().unwrap()
     }
 
-    pub fn t_copy_out(&self, out: &Tensor) -> Tensor {
-        self.f_t_copy_out(out).unwrap()
+    pub fn f_t_copy_out(&self, out: &Tensor) -> Tensor {
+        self.t_copy_out(out).unwrap()
     }
 
-    pub fn take(&self, index: &Tensor) -> Tensor {
-        self.f_take(index).unwrap()
+    pub fn f_take(&self, index: &Tensor) -> Tensor {
+        self.take(index).unwrap()
     }
 
-    pub fn take_along_dim(&self, indices: &Tensor, dim: impl Into<Option<i64>>) -> Tensor {
-        self.f_take_along_dim(indices, dim).unwrap()
+    pub fn f_take_along_dim(&self, indices: &Tensor, dim: impl Into<Option<i64>>) -> Tensor {
+        self.take_along_dim(indices, dim).unwrap()
     }
 
-    pub fn take_along_dim_out(
+    pub fn f_take_along_dim_out(
         &self,
         out: &Tensor,
         indices: &Tensor,
         dim: impl Into<Option<i64>>,
     ) -> Tensor {
-        self.f_take_along_dim_out(out, indices, dim).unwrap()
+        self.take_along_dim_out(out, indices, dim).unwrap()
     }
 
-    pub fn take_out(&self, out: &Tensor, index: &Tensor) -> Tensor {
-        self.f_take_out(out, index).unwrap()
+    pub fn f_take_out(&self, out: &Tensor, index: &Tensor) -> Tensor {
+        self.take_out(out, index).unwrap()
     }
 
-    pub fn tan(&self) -> Tensor {
-        self.f_tan().unwrap()
+    pub fn f_tan(&self) -> Tensor {
+        self.tan().unwrap()
     }
 
-    pub fn tan_(&mut self) -> Tensor {
-        self.f_tan_().unwrap()
+    pub fn f_tan_(&mut self) -> Tensor {
+        self.tan_().unwrap()
     }
 
-    pub fn tan_out(&self, out: &Tensor) -> Tensor {
-        self.f_tan_out(out).unwrap()
+    pub fn f_tan_out(&self, out: &Tensor) -> Tensor {
+        self.tan_out(out).unwrap()
     }
 
-    pub fn tanh(&self) -> Tensor {
-        self.f_tanh().unwrap()
+    pub fn f_tanh(&self) -> Tensor {
+        self.tanh().unwrap()
     }
 
-    pub fn tanh_(&mut self) -> Tensor {
-        self.f_tanh_().unwrap()
+    pub fn f_tanh_(&mut self) -> Tensor {
+        self.tanh_().unwrap()
     }
 
-    pub fn tanh_backward(grad_output: &Tensor, output: &Tensor) -> Tensor {
-        Tensor::f_tanh_backward(grad_output, output).unwrap()
+    pub fn f_tanh_backward(grad_output: &Tensor, output: &Tensor) -> Tensor {
+        Tensor::tanh_backward(grad_output, output).unwrap()
     }
 
-    pub fn tanh_backward_grad_input(
+    pub fn f_tanh_backward_grad_input(
         grad_input: &Tensor,
         grad_output: &Tensor,
         output: &Tensor,
     ) -> Tensor {
-        Tensor::f_tanh_backward_grad_input(grad_input, grad_output, output).unwrap()
+        Tensor::tanh_backward_grad_input(grad_input, grad_output, output).unwrap()
     }
 
-    pub fn tanh_out(&self, out: &Tensor) -> Tensor {
-        self.f_tanh_out(out).unwrap()
+    pub fn f_tanh_out(&self, out: &Tensor) -> Tensor {
+        self.tanh_out(out).unwrap()
     }
 
-    pub fn tensor_split(&self, sections: i64, dim: i64) -> Vec<Tensor> {
-        self.f_tensor_split(sections, dim).unwrap()
+    pub fn f_tensor_split(&self, sections: i64, dim: i64) -> Vec<Tensor> {
+        self.tensor_split(sections, dim).unwrap()
     }
 
-    pub fn tensor_split_indices(&self, indices: impl IntList, dim: i64) -> Vec<Tensor> {
-        self.f_tensor_split_indices(indices, dim).unwrap()
+    pub fn f_tensor_split_indices(&self, indices: impl IntList, dim: i64) -> Vec<Tensor> {
+        self.tensor_split_indices(indices, dim).unwrap()
     }
 
-    pub fn tensor_split_tensor_indices_or_sections(
+    pub fn f_tensor_split_tensor_indices_or_sections(
         &self,
         tensor_indices_or_sections: &Tensor,
         dim: i64,
     ) -> Vec<Tensor> {
-        self.f_tensor_split_tensor_indices_or_sections(tensor_indices_or_sections, dim).unwrap()
+        self.tensor_split_tensor_indices_or_sections(tensor_indices_or_sections, dim).unwrap()
     }
 
-    pub fn tensordot(
+    pub fn f_tensordot(
         &self,
         other: &Tensor,
         dims_self: impl IntList,
         dims_other: impl IntList,
     ) -> Tensor {
-        self.f_tensordot(other, dims_self, dims_other).unwrap()
+        self.tensordot(other, dims_self, dims_other).unwrap()
     }
 
-    pub fn tensordot_out(
+    pub fn f_tensordot_out(
         &self,
         out: &Tensor,
         other: &Tensor,
         dims_self: impl IntList,
         dims_other: impl IntList,
     ) -> Tensor {
-        self.f_tensordot_out(out, other, dims_self, dims_other).unwrap()
+        self.tensordot_out(out, other, dims_self, dims_other).unwrap()
     }
 
-    pub fn threshold<S: Into<Scalar>>(&self, threshold: S, value: S) -> Tensor {
-        self.f_threshold(threshold, value).unwrap()
+    pub fn f_threshold<S: Into<Scalar>>(&self, threshold: S, value: S) -> Tensor {
+        self.threshold(threshold, value).unwrap()
     }
 
-    pub fn threshold_<S: Into<Scalar>>(&mut self, threshold: S, value: S) -> Tensor {
-        self.f_threshold_(threshold, value).unwrap()
+    pub fn f_threshold_<S: Into<Scalar>>(&mut self, threshold: S, value: S) -> Tensor {
+        self.threshold_(threshold, value).unwrap()
     }
 
-    pub fn threshold_backward<S: Into<Scalar>>(
+    pub fn f_threshold_backward<S: Into<Scalar>>(
         &self,
         grad_output: &Tensor,
         threshold: S,
     ) -> Tensor {
-        self.f_threshold_backward(grad_output, threshold).unwrap()
+        self.threshold_backward(grad_output, threshold).unwrap()
     }
 
-    pub fn threshold_backward_grad_input<S: Into<Scalar>>(
+    pub fn f_threshold_backward_grad_input<S: Into<Scalar>>(
         &self,
         grad_input: &Tensor,
         grad_output: &Tensor,
         threshold: S,
     ) -> Tensor {
-        self.f_threshold_backward_grad_input(grad_input, grad_output, threshold).unwrap()
+        self.threshold_backward_grad_input(grad_input, grad_output, threshold).unwrap()
     }
 
-    pub fn threshold_out<S: Into<Scalar>>(&self, out: &Tensor, threshold: S, value: S) -> Tensor {
-        self.f_threshold_out(out, threshold, value).unwrap()
+    pub fn f_threshold_out<S: Into<Scalar>>(&self, out: &Tensor, threshold: S, value: S) -> Tensor {
+        self.threshold_out(out, threshold, value).unwrap()
     }
 
-    pub fn tile(&self, dims: impl IntList) -> Tensor {
-        self.f_tile(dims).unwrap()
+    pub fn f_tile(&self, dims: impl IntList) -> Tensor {
+        self.tile(dims).unwrap()
     }
 
-    pub fn to(&self, device: Device) -> Tensor {
-        self.f_to(device).unwrap()
+    pub fn f_to(&self, device: Device) -> Tensor {
+        self.to(device).unwrap()
     }
 
-    pub fn to_dense(&self, dtype: impl Into<Option<Kind>>) -> Tensor {
-        self.f_to_dense(dtype).unwrap()
+    pub fn f_to_dense(&self, dtype: impl Into<Option<Kind>>) -> Tensor {
+        self.to_dense(dtype).unwrap()
     }
 
-    pub fn to_dense_backward(&self, grad: &Tensor) -> Tensor {
-        self.f_to_dense_backward(grad).unwrap()
+    pub fn f_to_dense_backward(&self, grad: &Tensor) -> Tensor {
+        self.to_dense_backward(grad).unwrap()
     }
 
-    pub fn to_device_(
+    pub fn f_to_device_(
         &self,
         device: Device,
         dtype: Kind,
         non_blocking: bool,
         copy: bool,
     ) -> Tensor {
-        self.f_to_device_(device, dtype, non_blocking, copy).unwrap()
+        self.to_device_(device, dtype, non_blocking, copy).unwrap()
     }
 
-    pub fn to_dtype(&self, dtype: Kind, non_blocking: bool, copy: bool) -> Tensor {
-        self.f_to_dtype(dtype, non_blocking, copy).unwrap()
+    pub fn f_to_dtype(&self, dtype: Kind, non_blocking: bool, copy: bool) -> Tensor {
+        self.to_dtype(dtype, non_blocking, copy).unwrap()
     }
 
-    pub fn to_dtype_layout(
+    pub fn f_to_dtype_layout(
         &self,
         options: (Kind, Device),
         non_blocking: bool,
         copy: bool,
     ) -> Tensor {
-        self.f_to_dtype_layout(options, non_blocking, copy).unwrap()
+        self.to_dtype_layout(options, non_blocking, copy).unwrap()
     }
 
-    pub fn g_to_mkldnn(&self, dtype: impl Into<Option<Kind>>) -> Tensor {
-        self.f_to_mkldnn(dtype).unwrap()
+    pub fn f_to_mkldnn(&self, dtype: impl Into<Option<Kind>>) -> Tensor {
+        self.g_to_mkldnn(dtype).unwrap()
     }
 
-    pub fn to_mkldnn_backward(&self, grad: &Tensor) -> Tensor {
-        self.f_to_mkldnn_backward(grad).unwrap()
+    pub fn f_to_mkldnn_backward(&self, grad: &Tensor) -> Tensor {
+        self.to_mkldnn_backward(grad).unwrap()
     }
 
-    pub fn to_mkldnn_out(&self, out: &Tensor, dtype: impl Into<Option<Kind>>) -> Tensor {
-        self.f_to_mkldnn_out(out, dtype).unwrap()
+    pub fn f_to_mkldnn_out(&self, out: &Tensor, dtype: impl Into<Option<Kind>>) -> Tensor {
+        self.to_mkldnn_out(out, dtype).unwrap()
     }
 
-    pub fn to_other(&self, other: &Tensor, non_blocking: bool, copy: bool) -> Tensor {
-        self.f_to_other(other, non_blocking, copy).unwrap()
+    pub fn f_to_other(&self, other: &Tensor, non_blocking: bool, copy: bool) -> Tensor {
+        self.to_other(other, non_blocking, copy).unwrap()
     }
 
-    pub fn to_padded_tensor(&self, padding: f64, output_size: impl IntListOption) -> Tensor {
-        self.f_to_padded_tensor(padding, output_size).unwrap()
+    pub fn f_to_padded_tensor(&self, padding: f64, output_size: impl IntListOption) -> Tensor {
+        self.to_padded_tensor(padding, output_size).unwrap()
     }
 
-    pub fn to_padded_tensor_out(
+    pub fn f_to_padded_tensor_out(
         &self,
         out: &Tensor,
         padding: f64,
         output_size: impl IntListOption,
     ) -> Tensor {
-        self.f_to_padded_tensor_out(out, padding, output_size).unwrap()
+        self.to_padded_tensor_out(out, padding, output_size).unwrap()
     }
 
-    pub fn to_sparse(
+    pub fn f_to_sparse(
         &self,
         layout: Option<Layout>,
         blocksize: impl IntListOption,
         dense_dim: impl Into<Option<i64>>,
     ) -> Tensor {
-        self.f_to_sparse(layout, blocksize, dense_dim).unwrap()
+        self.to_sparse(layout, blocksize, dense_dim).unwrap()
     }
 
-    pub fn to_sparse_bsc(
+    pub fn f_to_sparse_bsc(
         &self,
         blocksize: impl IntList,
         dense_dim: impl Into<Option<i64>>,
     ) -> Tensor {
-        self.f_to_sparse_bsc(blocksize, dense_dim).unwrap()
+        self.to_sparse_bsc(blocksize, dense_dim).unwrap()
     }
 
-    pub fn to_sparse_bsc_out(
-        &self,
-        out: &Tensor,
-        blocksize: impl IntList,
-        dense_dim: impl Into<Option<i64>>,
-    ) -> Tensor {
-        self.f_to_sparse_bsc_out(out, blocksize, dense_dim).unwrap()
-    }
-
-    pub fn to_sparse_bsr(
-        &self,
-        blocksize: impl IntList,
-        dense_dim: impl Into<Option<i64>>,
-    ) -> Tensor {
-        self.f_to_sparse_bsr(blocksize, dense_dim).unwrap()
-    }
-
-    pub fn to_sparse_bsr_out(
+    pub fn f_to_sparse_bsc_out(
         &self,
         out: &Tensor,
         blocksize: impl IntList,
         dense_dim: impl Into<Option<i64>>,
     ) -> Tensor {
-        self.f_to_sparse_bsr_out(out, blocksize, dense_dim).unwrap()
+        self.to_sparse_bsc_out(out, blocksize, dense_dim).unwrap()
     }
 
-    pub fn to_sparse_csc(&self, dense_dim: impl Into<Option<i64>>) -> Tensor {
-        self.f_to_sparse_csc(dense_dim).unwrap()
+    pub fn f_to_sparse_bsr(
+        &self,
+        blocksize: impl IntList,
+        dense_dim: impl Into<Option<i64>>,
+    ) -> Tensor {
+        self.to_sparse_bsr(blocksize, dense_dim).unwrap()
     }
 
-    pub fn to_sparse_csc_out(&self, out: &Tensor, dense_dim: impl Into<Option<i64>>) -> Tensor {
-        self.f_to_sparse_csc_out(out, dense_dim).unwrap()
+    pub fn f_to_sparse_bsr_out(
+        &self,
+        out: &Tensor,
+        blocksize: impl IntList,
+        dense_dim: impl Into<Option<i64>>,
+    ) -> Tensor {
+        self.to_sparse_bsr_out(out, blocksize, dense_dim).unwrap()
     }
 
-    pub fn to_sparse_csr(&self, dense_dim: impl Into<Option<i64>>) -> Tensor {
-        self.f_to_sparse_csr(dense_dim).unwrap()
+    pub fn f_to_sparse_csc(&self, dense_dim: impl Into<Option<i64>>) -> Tensor {
+        self.to_sparse_csc(dense_dim).unwrap()
     }
 
-    pub fn to_sparse_csr_out(&self, out: &Tensor, dense_dim: impl Into<Option<i64>>) -> Tensor {
-        self.f_to_sparse_csr_out(out, dense_dim).unwrap()
+    pub fn f_to_sparse_csc_out(&self, out: &Tensor, dense_dim: impl Into<Option<i64>>) -> Tensor {
+        self.to_sparse_csc_out(out, dense_dim).unwrap()
     }
 
-    pub fn to_sparse_out(
+    pub fn f_to_sparse_csr(&self, dense_dim: impl Into<Option<i64>>) -> Tensor {
+        self.to_sparse_csr(dense_dim).unwrap()
+    }
+
+    pub fn f_to_sparse_csr_out(&self, out: &Tensor, dense_dim: impl Into<Option<i64>>) -> Tensor {
+        self.to_sparse_csr_out(out, dense_dim).unwrap()
+    }
+
+    pub fn f_to_sparse_out(
         &self,
         out: &Tensor,
         layout: Option<Layout>,
         blocksize: impl IntListOption,
         dense_dim: impl Into<Option<i64>>,
     ) -> Tensor {
-        self.f_to_sparse_out(out, layout, blocksize, dense_dim).unwrap()
+        self.to_sparse_out(out, layout, blocksize, dense_dim).unwrap()
     }
 
-    pub fn to_sparse_sparse_dim(&self, sparse_dim: i64) -> Tensor {
-        self.f_to_sparse_sparse_dim(sparse_dim).unwrap()
+    pub fn f_to_sparse_sparse_dim(&self, sparse_dim: i64) -> Tensor {
+        self.to_sparse_sparse_dim(sparse_dim).unwrap()
     }
 
-    pub fn to_sparse_sparse_dim_out(&self, out: &Tensor, sparse_dim: i64) -> Tensor {
-        self.f_to_sparse_sparse_dim_out(out, sparse_dim).unwrap()
+    pub fn f_to_sparse_sparse_dim_out(&self, out: &Tensor, sparse_dim: i64) -> Tensor {
+        self.to_sparse_sparse_dim_out(out, sparse_dim).unwrap()
     }
 
-    pub fn topk(&self, k: i64, dim: i64, largest: bool, sorted: bool) -> (Tensor, Tensor) {
-        self.f_topk(k, dim, largest, sorted).unwrap()
+    pub fn f_topk(&self, k: i64, dim: i64, largest: bool, sorted: bool) -> (Tensor, Tensor) {
+        self.topk(k, dim, largest, sorted).unwrap()
     }
 
-    pub fn topk_values(
+    pub fn f_topk_values(
         &self,
         values: &Tensor,
         indices: &Tensor,
@@ -17393,68 +17468,68 @@ impl Tensor {
         largest: bool,
         sorted: bool,
     ) -> (Tensor, Tensor) {
-        self.f_topk_values(values, indices, k, dim, largest, sorted).unwrap()
+        self.topk_values(values, indices, k, dim, largest, sorted).unwrap()
     }
 
-    pub fn totype(&self, scalar_type: Kind) -> Tensor {
-        self.f_totype(scalar_type).unwrap()
+    pub fn f_totype(&self, scalar_type: Kind) -> Tensor {
+        self.totype(scalar_type).unwrap()
     }
 
-    pub fn trace(&self) -> Tensor {
-        self.f_trace().unwrap()
+    pub fn f_trace(&self) -> Tensor {
+        self.trace().unwrap()
     }
 
-    pub fn trace_backward(grad: &Tensor, sizes: impl IntList) -> Tensor {
-        Tensor::f_trace_backward(grad, sizes).unwrap()
+    pub fn f_trace_backward(grad: &Tensor, sizes: impl IntList) -> Tensor {
+        Tensor::trace_backward(grad, sizes).unwrap()
     }
 
-    pub fn trace_out(&self, out: &Tensor) -> Tensor {
-        self.f_trace_out(out).unwrap()
+    pub fn f_trace_out(&self, out: &Tensor) -> Tensor {
+        self.trace_out(out).unwrap()
     }
 
-    pub fn transpose(&self, dim0: i64, dim1: i64) -> Tensor {
-        self.f_transpose(dim0, dim1).unwrap()
+    pub fn f_transpose(&self, dim0: i64, dim1: i64) -> Tensor {
+        self.transpose(dim0, dim1).unwrap()
     }
 
-    pub fn transpose_(&mut self, dim0: i64, dim1: i64) -> Tensor {
-        self.f_transpose_(dim0, dim1).unwrap()
+    pub fn f_transpose_(&mut self, dim0: i64, dim1: i64) -> Tensor {
+        self.transpose_(dim0, dim1).unwrap()
     }
 
-    pub fn transpose_copy(&self, dim0: i64, dim1: i64) -> Tensor {
-        self.f_transpose_copy(dim0, dim1).unwrap()
+    pub fn f_transpose_copy(&self, dim0: i64, dim1: i64) -> Tensor {
+        self.transpose_copy(dim0, dim1).unwrap()
     }
 
-    pub fn transpose_copy_int_out(&self, out: &Tensor, dim0: i64, dim1: i64) -> Tensor {
-        self.f_transpose_copy_int_out(out, dim0, dim1).unwrap()
+    pub fn f_transpose_copy_int_out(&self, out: &Tensor, dim0: i64, dim1: i64) -> Tensor {
+        self.transpose_copy_int_out(out, dim0, dim1).unwrap()
     }
 
-    pub fn trapezoid(y: &Tensor, dim: i64) -> Tensor {
-        Tensor::f_trapezoid(y, dim).unwrap()
+    pub fn f_trapezoid(y: &Tensor, dim: i64) -> Tensor {
+        Tensor::trapezoid(y, dim).unwrap()
     }
 
-    pub fn trapezoid_x(y: &Tensor, x: &Tensor, dim: i64) -> Tensor {
-        Tensor::f_trapezoid_x(y, x, dim).unwrap()
+    pub fn f_trapezoid_x(y: &Tensor, x: &Tensor, dim: i64) -> Tensor {
+        Tensor::trapezoid_x(y, x, dim).unwrap()
     }
 
-    pub fn trapz(y: &Tensor, x: &Tensor, dim: i64) -> Tensor {
-        Tensor::f_trapz(y, x, dim).unwrap()
+    pub fn f_trapz(y: &Tensor, x: &Tensor, dim: i64) -> Tensor {
+        Tensor::trapz(y, x, dim).unwrap()
     }
 
-    pub fn trapz_dx(y: &Tensor, dx: f64, dim: i64) -> Tensor {
-        Tensor::f_trapz_dx(y, dx, dim).unwrap()
+    pub fn f_trapz_dx(y: &Tensor, dx: f64, dim: i64) -> Tensor {
+        Tensor::trapz_dx(y, dx, dim).unwrap()
     }
 
-    pub fn triangular_solve(
+    pub fn f_triangular_solve(
         &self,
         a: &Tensor,
         upper: bool,
         transpose: bool,
         unitriangular: bool,
     ) -> (Tensor, Tensor) {
-        self.f_triangular_solve(a, upper, transpose, unitriangular).unwrap()
+        self.triangular_solve(a, upper, transpose, unitriangular).unwrap()
     }
 
-    pub fn triangular_solve_x(
+    pub fn f_triangular_solve_x(
         &self,
         x: &Tensor,
         m: &Tensor,
@@ -17463,30 +17538,30 @@ impl Tensor {
         transpose: bool,
         unitriangular: bool,
     ) -> (Tensor, Tensor) {
-        self.f_triangular_solve_x(x, m, a, upper, transpose, unitriangular).unwrap()
+        self.triangular_solve_x(x, m, a, upper, transpose, unitriangular).unwrap()
     }
 
-    pub fn tril(&self, diagonal: i64) -> Tensor {
-        self.f_tril(diagonal).unwrap()
+    pub fn f_tril(&self, diagonal: i64) -> Tensor {
+        self.tril(diagonal).unwrap()
     }
 
-    pub fn tril_(&mut self, diagonal: i64) -> Tensor {
-        self.f_tril_(diagonal).unwrap()
+    pub fn f_tril_(&mut self, diagonal: i64) -> Tensor {
+        self.tril_(diagonal).unwrap()
     }
 
-    pub fn tril_indices(row: i64, col: i64, offset: i64, options: (Kind, Device)) -> Tensor {
-        Tensor::f_tril_indices(row, col, offset, options).unwrap()
+    pub fn f_tril_indices(row: i64, col: i64, offset: i64, options: (Kind, Device)) -> Tensor {
+        Tensor::tril_indices(row, col, offset, options).unwrap()
     }
 
-    pub fn tril_indices_out(out: &Tensor, row: i64, col: i64, offset: i64) -> Tensor {
-        Tensor::f_tril_indices_out(out, row, col, offset).unwrap()
+    pub fn f_tril_indices_out(out: &Tensor, row: i64, col: i64, offset: i64) -> Tensor {
+        Tensor::tril_indices_out(out, row, col, offset).unwrap()
     }
 
-    pub fn tril_out(&self, out: &Tensor, diagonal: i64) -> Tensor {
-        self.f_tril_out(out, diagonal).unwrap()
+    pub fn f_tril_out(&self, out: &Tensor, diagonal: i64) -> Tensor {
+        self.tril_out(out, diagonal).unwrap()
     }
 
-    pub fn triplet_margin_loss(
+    pub fn f_triplet_margin_loss(
         anchor: &Tensor,
         positive: &Tensor,
         negative: &Tensor,
@@ -17496,101 +17571,104 @@ impl Tensor {
         swap: bool,
         reduction: crate::Reduction,
     ) -> Tensor {
-        Tensor::f_triplet_margin_loss(anchor, positive, negative, margin, p, eps, swap, reduction)
+        Tensor::triplet_margin_loss(anchor, positive, negative, margin, p, eps, swap, reduction)
             .unwrap()
     }
 
-    pub fn triu(&self, diagonal: i64) -> Tensor {
-        self.f_triu(diagonal).unwrap()
+    pub fn f_triu(&self, diagonal: i64) -> Tensor {
+        self.triu(diagonal).unwrap()
     }
 
-    pub fn triu_(&mut self, diagonal: i64) -> Tensor {
-        self.f_triu_(diagonal).unwrap()
+    pub fn f_triu_(&mut self, diagonal: i64) -> Tensor {
+        self.triu_(diagonal).unwrap()
     }
 
-    pub fn triu_indices(row: i64, col: i64, offset: i64, options: (Kind, Device)) -> Tensor {
-        Tensor::f_triu_indices(row, col, offset, options).unwrap()
+    pub fn f_triu_indices(row: i64, col: i64, offset: i64, options: (Kind, Device)) -> Tensor {
+        Tensor::triu_indices(row, col, offset, options).unwrap()
     }
 
-    pub fn triu_indices_out(out: &Tensor, row: i64, col: i64, offset: i64) -> Tensor {
-        Tensor::f_triu_indices_out(out, row, col, offset).unwrap()
+    pub fn f_triu_indices_out(out: &Tensor, row: i64, col: i64, offset: i64) -> Tensor {
+        Tensor::triu_indices_out(out, row, col, offset).unwrap()
     }
 
-    pub fn triu_out(&self, out: &Tensor, diagonal: i64) -> Tensor {
-        self.f_triu_out(out, diagonal).unwrap()
+    pub fn f_triu_out(&self, out: &Tensor, diagonal: i64) -> Tensor {
+        self.triu_out(out, diagonal).unwrap()
     }
 
-    pub fn true_divide(&self, other: &Tensor) -> Tensor {
-        self.f_true_divide(other).unwrap()
+    pub fn f_true_divide(&self, other: &Tensor) -> Tensor {
+        self.true_divide(other).unwrap()
     }
 
-    pub fn true_divide_(&mut self, other: &Tensor) -> Tensor {
-        self.f_true_divide_(other).unwrap()
+    pub fn f_true_divide_(&mut self, other: &Tensor) -> Tensor {
+        self.true_divide_(other).unwrap()
     }
 
-    pub fn true_divide_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_true_divide_out(out, other).unwrap()
+    pub fn f_true_divide_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.true_divide_out(out, other).unwrap()
     }
 
-    pub fn true_divide_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_true_divide_scalar(other).unwrap()
+    pub fn f_true_divide_scalar<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.true_divide_scalar(other).unwrap()
     }
 
-    pub fn true_divide_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_true_divide_scalar_(other).unwrap()
+    pub fn f_true_divide_scalar_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.true_divide_scalar_(other).unwrap()
     }
 
-    pub fn trunc(&self) -> Tensor {
-        self.f_trunc().unwrap()
+    pub fn f_trunc(&self) -> Tensor {
+        self.trunc().unwrap()
     }
 
-    pub fn trunc_(&mut self) -> Tensor {
-        self.f_trunc_().unwrap()
+    pub fn f_trunc_(&mut self) -> Tensor {
+        self.trunc_().unwrap()
     }
 
-    pub fn trunc_out(&self, out: &Tensor) -> Tensor {
-        self.f_trunc_out(out).unwrap()
+    pub fn f_trunc_out(&self, out: &Tensor) -> Tensor {
+        self.trunc_out(out).unwrap()
     }
 
-    pub fn type_as(&self, other: &Tensor) -> Tensor {
-        self.f_type_as(other).unwrap()
+    pub fn f_type_as(&self, other: &Tensor) -> Tensor {
+        self.type_as(other).unwrap()
     }
 
-    pub fn unbind(&self, dim: i64) -> Vec<Tensor> {
-        self.f_unbind(dim).unwrap()
+    pub fn f_unbind(&self, dim: i64) -> Vec<Tensor> {
+        self.unbind(dim).unwrap()
     }
 
-    pub fn unbind_copy(&self, dim: i64) -> Vec<Tensor> {
-        self.f_unbind_copy(dim).unwrap()
+    pub fn f_unbind_copy(&self, dim: i64) -> Vec<Tensor> {
+        self.unbind_copy(dim).unwrap()
     }
 
-    pub fn unbind_copy_int_out<T: Borrow<Tensor>>(&self, out: &[T], dim: i64) {
-        self.f_unbind_copy_int_out(out, dim).unwrap()
+    pub fn f_unbind_copy_int_out<T: Borrow<Tensor>>(&self, out: &[T], dim: i64) {
+        self.unbind_copy_int_out(out, dim).unwrap()
     }
 
-    pub fn unflatten(&self, dim: i64, sizes: impl IntList) -> Tensor {
-        self.f_unflatten(dim, sizes).unwrap()
+    pub fn f_unflatten(&self, dim: i64, sizes: impl IntList) -> Tensor {
+        self.unflatten(dim, sizes).unwrap()
     }
 
-    pub fn unflatten_dense_tensors<T: Borrow<Tensor>>(flat: &Tensor, tensors: &[T]) -> Vec<Tensor> {
-        Tensor::f_unflatten_dense_tensors(flat, tensors).unwrap()
+    pub fn f_unflatten_dense_tensors<T: Borrow<Tensor>>(
+        flat: &Tensor,
+        tensors: &[T],
+    ) -> Vec<Tensor> {
+        Tensor::unflatten_dense_tensors(flat, tensors).unwrap()
     }
 
-    pub fn unfold(&self, dimension: i64, size: i64, step: i64) -> Tensor {
-        self.f_unfold(dimension, size, step).unwrap()
+    pub fn f_unfold(&self, dimension: i64, size: i64, step: i64) -> Tensor {
+        self.unfold(dimension, size, step).unwrap()
     }
 
-    pub fn unfold_backward(
+    pub fn f_unfold_backward(
         grad_in: &Tensor,
         input_sizes: impl IntList,
         dim: i64,
         size: i64,
         step: i64,
     ) -> Tensor {
-        Tensor::f_unfold_backward(grad_in, input_sizes, dim, size, step).unwrap()
+        Tensor::unfold_backward(grad_in, input_sizes, dim, size, step).unwrap()
     }
 
-    pub fn unfold_backward_out(
+    pub fn f_unfold_backward_out(
         out: &Tensor,
         grad_in: &Tensor,
         input_sizes: impl IntList,
@@ -17598,39 +17676,39 @@ impl Tensor {
         size: i64,
         step: i64,
     ) -> Tensor {
-        Tensor::f_unfold_backward_out(out, grad_in, input_sizes, dim, size, step).unwrap()
+        Tensor::unfold_backward_out(out, grad_in, input_sizes, dim, size, step).unwrap()
     }
 
-    pub fn unfold_copy(&self, dimension: i64, size: i64, step: i64) -> Tensor {
-        self.f_unfold_copy(dimension, size, step).unwrap()
+    pub fn f_unfold_copy(&self, dimension: i64, size: i64, step: i64) -> Tensor {
+        self.unfold_copy(dimension, size, step).unwrap()
     }
 
-    pub fn unfold_copy_out(&self, out: &Tensor, dimension: i64, size: i64, step: i64) -> Tensor {
-        self.f_unfold_copy_out(out, dimension, size, step).unwrap()
+    pub fn f_unfold_copy_out(&self, out: &Tensor, dimension: i64, size: i64, step: i64) -> Tensor {
+        self.unfold_copy_out(out, dimension, size, step).unwrap()
     }
 
-    pub fn uniform(&self, from: f64, to: f64) -> Tensor {
-        self.f_uniform(from, to).unwrap()
+    pub fn f_uniform(&self, from: f64, to: f64) -> Tensor {
+        self.uniform(from, to).unwrap()
     }
 
-    pub fn uniform_(&mut self, from: f64, to: f64) -> Tensor {
-        self.f_uniform_(from, to).unwrap()
+    pub fn f_uniform_(&mut self, from: f64, to: f64) -> Tensor {
+        self.uniform_(from, to).unwrap()
     }
 
-    pub fn uniform_out(&self, out: &Tensor, from: f64, to: f64) -> Tensor {
-        self.f_uniform_out(out, from, to).unwrap()
+    pub fn f_uniform_out(&self, out: &Tensor, from: f64, to: f64) -> Tensor {
+        self.uniform_out(out, from, to).unwrap()
     }
 
-    pub fn unique_consecutive(
+    pub fn f_unique_consecutive(
         &self,
         return_inverse: bool,
         return_counts: bool,
         dim: impl Into<Option<i64>>,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_unique_consecutive(return_inverse, return_counts, dim).unwrap()
+        self.unique_consecutive(return_inverse, return_counts, dim).unwrap()
     }
 
-    pub fn unique_consecutive_out(
+    pub fn f_unique_consecutive_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -17639,29 +17717,29 @@ impl Tensor {
         return_counts: bool,
         dim: impl Into<Option<i64>>,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_unique_consecutive_out(out0, out1, out2, return_inverse, return_counts, dim).unwrap()
+        self.unique_consecutive_out(out0, out1, out2, return_inverse, return_counts, dim).unwrap()
     }
 
-    pub fn unique_dim(
+    pub fn f_unique_dim(
         &self,
         dim: i64,
         sorted: bool,
         return_inverse: bool,
         return_counts: bool,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_unique_dim(dim, sorted, return_inverse, return_counts).unwrap()
+        self.unique_dim(dim, sorted, return_inverse, return_counts).unwrap()
     }
 
-    pub fn unique_dim_consecutive(
+    pub fn f_unique_dim_consecutive(
         &self,
         dim: i64,
         return_inverse: bool,
         return_counts: bool,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_unique_dim_consecutive(dim, return_inverse, return_counts).unwrap()
+        self.unique_dim_consecutive(dim, return_inverse, return_counts).unwrap()
     }
 
-    pub fn unique_dim_consecutive_out(
+    pub fn f_unique_dim_consecutive_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -17670,11 +17748,11 @@ impl Tensor {
         return_inverse: bool,
         return_counts: bool,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_unique_dim_consecutive_out(out0, out1, out2, dim, return_inverse, return_counts)
+        self.unique_dim_consecutive_out(out0, out1, out2, dim, return_inverse, return_counts)
             .unwrap()
     }
 
-    pub fn unique_dim_out(
+    pub fn f_unique_dim_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -17684,61 +17762,66 @@ impl Tensor {
         return_inverse: bool,
         return_counts: bool,
     ) -> (Tensor, Tensor, Tensor) {
-        self.f_unique_dim_out(out0, out1, out2, dim, sorted, return_inverse, return_counts).unwrap()
+        self.unique_dim_out(out0, out1, out2, dim, sorted, return_inverse, return_counts).unwrap()
     }
 
-    pub fn unsafe_chunk(&self, chunks: i64, dim: i64) -> Vec<Tensor> {
-        self.f_unsafe_chunk(chunks, dim).unwrap()
+    pub fn f_unsafe_chunk(&self, chunks: i64, dim: i64) -> Vec<Tensor> {
+        self.unsafe_chunk(chunks, dim).unwrap()
     }
 
-    pub fn unsafe_split(&self, split_size: i64, dim: i64) -> Vec<Tensor> {
-        self.f_unsafe_split(split_size, dim).unwrap()
+    pub fn f_unsafe_split(&self, split_size: i64, dim: i64) -> Vec<Tensor> {
+        self.unsafe_split(split_size, dim).unwrap()
     }
 
-    pub fn unsafe_split_tensor_out<T: Borrow<Tensor>>(&self, out: &[T], split_size: i64, dim: i64) {
-        self.f_unsafe_split_tensor_out(out, split_size, dim).unwrap()
+    pub fn f_unsafe_split_tensor_out<T: Borrow<Tensor>>(
+        &self,
+        out: &[T],
+        split_size: i64,
+        dim: i64,
+    ) {
+        self.unsafe_split_tensor_out(out, split_size, dim).unwrap()
     }
 
-    pub fn unsafe_split_with_sizes(&self, split_sizes: impl IntList, dim: i64) -> Vec<Tensor> {
-        self.f_unsafe_split_with_sizes(split_sizes, dim).unwrap()
+    pub fn f_unsafe_split_with_sizes(&self, split_sizes: impl IntList, dim: i64) -> Vec<Tensor> {
+        self.unsafe_split_with_sizes(split_sizes, dim).unwrap()
     }
 
-    pub fn unsafe_split_with_sizes_out<T: Borrow<Tensor>>(
+    pub fn f_unsafe_split_with_sizes_out<T: Borrow<Tensor>>(
         &self,
         out: &[T],
         split_sizes: impl IntList,
         dim: i64,
     ) {
-        self.f_unsafe_split_with_sizes_out(out, split_sizes, dim).unwrap()
+        self.unsafe_split_with_sizes_out(out, split_sizes, dim).unwrap()
     }
 
-    pub fn unsqueeze(&self, dim: i64) -> Tensor {
-        self.f_unsqueeze(dim).unwrap()
+    pub fn f_unsqueeze(&self, dim: i64) -> Tensor {
+        self.unsqueeze(dim).unwrap()
     }
 
-    pub fn unsqueeze_(&mut self, dim: i64) -> Tensor {
-        self.f_unsqueeze_(dim).unwrap()
+    pub fn f_unsqueeze_(&mut self, dim: i64) -> Tensor {
+        self.unsqueeze_(dim).unwrap()
     }
 
-    pub fn unsqueeze_copy(&self, dim: i64) -> Tensor {
-        self.f_unsqueeze_copy(dim).unwrap()
+    pub fn f_unsqueeze_copy(&self, dim: i64) -> Tensor {
+        self.unsqueeze_copy(dim).unwrap()
     }
 
-    pub fn unsqueeze_copy_out(&self, out: &Tensor, dim: i64) -> Tensor {
-        self.f_unsqueeze_copy_out(out, dim).unwrap()
+    pub fn f_unsqueeze_copy_out(&self, out: &Tensor, dim: i64) -> Tensor {
+        self.unsqueeze_copy_out(out, dim).unwrap()
     }
 
-    pub fn upsample_bicubic2d(
+    pub fn f_upsample_bicubic2d(
         &self,
         output_size: impl IntList,
         align_corners: bool,
         scales_h: impl Into<Option<f64>>,
         scales_w: impl Into<Option<f64>>,
     ) -> Tensor {
-        self.f_upsample_bicubic2d(output_size, align_corners, scales_h, scales_w).unwrap()
+        self.upsample_bicubic2d(output_size, align_corners, scales_h, scales_w).unwrap()
     }
 
-    pub fn upsample_bicubic2d_backward(
+    pub fn f_upsample_bicubic2d_backward(
         grad_output: &Tensor,
         output_size: impl IntList,
         input_size: impl IntList,
@@ -17746,7 +17829,7 @@ impl Tensor {
         scales_h: impl Into<Option<f64>>,
         scales_w: impl Into<Option<f64>>,
     ) -> Tensor {
-        Tensor::f_upsample_bicubic2d_backward(
+        Tensor::upsample_bicubic2d_backward(
             grad_output,
             output_size,
             input_size,
@@ -17757,7 +17840,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn upsample_bicubic2d_backward_grad_input(
+    pub fn f_upsample_bicubic2d_backward_grad_input(
         grad_input: &Tensor,
         grad_output: &Tensor,
         output_size: impl IntList,
@@ -17766,7 +17849,7 @@ impl Tensor {
         scales_h: impl Into<Option<f64>>,
         scales_w: impl Into<Option<f64>>,
     ) -> Tensor {
-        Tensor::f_upsample_bicubic2d_backward_grad_input(
+        Tensor::upsample_bicubic2d_backward_grad_input(
             grad_input,
             grad_output,
             output_size,
@@ -17778,7 +17861,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn upsample_bicubic2d_out(
+    pub fn f_upsample_bicubic2d_out(
         &self,
         out: &Tensor,
         output_size: impl IntList,
@@ -17786,29 +17869,29 @@ impl Tensor {
         scales_h: impl Into<Option<f64>>,
         scales_w: impl Into<Option<f64>>,
     ) -> Tensor {
-        self.f_upsample_bicubic2d_out(out, output_size, align_corners, scales_h, scales_w).unwrap()
+        self.upsample_bicubic2d_out(out, output_size, align_corners, scales_h, scales_w).unwrap()
     }
 
-    pub fn upsample_bicubic2d_vec(
+    pub fn f_upsample_bicubic2d_vec(
         &self,
         output_size: impl IntListOption,
         align_corners: bool,
         scale_factors: impl DoubleList,
     ) -> Tensor {
-        self.f_upsample_bicubic2d_vec(output_size, align_corners, scale_factors).unwrap()
+        self.upsample_bicubic2d_vec(output_size, align_corners, scale_factors).unwrap()
     }
 
-    pub fn upsample_bilinear2d(
+    pub fn f_upsample_bilinear2d(
         &self,
         output_size: impl IntList,
         align_corners: bool,
         scales_h: impl Into<Option<f64>>,
         scales_w: impl Into<Option<f64>>,
     ) -> Tensor {
-        self.f_upsample_bilinear2d(output_size, align_corners, scales_h, scales_w).unwrap()
+        self.upsample_bilinear2d(output_size, align_corners, scales_h, scales_w).unwrap()
     }
 
-    pub fn upsample_bilinear2d_backward(
+    pub fn f_upsample_bilinear2d_backward(
         grad_output: &Tensor,
         output_size: impl IntList,
         input_size: impl IntList,
@@ -17816,7 +17899,7 @@ impl Tensor {
         scales_h: impl Into<Option<f64>>,
         scales_w: impl Into<Option<f64>>,
     ) -> Tensor {
-        Tensor::f_upsample_bilinear2d_backward(
+        Tensor::upsample_bilinear2d_backward(
             grad_output,
             output_size,
             input_size,
@@ -17827,7 +17910,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn upsample_bilinear2d_backward_grad_input(
+    pub fn f_upsample_bilinear2d_backward_grad_input(
         grad_input: &Tensor,
         grad_output: &Tensor,
         output_size: impl IntList,
@@ -17836,7 +17919,7 @@ impl Tensor {
         scales_h: impl Into<Option<f64>>,
         scales_w: impl Into<Option<f64>>,
     ) -> Tensor {
-        Tensor::f_upsample_bilinear2d_backward_grad_input(
+        Tensor::upsample_bilinear2d_backward_grad_input(
             grad_input,
             grad_output,
             output_size,
@@ -17848,7 +17931,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn upsample_bilinear2d_out(
+    pub fn f_upsample_bilinear2d_out(
         &self,
         out: &Tensor,
         output_size: impl IntList,
@@ -17856,35 +17939,35 @@ impl Tensor {
         scales_h: impl Into<Option<f64>>,
         scales_w: impl Into<Option<f64>>,
     ) -> Tensor {
-        self.f_upsample_bilinear2d_out(out, output_size, align_corners, scales_h, scales_w).unwrap()
+        self.upsample_bilinear2d_out(out, output_size, align_corners, scales_h, scales_w).unwrap()
     }
 
-    pub fn upsample_bilinear2d_vec(
+    pub fn f_upsample_bilinear2d_vec(
         &self,
         output_size: impl IntListOption,
         align_corners: bool,
         scale_factors: impl DoubleList,
     ) -> Tensor {
-        self.f_upsample_bilinear2d_vec(output_size, align_corners, scale_factors).unwrap()
+        self.upsample_bilinear2d_vec(output_size, align_corners, scale_factors).unwrap()
     }
 
-    pub fn upsample_linear1d(
+    pub fn f_upsample_linear1d(
         &self,
         output_size: impl IntList,
         align_corners: bool,
         scales: impl Into<Option<f64>>,
     ) -> Tensor {
-        self.f_upsample_linear1d(output_size, align_corners, scales).unwrap()
+        self.upsample_linear1d(output_size, align_corners, scales).unwrap()
     }
 
-    pub fn upsample_linear1d_backward(
+    pub fn f_upsample_linear1d_backward(
         grad_output: &Tensor,
         output_size: impl IntList,
         input_size: impl IntList,
         align_corners: bool,
         scales: impl Into<Option<f64>>,
     ) -> Tensor {
-        Tensor::f_upsample_linear1d_backward(
+        Tensor::upsample_linear1d_backward(
             grad_output,
             output_size,
             input_size,
@@ -17894,7 +17977,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn upsample_linear1d_backward_grad_input(
+    pub fn f_upsample_linear1d_backward_grad_input(
         grad_input: &Tensor,
         grad_output: &Tensor,
         output_size: impl IntList,
@@ -17902,7 +17985,7 @@ impl Tensor {
         align_corners: bool,
         scales: impl Into<Option<f64>>,
     ) -> Tensor {
-        Tensor::f_upsample_linear1d_backward_grad_input(
+        Tensor::upsample_linear1d_backward_grad_input(
             grad_input,
             grad_output,
             output_size,
@@ -17913,50 +17996,50 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn upsample_linear1d_out(
+    pub fn f_upsample_linear1d_out(
         &self,
         out: &Tensor,
         output_size: impl IntList,
         align_corners: bool,
         scales: impl Into<Option<f64>>,
     ) -> Tensor {
-        self.f_upsample_linear1d_out(out, output_size, align_corners, scales).unwrap()
+        self.upsample_linear1d_out(out, output_size, align_corners, scales).unwrap()
     }
 
-    pub fn upsample_linear1d_vec(
+    pub fn f_upsample_linear1d_vec(
         &self,
         output_size: impl IntListOption,
         align_corners: bool,
         scale_factors: impl DoubleList,
     ) -> Tensor {
-        self.f_upsample_linear1d_vec(output_size, align_corners, scale_factors).unwrap()
+        self.upsample_linear1d_vec(output_size, align_corners, scale_factors).unwrap()
     }
 
-    pub fn upsample_nearest1d(
+    pub fn f_upsample_nearest1d(
         &self,
         output_size: impl IntList,
         scales: impl Into<Option<f64>>,
     ) -> Tensor {
-        self.f_upsample_nearest1d(output_size, scales).unwrap()
+        self.upsample_nearest1d(output_size, scales).unwrap()
     }
 
-    pub fn upsample_nearest1d_backward(
+    pub fn f_upsample_nearest1d_backward(
         grad_output: &Tensor,
         output_size: impl IntList,
         input_size: impl IntList,
         scales: impl Into<Option<f64>>,
     ) -> Tensor {
-        Tensor::f_upsample_nearest1d_backward(grad_output, output_size, input_size, scales).unwrap()
+        Tensor::upsample_nearest1d_backward(grad_output, output_size, input_size, scales).unwrap()
     }
 
-    pub fn upsample_nearest1d_backward_grad_input(
+    pub fn f_upsample_nearest1d_backward_grad_input(
         grad_input: &Tensor,
         grad_output: &Tensor,
         output_size: impl IntList,
         input_size: impl IntList,
         scales: impl Into<Option<f64>>,
     ) -> Tensor {
-        Tensor::f_upsample_nearest1d_backward_grad_input(
+        Tensor::upsample_nearest1d_backward_grad_input(
             grad_input,
             grad_output,
             output_size,
@@ -17966,40 +18049,40 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn upsample_nearest1d_out(
+    pub fn f_upsample_nearest1d_out(
         &self,
         out: &Tensor,
         output_size: impl IntList,
         scales: impl Into<Option<f64>>,
     ) -> Tensor {
-        self.f_upsample_nearest1d_out(out, output_size, scales).unwrap()
+        self.upsample_nearest1d_out(out, output_size, scales).unwrap()
     }
 
-    pub fn upsample_nearest1d_vec(
+    pub fn f_upsample_nearest1d_vec(
         &self,
         output_size: impl IntListOption,
         scale_factors: impl DoubleList,
     ) -> Tensor {
-        self.f_upsample_nearest1d_vec(output_size, scale_factors).unwrap()
+        self.upsample_nearest1d_vec(output_size, scale_factors).unwrap()
     }
 
-    pub fn upsample_nearest2d(
+    pub fn f_upsample_nearest2d(
         &self,
         output_size: impl IntList,
         scales_h: impl Into<Option<f64>>,
         scales_w: impl Into<Option<f64>>,
     ) -> Tensor {
-        self.f_upsample_nearest2d(output_size, scales_h, scales_w).unwrap()
+        self.upsample_nearest2d(output_size, scales_h, scales_w).unwrap()
     }
 
-    pub fn upsample_nearest2d_backward(
+    pub fn f_upsample_nearest2d_backward(
         grad_output: &Tensor,
         output_size: impl IntList,
         input_size: impl IntList,
         scales_h: impl Into<Option<f64>>,
         scales_w: impl Into<Option<f64>>,
     ) -> Tensor {
-        Tensor::f_upsample_nearest2d_backward(
+        Tensor::upsample_nearest2d_backward(
             grad_output,
             output_size,
             input_size,
@@ -18009,7 +18092,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn upsample_nearest2d_backward_grad_input(
+    pub fn f_upsample_nearest2d_backward_grad_input(
         grad_input: &Tensor,
         grad_output: &Tensor,
         output_size: impl IntList,
@@ -18017,7 +18100,7 @@ impl Tensor {
         scales_h: impl Into<Option<f64>>,
         scales_w: impl Into<Option<f64>>,
     ) -> Tensor {
-        Tensor::f_upsample_nearest2d_backward_grad_input(
+        Tensor::upsample_nearest2d_backward_grad_input(
             grad_input,
             grad_output,
             output_size,
@@ -18028,35 +18111,35 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn upsample_nearest2d_out(
+    pub fn f_upsample_nearest2d_out(
         &self,
         out: &Tensor,
         output_size: impl IntList,
         scales_h: impl Into<Option<f64>>,
         scales_w: impl Into<Option<f64>>,
     ) -> Tensor {
-        self.f_upsample_nearest2d_out(out, output_size, scales_h, scales_w).unwrap()
+        self.upsample_nearest2d_out(out, output_size, scales_h, scales_w).unwrap()
     }
 
-    pub fn upsample_nearest2d_vec(
+    pub fn f_upsample_nearest2d_vec(
         &self,
         output_size: impl IntListOption,
         scale_factors: impl DoubleList,
     ) -> Tensor {
-        self.f_upsample_nearest2d_vec(output_size, scale_factors).unwrap()
+        self.upsample_nearest2d_vec(output_size, scale_factors).unwrap()
     }
 
-    pub fn upsample_nearest3d(
+    pub fn f_upsample_nearest3d(
         &self,
         output_size: impl IntList,
         scales_d: impl Into<Option<f64>>,
         scales_h: impl Into<Option<f64>>,
         scales_w: impl Into<Option<f64>>,
     ) -> Tensor {
-        self.f_upsample_nearest3d(output_size, scales_d, scales_h, scales_w).unwrap()
+        self.upsample_nearest3d(output_size, scales_d, scales_h, scales_w).unwrap()
     }
 
-    pub fn upsample_nearest3d_backward(
+    pub fn f_upsample_nearest3d_backward(
         grad_output: &Tensor,
         output_size: impl IntList,
         input_size: impl IntList,
@@ -18064,7 +18147,7 @@ impl Tensor {
         scales_h: impl Into<Option<f64>>,
         scales_w: impl Into<Option<f64>>,
     ) -> Tensor {
-        Tensor::f_upsample_nearest3d_backward(
+        Tensor::upsample_nearest3d_backward(
             grad_output,
             output_size,
             input_size,
@@ -18075,7 +18158,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn upsample_nearest3d_backward_grad_input(
+    pub fn f_upsample_nearest3d_backward_grad_input(
         grad_input: &Tensor,
         grad_output: &Tensor,
         output_size: impl IntList,
@@ -18084,7 +18167,7 @@ impl Tensor {
         scales_h: impl Into<Option<f64>>,
         scales_w: impl Into<Option<f64>>,
     ) -> Tensor {
-        Tensor::f_upsample_nearest3d_backward_grad_input(
+        Tensor::upsample_nearest3d_backward_grad_input(
             grad_input,
             grad_output,
             output_size,
@@ -18096,7 +18179,7 @@ impl Tensor {
         .unwrap()
     }
 
-    pub fn upsample_nearest3d_out(
+    pub fn f_upsample_nearest3d_out(
         &self,
         out: &Tensor,
         output_size: impl IntList,
@@ -18104,18 +18187,18 @@ impl Tensor {
         scales_h: impl Into<Option<f64>>,
         scales_w: impl Into<Option<f64>>,
     ) -> Tensor {
-        self.f_upsample_nearest3d_out(out, output_size, scales_d, scales_h, scales_w).unwrap()
+        self.upsample_nearest3d_out(out, output_size, scales_d, scales_h, scales_w).unwrap()
     }
 
-    pub fn upsample_nearest3d_vec(
+    pub fn f_upsample_nearest3d_vec(
         &self,
         output_size: impl IntListOption,
         scale_factors: impl DoubleList,
     ) -> Tensor {
-        self.f_upsample_nearest3d_vec(output_size, scale_factors).unwrap()
+        self.upsample_nearest3d_vec(output_size, scale_factors).unwrap()
     }
 
-    pub fn upsample_trilinear3d(
+    pub fn f_upsample_trilinear3d(
         &self,
         output_size: impl IntList,
         align_corners: bool,
@@ -18123,150 +18206,142 @@ impl Tensor {
         scales_h: impl Into<Option<f64>>,
         scales_w: impl Into<Option<f64>>,
     ) -> Tensor {
-        self.f_upsample_trilinear3d(output_size, align_corners, scales_d, scales_h, scales_w)
+        self.upsample_trilinear3d(output_size, align_corners, scales_d, scales_h, scales_w).unwrap()
+    }
+
+    pub fn f_upsample_trilinear3d_backward(
+        grad_output: &Tensor,
+        output_size: impl IntList,
+        input_size: impl IntList,
+        align_corners: bool,
+        scales_d: impl Into<Option<f64>>,
+        scales_h: impl Into<Option<f64>>,
+        scales_w: impl Into<Option<f64>>,
+    ) -> Tensor {
+        Tensor::upsample_trilinear3d_backward(
+            grad_output,
+            output_size,
+            input_size,
+            align_corners,
+            scales_d,
+            scales_h,
+            scales_w,
+        )
+        .unwrap()
+    }
+
+    pub fn f_upsample_trilinear3d_backward_grad_input(
+        grad_input: &Tensor,
+        grad_output: &Tensor,
+        output_size: impl IntList,
+        input_size: impl IntList,
+        align_corners: bool,
+        scales_d: impl Into<Option<f64>>,
+        scales_h: impl Into<Option<f64>>,
+        scales_w: impl Into<Option<f64>>,
+    ) -> Tensor {
+        Tensor::upsample_trilinear3d_backward_grad_input(
+            grad_input,
+            grad_output,
+            output_size,
+            input_size,
+            align_corners,
+            scales_d,
+            scales_h,
+            scales_w,
+        )
+        .unwrap()
+    }
+
+    pub fn f_upsample_trilinear3d_out(
+        &self,
+        out: &Tensor,
+        output_size: impl IntList,
+        align_corners: bool,
+        scales_d: impl Into<Option<f64>>,
+        scales_h: impl Into<Option<f64>>,
+        scales_w: impl Into<Option<f64>>,
+    ) -> Tensor {
+        self.upsample_trilinear3d_out(out, output_size, align_corners, scales_d, scales_h, scales_w)
             .unwrap()
     }
 
-    pub fn upsample_trilinear3d_backward(
-        grad_output: &Tensor,
-        output_size: impl IntList,
-        input_size: impl IntList,
-        align_corners: bool,
-        scales_d: impl Into<Option<f64>>,
-        scales_h: impl Into<Option<f64>>,
-        scales_w: impl Into<Option<f64>>,
-    ) -> Tensor {
-        Tensor::f_upsample_trilinear3d_backward(
-            grad_output,
-            output_size,
-            input_size,
-            align_corners,
-            scales_d,
-            scales_h,
-            scales_w,
-        )
-        .unwrap()
-    }
-
-    pub fn upsample_trilinear3d_backward_grad_input(
-        grad_input: &Tensor,
-        grad_output: &Tensor,
-        output_size: impl IntList,
-        input_size: impl IntList,
-        align_corners: bool,
-        scales_d: impl Into<Option<f64>>,
-        scales_h: impl Into<Option<f64>>,
-        scales_w: impl Into<Option<f64>>,
-    ) -> Tensor {
-        Tensor::f_upsample_trilinear3d_backward_grad_input(
-            grad_input,
-            grad_output,
-            output_size,
-            input_size,
-            align_corners,
-            scales_d,
-            scales_h,
-            scales_w,
-        )
-        .unwrap()
-    }
-
-    pub fn upsample_trilinear3d_out(
-        &self,
-        out: &Tensor,
-        output_size: impl IntList,
-        align_corners: bool,
-        scales_d: impl Into<Option<f64>>,
-        scales_h: impl Into<Option<f64>>,
-        scales_w: impl Into<Option<f64>>,
-    ) -> Tensor {
-        self.f_upsample_trilinear3d_out(
-            out,
-            output_size,
-            align_corners,
-            scales_d,
-            scales_h,
-            scales_w,
-        )
-        .unwrap()
-    }
-
-    pub fn upsample_trilinear3d_vec(
+    pub fn f_upsample_trilinear3d_vec(
         &self,
         output_size: impl IntListOption,
         align_corners: bool,
         scale_factors: impl DoubleList,
     ) -> Tensor {
-        self.f_upsample_trilinear3d_vec(output_size, align_corners, scale_factors).unwrap()
+        self.upsample_trilinear3d_vec(output_size, align_corners, scale_factors).unwrap()
     }
 
-    pub fn value_selecting_reduction_backward(
+    pub fn f_value_selecting_reduction_backward(
         grad: &Tensor,
         dim: i64,
         indices: &Tensor,
         sizes: impl IntList,
         keepdim: bool,
     ) -> Tensor {
-        Tensor::f_value_selecting_reduction_backward(grad, dim, indices, sizes, keepdim).unwrap()
+        Tensor::value_selecting_reduction_backward(grad, dim, indices, sizes, keepdim).unwrap()
     }
 
-    pub fn values(&self) -> Tensor {
-        self.f_values().unwrap()
+    pub fn f_values(&self) -> Tensor {
+        self.values().unwrap()
     }
 
-    pub fn values_copy(&self) -> Tensor {
-        self.f_values_copy().unwrap()
+    pub fn f_values_copy(&self) -> Tensor {
+        self.values_copy().unwrap()
     }
 
-    pub fn values_copy_out(&self, out: &Tensor) -> Tensor {
-        self.f_values_copy_out(out).unwrap()
+    pub fn f_values_copy_out(&self, out: &Tensor) -> Tensor {
+        self.values_copy_out(out).unwrap()
     }
 
-    pub fn vander(x: &Tensor, n: impl Into<Option<i64>>, increasing: bool) -> Tensor {
-        Tensor::f_vander(x, n, increasing).unwrap()
+    pub fn f_vander(x: &Tensor, n: impl Into<Option<i64>>, increasing: bool) -> Tensor {
+        Tensor::vander(x, n, increasing).unwrap()
     }
 
-    pub fn var(&self, unbiased: bool) -> Tensor {
-        self.f_var(unbiased).unwrap()
+    pub fn f_var(&self, unbiased: bool) -> Tensor {
+        self.var(unbiased).unwrap()
     }
 
-    pub fn var_correction(
+    pub fn f_var_correction(
         &self,
         dim: impl IntListOption,
         correction: impl Into<Option<i64>>,
         keepdim: bool,
     ) -> Tensor {
-        self.f_var_correction(dim, correction, keepdim).unwrap()
+        self.var_correction(dim, correction, keepdim).unwrap()
     }
 
-    pub fn var_correction_out(
+    pub fn f_var_correction_out(
         &self,
         out: &Tensor,
         dim: impl IntListOption,
         correction: impl Into<Option<i64>>,
         keepdim: bool,
     ) -> Tensor {
-        self.f_var_correction_out(out, dim, correction, keepdim).unwrap()
+        self.var_correction_out(out, dim, correction, keepdim).unwrap()
     }
 
-    pub fn var_dim(&self, dim: impl IntListOption, unbiased: bool, keepdim: bool) -> Tensor {
-        self.f_var_dim(dim, unbiased, keepdim).unwrap()
+    pub fn f_var_dim(&self, dim: impl IntListOption, unbiased: bool, keepdim: bool) -> Tensor {
+        self.var_dim(dim, unbiased, keepdim).unwrap()
     }
 
-    pub fn var_mean(&self, unbiased: bool) -> (Tensor, Tensor) {
-        self.f_var_mean(unbiased).unwrap()
+    pub fn f_var_mean(&self, unbiased: bool) -> (Tensor, Tensor) {
+        self.var_mean(unbiased).unwrap()
     }
 
-    pub fn var_mean_correction(
+    pub fn f_var_mean_correction(
         &self,
         dim: impl IntListOption,
         correction: impl Into<Option<i64>>,
         keepdim: bool,
     ) -> (Tensor, Tensor) {
-        self.f_var_mean_correction(dim, correction, keepdim).unwrap()
+        self.var_mean_correction(dim, correction, keepdim).unwrap()
     }
 
-    pub fn var_mean_correction_out(
+    pub fn f_var_mean_correction_out(
         &self,
         out0: &Tensor,
         out1: &Tensor,
@@ -18274,193 +18349,193 @@ impl Tensor {
         correction: impl Into<Option<i64>>,
         keepdim: bool,
     ) -> (Tensor, Tensor) {
-        self.f_var_mean_correction_out(out0, out1, dim, correction, keepdim).unwrap()
+        self.var_mean_correction_out(out0, out1, dim, correction, keepdim).unwrap()
     }
 
-    pub fn var_mean_dim(
+    pub fn f_var_mean_dim(
         &self,
         dim: impl IntListOption,
         unbiased: bool,
         keepdim: bool,
     ) -> (Tensor, Tensor) {
-        self.f_var_mean_dim(dim, unbiased, keepdim).unwrap()
+        self.var_mean_dim(dim, unbiased, keepdim).unwrap()
     }
 
-    pub fn var_out(
+    pub fn f_var_out(
         &self,
         out: &Tensor,
         dim: impl IntListOption,
         unbiased: bool,
         keepdim: bool,
     ) -> Tensor {
-        self.f_var_out(out, dim, unbiased, keepdim).unwrap()
+        self.var_out(out, dim, unbiased, keepdim).unwrap()
     }
 
-    pub fn vdot(&self, other: &Tensor) -> Tensor {
-        self.f_vdot(other).unwrap()
+    pub fn f_vdot(&self, other: &Tensor) -> Tensor {
+        self.vdot(other).unwrap()
     }
 
-    pub fn vdot_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_vdot_out(out, other).unwrap()
+    pub fn f_vdot_out(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.vdot_out(out, other).unwrap()
     }
 
-    pub fn view_(&self, size: impl IntList) -> Tensor {
-        self.f_view_(size).unwrap()
+    pub fn f_view_(&self, size: impl IntList) -> Tensor {
+        self.view_(size).unwrap()
     }
 
-    pub fn view_as(&self, other: &Tensor) -> Tensor {
-        self.f_view_as(other).unwrap()
+    pub fn f_view_as(&self, other: &Tensor) -> Tensor {
+        self.view_as(other).unwrap()
     }
 
-    pub fn view_as_complex(&self) -> Tensor {
-        self.f_view_as_complex().unwrap()
+    pub fn f_view_as_complex(&self) -> Tensor {
+        self.view_as_complex().unwrap()
     }
 
-    pub fn view_as_complex_copy(&self) -> Tensor {
-        self.f_view_as_complex_copy().unwrap()
+    pub fn f_view_as_complex_copy(&self) -> Tensor {
+        self.view_as_complex_copy().unwrap()
     }
 
-    pub fn view_as_complex_copy_out(&self, out: &Tensor) -> Tensor {
-        self.f_view_as_complex_copy_out(out).unwrap()
+    pub fn f_view_as_complex_copy_out(&self, out: &Tensor) -> Tensor {
+        self.view_as_complex_copy_out(out).unwrap()
     }
 
-    pub fn view_as_real(&self) -> Tensor {
-        self.f_view_as_real().unwrap()
+    pub fn f_view_as_real(&self) -> Tensor {
+        self.view_as_real().unwrap()
     }
 
-    pub fn view_as_real_copy(&self) -> Tensor {
-        self.f_view_as_real_copy().unwrap()
+    pub fn f_view_as_real_copy(&self) -> Tensor {
+        self.view_as_real_copy().unwrap()
     }
 
-    pub fn view_as_real_copy_out(&self, out: &Tensor) -> Tensor {
-        self.f_view_as_real_copy_out(out).unwrap()
+    pub fn f_view_as_real_copy_out(&self, out: &Tensor) -> Tensor {
+        self.view_as_real_copy_out(out).unwrap()
     }
 
-    pub fn view_copy(&self, size: impl IntList) -> Tensor {
-        self.f_view_copy(size).unwrap()
+    pub fn f_view_copy(&self, size: impl IntList) -> Tensor {
+        self.view_copy(size).unwrap()
     }
 
-    pub fn view_copy_dtype(&self, dtype: Kind) -> Tensor {
-        self.f_view_copy_dtype(dtype).unwrap()
+    pub fn f_view_copy_dtype(&self, dtype: Kind) -> Tensor {
+        self.view_copy_dtype(dtype).unwrap()
     }
 
-    pub fn view_copy_dtype_out(&self, out: &Tensor, dtype: Kind) -> Tensor {
-        self.f_view_copy_dtype_out(out, dtype).unwrap()
+    pub fn f_view_copy_dtype_out(&self, out: &Tensor, dtype: Kind) -> Tensor {
+        self.view_copy_dtype_out(out, dtype).unwrap()
     }
 
-    pub fn view_copy_out(&self, out: &Tensor, size: impl IntList) -> Tensor {
-        self.f_view_copy_out(out, size).unwrap()
+    pub fn f_view_copy_out(&self, out: &Tensor, size: impl IntList) -> Tensor {
+        self.view_copy_out(out, size).unwrap()
     }
 
-    pub fn view_dtype(&self, dtype: Kind) -> Tensor {
-        self.f_view_dtype(dtype).unwrap()
+    pub fn f_view_dtype(&self, dtype: Kind) -> Tensor {
+        self.view_dtype(dtype).unwrap()
     }
 
-    pub fn vsplit(&self, sections: i64) -> Vec<Tensor> {
-        self.f_vsplit(sections).unwrap()
+    pub fn f_vsplit(&self, sections: i64) -> Vec<Tensor> {
+        self.vsplit(sections).unwrap()
     }
 
-    pub fn vsplit_array(&self, indices: impl IntList) -> Vec<Tensor> {
-        self.f_vsplit_array(indices).unwrap()
+    pub fn f_vsplit_array(&self, indices: impl IntList) -> Vec<Tensor> {
+        self.vsplit_array(indices).unwrap()
     }
 
-    pub fn vstack<T: Borrow<Tensor>>(tensors: &[T]) -> Tensor {
-        Tensor::f_vstack(tensors).unwrap()
+    pub fn f_vstack<T: Borrow<Tensor>>(tensors: &[T]) -> Tensor {
+        Tensor::vstack(tensors).unwrap()
     }
 
-    pub fn vstack_out<T: Borrow<Tensor>>(out: &Tensor, tensors: &[T]) -> Tensor {
-        Tensor::f_vstack_out(out, tensors).unwrap()
+    pub fn f_vstack_out<T: Borrow<Tensor>>(out: &Tensor, tensors: &[T]) -> Tensor {
+        Tensor::vstack_out(out, tensors).unwrap()
     }
 
-    pub fn where_(condition: &Tensor) -> Vec<Tensor> {
-        Tensor::f_where_(condition).unwrap()
+    pub fn f_where_(condition: &Tensor) -> Vec<Tensor> {
+        Tensor::where_(condition).unwrap()
     }
 
-    pub fn where_scalar<S: Into<Scalar>>(condition: &Tensor, self_scalar: S, other: S) -> Tensor {
-        Tensor::f_where_scalar(condition, self_scalar, other).unwrap()
+    pub fn f_where_scalar<S: Into<Scalar>>(condition: &Tensor, self_scalar: S, other: S) -> Tensor {
+        Tensor::where_scalar(condition, self_scalar, other).unwrap()
     }
 
-    pub fn where_scalarother<S: Into<Scalar>>(&self, condition: &Tensor, other: S) -> Tensor {
-        self.f_where_scalarother(condition, other).unwrap()
+    pub fn f_where_scalarother<S: Into<Scalar>>(&self, condition: &Tensor, other: S) -> Tensor {
+        self.where_scalarother(condition, other).unwrap()
     }
 
-    pub fn where_scalarself<S: Into<Scalar>>(
+    pub fn f_where_scalarself<S: Into<Scalar>>(
         condition: &Tensor,
         self_scalar: S,
         other: &Tensor,
     ) -> Tensor {
-        Tensor::f_where_scalarself(condition, self_scalar, other).unwrap()
+        Tensor::where_scalarself(condition, self_scalar, other).unwrap()
     }
 
-    pub fn where_self(&self, condition: &Tensor, other: &Tensor) -> Tensor {
-        self.f_where_self(condition, other).unwrap()
+    pub fn f_where_self(&self, condition: &Tensor, other: &Tensor) -> Tensor {
+        self.where_self(condition, other).unwrap()
     }
 
-    pub fn where_self_out(&self, out: &Tensor, condition: &Tensor, other: &Tensor) -> Tensor {
-        self.f_where_self_out(out, condition, other).unwrap()
+    pub fn f_where_self_out(&self, out: &Tensor, condition: &Tensor, other: &Tensor) -> Tensor {
+        self.where_self_out(out, condition, other).unwrap()
     }
 
-    pub fn xlogy(&self, other: &Tensor) -> Tensor {
-        self.f_xlogy(other).unwrap()
+    pub fn f_xlogy(&self, other: &Tensor) -> Tensor {
+        self.xlogy(other).unwrap()
     }
 
-    pub fn xlogy_(&mut self, other: &Tensor) -> Tensor {
-        self.f_xlogy_(other).unwrap()
+    pub fn f_xlogy_(&mut self, other: &Tensor) -> Tensor {
+        self.xlogy_(other).unwrap()
     }
 
-    pub fn xlogy_outscalar_other<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
-        self.f_xlogy_outscalar_other(out, other).unwrap()
+    pub fn f_xlogy_outscalar_other<S: Into<Scalar>>(&self, out: &Tensor, other: S) -> Tensor {
+        self.xlogy_outscalar_other(out, other).unwrap()
     }
 
-    pub fn xlogy_outscalar_self<S: Into<Scalar>>(
+    pub fn f_xlogy_outscalar_self<S: Into<Scalar>>(
         out: &Tensor,
         self_scalar: S,
         other: &Tensor,
     ) -> Tensor {
-        Tensor::f_xlogy_outscalar_self(out, self_scalar, other).unwrap()
+        Tensor::xlogy_outscalar_self(out, self_scalar, other).unwrap()
     }
 
-    pub fn xlogy_outtensor(&self, out: &Tensor, other: &Tensor) -> Tensor {
-        self.f_xlogy_outtensor(out, other).unwrap()
+    pub fn f_xlogy_outtensor(&self, out: &Tensor, other: &Tensor) -> Tensor {
+        self.xlogy_outtensor(out, other).unwrap()
     }
 
-    pub fn xlogy_scalar_other<S: Into<Scalar>>(&self, other: S) -> Tensor {
-        self.f_xlogy_scalar_other(other).unwrap()
+    pub fn f_xlogy_scalar_other<S: Into<Scalar>>(&self, other: S) -> Tensor {
+        self.xlogy_scalar_other(other).unwrap()
     }
 
-    pub fn xlogy_scalar_other_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
-        self.f_xlogy_scalar_other_(other).unwrap()
+    pub fn f_xlogy_scalar_other_<S: Into<Scalar>>(&mut self, other: S) -> Tensor {
+        self.xlogy_scalar_other_(other).unwrap()
     }
 
-    pub fn xlogy_scalar_self<S: Into<Scalar>>(self_scalar: S, other: &Tensor) -> Tensor {
-        Tensor::f_xlogy_scalar_self(self_scalar, other).unwrap()
+    pub fn f_xlogy_scalar_self<S: Into<Scalar>>(self_scalar: S, other: &Tensor) -> Tensor {
+        Tensor::xlogy_scalar_self(self_scalar, other).unwrap()
     }
 
-    pub fn zero(&self) -> Tensor {
-        self.f_zero().unwrap()
+    pub fn f_zero(&self) -> Tensor {
+        self.zero().unwrap()
     }
 
-    pub fn zero_(&mut self) -> Tensor {
-        self.f_zero_().unwrap()
+    pub fn f_zero_(&mut self) -> Tensor {
+        self.zero_().unwrap()
     }
 
-    pub fn zero_out(&self, out: &Tensor) -> Tensor {
-        self.f_zero_out(out).unwrap()
+    pub fn f_zero_out(&self, out: &Tensor) -> Tensor {
+        self.zero_out(out).unwrap()
     }
 
-    pub fn zeros(size: impl IntList, options: (Kind, Device)) -> Tensor {
-        Tensor::f_zeros(size, options).unwrap()
+    pub fn f_zeros(size: impl IntList, options: (Kind, Device)) -> Tensor {
+        Tensor::zeros(size, options).unwrap()
     }
 
-    pub fn zeros_like(&self) -> Tensor {
-        self.f_zeros_like().unwrap()
+    pub fn f_zeros_like(&self) -> Tensor {
+        self.zeros_like().unwrap()
     }
 
-    pub fn zeros_like_out(&self, out: &Tensor) -> Tensor {
-        self.f_zeros_like_out(out).unwrap()
+    pub fn f_zeros_like_out(&self, out: &Tensor) -> Tensor {
+        self.zeros_like_out(out).unwrap()
     }
 
-    pub fn zeros_out(out: &Tensor, size: impl IntList) -> Tensor {
-        Tensor::f_zeros_out(out, size).unwrap()
+    pub fn f_zeros_out(out: &Tensor, size: impl IntList) -> Tensor {
+        Tensor::zeros_out(out, size).unwrap()
     }
 }

--- a/src/wrappers/utils.rs
+++ b/src/wrappers/utils.rs
@@ -134,7 +134,7 @@ pub fn version_cudart() -> i64 {
 /// backend is not included by default as of PyTorch 2.0.0.
 /// https://pytorch.org/tutorials/prototype/vulkan_workflow.html#building-pytorch-with-vulkan-backend
 pub fn has_vulkan() -> bool {
-    crate::Tensor::is_vulkan_available()
+    crate::Tensor::is_vulkan_available().unwrap_or(false)
 }
 
 /// Quantization engines


### PR DESCRIPTION
This PR prototypes switching to a having functions that return `Result<R, TchError>` rather than `R` as soon as the C++ side may raise an exception. The change is very large and impactful, so it's certainly not clear we will want to proceed with this.