### PR TITLE
Llama improvements.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ regex = { version = "1.6.0", optional = true }
 image = { version = "0.24.5", optional = true }
 clap = { version = "4.2.4", features = ["derive"], optional = true }
 serde_json = { version = "1.0.96", optional = true }
+memmap2 = { version = "0.6.1", optional = true }
 
 [dev-dependencies]
 anyhow = "1"
@@ -59,4 +60,4 @@ required-features = ["regex"]
 
 [[example]]
 name = "llama"
-required-features = ["regex", "clap", "serde_json"]
+required-features = ["regex", "clap", "serde_json", "memmap2"]


### PR DESCRIPTION
Improve the llama example.
- Use MPS when available (i.e. on macs).
- Make the float dtype used for computations configurable.
- Custom weight loading using mmap, some parts of this should probably be merged in the main safetensor loading code.