### PR TITLE
Add dlpack support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ image = { version = "0.24.5", optional = true }
 clap = { version = "4.2.4", features = ["derive"], optional = true }
 serde_json = { version = "1.0.96", optional = true }
 memmap2 = { version = "0.6.1", optional = true }
+dlpark = { version = "0.2.2", default-features = false }
 
 [dev-dependencies]
 anyhow = "1"

--- a/tests/tensor_tests.rs
+++ b/tests/tensor_tests.rs
@@ -487,3 +487,12 @@ fn convert_ndarray() {
     let array_3d: ndarray::ArrayD<i64> = t_3d.as_ref().try_into().unwrap();
     assert_eq!(array_3d.as_slice(), ndarray::array![[[0, 1], [2, 3]], [[4, 5], [6, 7]]].as_slice());
 }
+
+#[test]
+fn convert_dlpack() {
+    let t1: Tensor = Tensor::from_slice(&[0, 1, 2, 3]);
+    let dlpack = t1.to_dlpack();
+    let t2 = Tensor::from_dlpack(dlpack);
+    assert!(t1.allclose(&t2, 1e-5, 1e-5, false));
+    assert_eq!(t1.data_ptr(), t2.data_ptr());
+}

--- a/torch-sys/Cargo.toml
+++ b/torch-sys/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["external-ffi-bindings", "science"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
+dlpark = { version = "0.2.2", default-features = false }
 libc = "0.2.0"
 
 [build-dependencies]

--- a/torch-sys/libtch/torch_api.cpp
+++ b/torch-sys/libtch/torch_api.cpp
@@ -7,6 +7,7 @@
 #include<torch/csrc/jit/runtime/graph_executor.h>
 #include<torch/torch.h>
 #include<ATen/autocast_mode.h>
+#include<ATen/DLConvertor.h>
 #include<torch/script.h>
 #include<torch/csrc/jit/passes/tensorexpr_fuser.h>
 #include<torch/csrc/jit/codegen/cuda/interface.h>
@@ -665,6 +666,14 @@ void at_run_backward(tensor *tensors,
       outputs[i] = static_cast<tensor>(new torch::autograd::Variable(vl[i]));
     }
   )
+}
+
+DLManagedTensor* at_to_dlpack(tensor src) {
+  return at::toDLPack(*src);
+}
+
+tensor at_from_dlpack(DLManagedTensor* src) {
+  return new torch::Tensor(at::fromDLPack(src));
 }
 
 optimizer ato_adam(double learning_rate,

--- a/torch-sys/libtch/torch_api.h
+++ b/torch-sys/libtch/torch_api.h
@@ -4,6 +4,7 @@
 
 #ifdef __cplusplus
 #include<torch/torch.h>
+#include<ATen/dlpack.h>
 #include<stdexcept>
 using namespace std;
 extern thread_local char *torch_last_err;
@@ -113,6 +114,9 @@ void at_run_backward(tensor *tensors,
                       tensor *outputs,
                       int keep_graph,
                       int create_graph);
+
+DLManagedTensor* at_to_dlpack(tensor src);
+tensor at_from_dlpack(DLManagedTensor* src);
 
 optimizer ato_adam(double learning_rate,
                    double beta1,

--- a/torch-sys/src/lib.rs
+++ b/torch-sys/src/lib.rs
@@ -4,6 +4,7 @@ pub mod io;
 pub mod python;
 mod traits;
 
+use dlpark::ffi::DLManagedTensor;
 use libc::{c_char, c_int, c_uchar, c_void, size_t};
 pub use traits::{DoubleList, IntList, IntListOption};
 
@@ -60,6 +61,8 @@ extern "C" {
         keep_graph: c_int,
         create_graph: c_int,
     );
+    pub fn at_to_dlpack(src: *mut C_tensor) -> *mut DLManagedTensor;
+    pub fn at_from_dlpack(src: *mut DLManagedTensor) -> *mut C_tensor;
     pub fn at_copy_data(
         arg: *mut C_tensor,
         vs: *const c_void,


### PR DESCRIPTION
[DLPack](https://github.com/dmlc/dlpack) is an open in-memory tensor structure for sharing tensors among frameworks. DLPack enables

- Easier sharing of operators between deep learning frameworks.
- Easier wrapping of vendor level operator implementations, allowing collaboration when introducing new devices/ops.
- Quick swapping of backend implementations, like different version of BLAS
- For final users, this could bring more operators, and possibility of mixing usage between frameworks.

Supporting dlpack will make it easier to share tensors with `dfdx`, `ndarray` and maybe `OrtTensor`. 