### PR TITLE
add correction and update test for onehot()

### DIFF
--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -227,7 +227,7 @@ impl Tensor {
     /// [N1, ..., Nk, labels]. The returned tensor uses float values.
     /// Elements of the input vector are expected to be between 0 and labels-1.
     pub fn onehot(&self, labels: i64) -> Tensor {
-        Tensor::zeros([self.size(), vec![labels]].concat(), crate::wrappers::kind::FLOAT_CPU)
+        Tensor::zeros([self.size(), vec![labels]].concat(), (self.kind(), self.device()))
             .scatter_value_(-1, &self.unsqueeze(-1).to_kind(Kind::Int64), 1.0)
     }
 

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -227,7 +227,7 @@ impl Tensor {
     /// [N1, ..., Nk, labels]. The returned tensor uses float values.
     /// Elements of the input vector are expected to be between 0 and labels-1.
     pub fn onehot(&self, labels: i64) -> Tensor {
-        Tensor::zeros([self.size(), vec![labels]].concat(), (self.kind(), self.device()))
+        Tensor::zeros([self.size(), vec![labels]].concat(), (Kind::Float, self.device()))
             .scatter_value_(-1, &self.unsqueeze(-1).to_kind(Kind::Int64), 1.0)
     }
 

--- a/tests/tensor_tests.rs
+++ b/tests/tensor_tests.rs
@@ -132,25 +132,14 @@ fn cat_and_stack() {
 
 #[test]
 fn onehot() {
-    let xs = Tensor::from_slice(&[0, 1, 2, 3]).to_kind(tch::Kind::Int64);
+    let xs = Tensor::from_slice(&[0, 1, 2, 3]);
     let onehot = xs.onehot(4);
     assert_eq!(
         vec_f64_from(&onehot),
         vec![1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0]
     );
-    assert_eq!(onehot.size(), vec![4, 4]);
-    assert_eq!(onehot.kind(), tch::Kind::Int64);
-    assert_eq!(onehot.device(), Device::Cpu);
-
-    let xs = Tensor::from_slice(&[0, 1, 2, 3]).to_kind(tch::Kind::Float);
-    let onehot = xs.onehot(4);
-    assert_eq!(
-        vec_f64_from(&onehot),
-        vec![1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0]
-    );
-    assert_eq!(onehot.size(), vec![4, 4]);
-    assert_eq!(onehot.kind(), tch::Kind::Float);
-    assert_eq!(onehot.device(), Device::Cpu);
+    assert_eq!(onehot.device(), xs.device());
+    assert_eq!(onehot.size(), vec![4, 4])
 }
 
 #[test]

--- a/tests/tensor_tests.rs
+++ b/tests/tensor_tests.rs
@@ -132,25 +132,25 @@ fn cat_and_stack() {
 
 #[test]
 fn onehot() {
-    let xs = Tensor::from_slice(&[0, 1, 2, 3]).to_device(Device::Mps).to_kind(tch::Kind::Int64);
+    let xs = Tensor::from_slice(&[0, 1, 2, 3]).to_kind(tch::Kind::Int64);
     let onehot = xs.onehot(4);
     assert_eq!(
-        vec_f32_from(&onehot),
+        vec_f64_from(&onehot),
         vec![1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0]
     );
     assert_eq!(onehot.size(), vec![4, 4]);
     assert_eq!(onehot.kind(), tch::Kind::Int64);
-    assert_eq!(onehot.device(), Device::Mps);
+    assert_eq!(onehot.device(), Device::Cpu);
 
-    let xs = Tensor::from_slice(&[0, 1, 2, 3]).to_device(Device::Mps).to_kind(tch::Kind::Float);
+    let xs = Tensor::from_slice(&[0, 1, 2, 3]).to_kind(tch::Kind::Float);
     let onehot = xs.onehot(4);
     assert_eq!(
-        vec_f32_from(&onehot),
+        vec_f64_from(&onehot),
         vec![1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0]
     );
     assert_eq!(onehot.size(), vec![4, 4]);
     assert_eq!(onehot.kind(), tch::Kind::Float);
-    assert_eq!(onehot.device(), Device::Mps);
+    assert_eq!(onehot.device(), Device::Cpu);
 }
 
 #[test]

--- a/tests/tensor_tests.rs
+++ b/tests/tensor_tests.rs
@@ -132,13 +132,25 @@ fn cat_and_stack() {
 
 #[test]
 fn onehot() {
-    let xs = Tensor::from_slice(&[0, 1, 2, 3]);
+    let xs = Tensor::from_slice(&[0, 1, 2, 3]).to_device(Device::Mps).to_kind(tch::Kind::Int64);
     let onehot = xs.onehot(4);
     assert_eq!(
-        vec_f64_from(&onehot),
+        vec_f32_from(&onehot),
         vec![1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0]
     );
-    assert_eq!(onehot.size(), vec![4, 4])
+    assert_eq!(onehot.size(), vec![4, 4]);
+    assert_eq!(onehot.kind(), tch::Kind::Int64);
+    assert_eq!(onehot.device(), Device::Mps);
+
+    let xs = Tensor::from_slice(&[0, 1, 2, 3]).to_device(Device::Mps).to_kind(tch::Kind::Float);
+    let onehot = xs.onehot(4);
+    assert_eq!(
+        vec_f32_from(&onehot),
+        vec![1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0]
+    );
+    assert_eq!(onehot.size(), vec![4, 4]);
+    assert_eq!(onehot.kind(), tch::Kind::Float);
+    assert_eq!(onehot.device(), Device::Mps);
 }
 
 #[test]


### PR DESCRIPTION
I found that my code failed when run on a GPU because the tensor::onehot() fn was hardcoded to use Device::Cpu. 

This PR changes onehot() to use the same device as the tensor it is applied to. The onehot test is modifies to confirm the new behavior.

 In the test, the device is set to Mps to confirm that it is not defaulting to CPU. This test was run on a non-mps device, confirming that the test does not require Mps to run.