### PR TITLE
Implemented sync

### DIFF
--- a/src/nn/func.rs
+++ b/src/nn/func.rs
@@ -3,7 +3,7 @@ use crate::Tensor;
 
 /// A layer defined by a simple closure.
 pub struct Func<'a> {
-    f: Box<dyn 'a + Fn(&Tensor) -> Tensor + Send>,
+    f: Box<dyn 'a + Fn(&Tensor) -> Tensor + Send + Sync>,
 }
 
 impl<'a> std::fmt::Debug for Func<'a> {
@@ -14,7 +14,7 @@ impl<'a> std::fmt::Debug for Func<'a> {
 
 pub fn func<'a, F>(f: F) -> Func<'a>
 where
-    F: 'a + Fn(&Tensor) -> Tensor + Send,
+    F: 'a + Fn(&Tensor) -> Tensor + Send + Sync,
 {
     Func { f: Box::new(f) }
 }
@@ -28,7 +28,7 @@ impl<'a> super::module::Module for Func<'a> {
 /// A layer defined by a closure with an additional training parameter.
 #[allow(clippy::type_complexity)]
 pub struct FuncT<'a> {
-    f: Box<dyn 'a + Fn(&Tensor, bool) -> Tensor + Send>,
+    f: Box<dyn 'a + Fn(&Tensor, bool) -> Tensor + Send + Sync>,
 }
 
 impl<'a> std::fmt::Debug for FuncT<'a> {
@@ -39,7 +39,7 @@ impl<'a> std::fmt::Debug for FuncT<'a> {
 
 pub fn func_t<'a, F>(f: F) -> FuncT<'a>
 where
-    F: 'a + Fn(&Tensor, bool) -> Tensor + Send,
+    F: 'a + Fn(&Tensor, bool) -> Tensor + Send + Sync,
 {
     FuncT { f: Box::new(f) }
 }

--- a/src/nn/module.rs
+++ b/src/nn/module.rs
@@ -2,7 +2,7 @@
 use crate::{data::Iter2, Device, Tensor};
 
 /// The simplest module trait, defining a forward function.
-pub trait Module: std::fmt::Debug + Send {
+pub trait Module: std::fmt::Debug + Send + Sync {
     fn forward(&self, xs: &Tensor) -> Tensor;
 }
 
@@ -10,7 +10,7 @@ pub trait Module: std::fmt::Debug + Send {
 ///
 /// The train parameter is commonly used to have different behavior between training
 /// and evaluation, e.g. when using dropout or batch-normalization.
-pub trait ModuleT: std::fmt::Debug + Send {
+pub trait ModuleT: std::fmt::Debug + Send + Sync {
     fn forward_t(&self, xs: &Tensor, train: bool) -> Tensor;
 
     fn batch_accuracy_for_logits(

--- a/src/nn/sequential.rs
+++ b/src/nn/sequential.rs
@@ -47,7 +47,7 @@ impl Sequential {
     /// Appends a closure after all the current layers.
     pub fn add_fn<F>(self, f: F) -> Self
     where
-        F: 'static + Fn(&Tensor) -> Tensor + Send,
+        F: 'static + Fn(&Tensor) -> Tensor + Send + Sync,
     {
         self.add(super::func(f))
     }
@@ -116,7 +116,7 @@ impl SequentialT {
     /// Appends a closure after all the current layers.
     pub fn add_fn<F>(self, f: F) -> Self
     where
-        F: 'static + Fn(&Tensor) -> Tensor + Send,
+        F: 'static + Fn(&Tensor) -> Tensor + Send + Sync,
     {
         self.add(super::func(f))
     }
@@ -124,7 +124,7 @@ impl SequentialT {
     /// Appends a closure after all the current layers.
     pub fn add_fn_t<F>(self, f: F) -> Self
     where
-        F: 'static + Fn(&Tensor, bool) -> Tensor + Send,
+        F: 'static + Fn(&Tensor, bool) -> Tensor + Send + Sync,
     {
         self.add(super::func_t(f))
     }

--- a/src/wrappers/tensor.rs
+++ b/src/wrappers/tensor.rs
@@ -20,6 +20,7 @@ pub struct Tensor {
 }
 
 unsafe impl Send for Tensor {}
+unsafe impl Sync for Tensor {}
 
 pub extern "C" fn add_callback(data: *mut c_void, name: *const c_char, c_tensor: *mut C_tensor) {
     let name = unsafe { std::ffi::CStr::from_ptr(name).to_str().unwrap() };


### PR DESCRIPTION
When using tch-rs inside a threaded context, `Sync` needs to be implemented. I have added the necessary trait bounds here to accomplish this.