### PR TITLE
`varStore.load` automated precision update

### DIFF
--- a/src/nn/var_store.rs
+++ b/src/nn/var_store.rs
@@ -182,14 +182,19 @@ impl VarStore {
         Ok(named_tensors?.into_iter().collect())
     }
 
+    fn copy_data_with_precision_casting(src: &Tensor, dst: &mut Tensor) -> Result<(), TchError> {
+        dst.set_data(&dst.to_kind(src.kind()));
+        dst.f_copy_(src)
+    }
+
     fn load_internal<T: AsRef<std::path::Path>>(&mut self, path: T) -> Result<(), TchError> {
         let named_tensors = self.named_tensors(&path)?;
         let mut variables = self.variables_.lock().unwrap();
         for (name, var) in variables.named_variables.iter_mut() {
             match named_tensors.get(name) {
                 Some(src) => crate::no_grad(|| {
-                    var.set_data(&var.to_kind(src.kind()));
-                    var.f_copy_(src).map_err(|e| e.path_context(name))
+                    Self::copy_data_with_precision_casting(src, var)
+                        .map_err(|e| e.path_context(name))
                 })?,
                 None => {
                     return Err(TchError::TensorNameNotFound(
@@ -237,7 +242,10 @@ impl VarStore {
         let mut variables = self.variables_.lock().unwrap();
         for (name, var) in variables.named_variables.iter_mut() {
             match named_tensors.get(name) {
-                Some(src) => crate::no_grad(|| var.f_copy_(src).map_err(|e| e.path_context(name)))?,
+                Some(src) => crate::no_grad(|| {
+                    Self::copy_data_with_precision_casting(src, var)
+                        .map_err(|e| e.path_context(name))
+                })?,
                 None => {
                     return Err(TchError::TensorNameNotFound(
                         name.to_string(),
@@ -268,7 +276,10 @@ impl VarStore {
         let mut missing_variables = Vec::new();
         for (name, var) in variables.named_variables.iter_mut() {
             match named_tensors.get(name) {
-                Some(src) => crate::no_grad(|| var.f_copy_(src).map_err(|e| e.path_context(name)))?,
+                Some(src) => crate::no_grad(|| {
+                    Self::copy_data_with_precision_casting(src, var)
+                        .map_err(|e| e.path_context(name))
+                })?,
                 None => {
                     missing_variables.push(name.to_owned());
                 }

--- a/src/nn/var_store.rs
+++ b/src/nn/var_store.rs
@@ -182,7 +182,10 @@ impl VarStore {
         Ok(named_tensors?.into_iter().collect())
     }
 
-    fn copy_data_with_precision_casting(src: &Tensor, dst: &mut Tensor) -> Result<(), TchError> {
+    /// Copies the data from source tensor to destination
+    ///
+    /// Updates the precision of the destination to match the source
+    fn copy_data_with_precision_update(src: &Tensor, dst: &mut Tensor) -> Result<(), TchError> {
         dst.set_data(&dst.to_kind(src.kind()));
         dst.f_copy_(src)
     }
@@ -193,7 +196,7 @@ impl VarStore {
         for (name, var) in variables.named_variables.iter_mut() {
             match named_tensors.get(name) {
                 Some(src) => crate::no_grad(|| {
-                    Self::copy_data_with_precision_casting(src, var)
+                    Self::copy_data_with_precision_update(src, var)
                         .map_err(|e| e.path_context(name))
                 })?,
                 None => {
@@ -243,7 +246,7 @@ impl VarStore {
         for (name, var) in variables.named_variables.iter_mut() {
             match named_tensors.get(name) {
                 Some(src) => crate::no_grad(|| {
-                    Self::copy_data_with_precision_casting(src, var)
+                    Self::copy_data_with_precision_update(src, var)
                         .map_err(|e| e.path_context(name))
                 })?,
                 None => {
@@ -277,7 +280,7 @@ impl VarStore {
         for (name, var) in variables.named_variables.iter_mut() {
             match named_tensors.get(name) {
                 Some(src) => crate::no_grad(|| {
-                    Self::copy_data_with_precision_casting(src, var)
+                    Self::copy_data_with_precision_update(src, var)
                         .map_err(|e| e.path_context(name))
                 })?,
                 None => {

--- a/src/nn/var_store.rs
+++ b/src/nn/var_store.rs
@@ -187,7 +187,10 @@ impl VarStore {
         let mut variables = self.variables_.lock().unwrap();
         for (name, var) in variables.named_variables.iter_mut() {
             match named_tensors.get(name) {
-                Some(src) => crate::no_grad(|| var.f_copy_(src).map_err(|e| e.path_context(name)))?,
+                Some(src) => crate::no_grad(|| {
+                    var.set_data(&var.to_kind(src.kind()));
+                    var.f_copy_(src).map_err(|e| e.path_context(name))
+                })?,
                 None => {
                     return Err(TchError::TensorNameNotFound(
                         name.to_string(),

--- a/tests/var_store.rs
+++ b/tests/var_store.rs
@@ -37,9 +37,9 @@ fn save_and_load_var_store() {
         let _w = vs.sub("a").sub("b").sub("ccc").ones("t123", &[3]);
         (u, v)
     };
-    let vs1 = VarStore::new(Device::Cpu);
-    let mut vs2 = VarStore::new(Device::Cpu);
+    let mut vs1 = VarStore::new(Device::Cpu);
     let (mut u1, mut v1) = add(&vs1.root());
+    let mut vs2 = VarStore::new(Device::Cpu);
     let (u2, v2) = add(&vs2.root());
     tch::no_grad(|| {
         u1 += 42.0;
@@ -54,6 +54,18 @@ fn save_and_load_var_store() {
     assert_eq!(f64_from(&u1.mean(Kind::Float)), 42.0);
     assert_eq!(f64_from(&u2.mean(Kind::Float)), 42.0);
     assert_eq!(f64_from(&v2.mean(Kind::Float)), 2.0);
+    fs::remove_file(&filename).unwrap();
+
+    // Save and reload in half-precision
+    vs1.half();
+    let mut vs2 = VarStore::new(Device::Cpu);
+    let (u2, v2) = add(&vs2.root());
+    vs1.save(&filename).unwrap();
+    vs2.load(&filename).unwrap();
+    assert_eq!(u2.kind(), Kind::Half);
+    assert_eq!(v2.kind(), Kind::Half);
+    assert_eq!(f64_from(&u2.mean(Kind::Half)), 42.0);
+    assert_eq!(f64_from(&v2.mean(Kind::Half)), 2.0);
     fs::remove_file(filename).unwrap();
 }
 
@@ -68,7 +80,7 @@ fn save_to_stream_and_load_var_store() {
         let _w = vs.sub("a").sub("b").sub("ccc").ones("t123", &[3]);
         (u, v)
     };
-    let vs1 = VarStore::new(Device::Cpu);
+    let mut vs1 = VarStore::new(Device::Cpu);
     let mut vs2 = VarStore::new(Device::Cpu);
     let (mut u1, mut v1) = add(&vs1.root());
     let (u2, v2) = add(&vs2.root());
@@ -85,6 +97,18 @@ fn save_to_stream_and_load_var_store() {
     assert_eq!(f64_from(&u1.mean(Kind::Float)), 42.0);
     assert_eq!(f64_from(&u2.mean(Kind::Float)), 42.0);
     assert_eq!(f64_from(&v2.mean(Kind::Float)), 2.0);
+    fs::remove_file(&filename).unwrap();
+
+    // Save and reload in half-precision
+    vs1.half();
+    let mut vs2 = VarStore::new(Device::Cpu);
+    let (u2, v2) = add(&vs2.root());
+    vs1.save_to_stream(std::fs::File::create(&filename).unwrap()).unwrap();
+    vs2.load(&filename).unwrap();
+    assert_eq!(u2.kind(), Kind::Half);
+    assert_eq!(v2.kind(), Kind::Half);
+    assert_eq!(f64_from(&u2.mean(Kind::Half)), 42.0);
+    assert_eq!(f64_from(&v2.mean(Kind::Half)), 2.0);
     fs::remove_file(filename).unwrap();
 }
 
@@ -99,7 +123,7 @@ fn save_and_load_from_stream_var_store() {
         let _w = vs.sub("a").sub("b").sub("ccc").ones("t123", &[3]);
         (u, v)
     };
-    let vs1 = VarStore::new(Device::Cpu);
+    let mut vs1 = VarStore::new(Device::Cpu);
     let mut vs2 = VarStore::new(Device::Cpu);
     let (mut u1, mut v1) = add(&vs1.root());
     let (u2, v2) = add(&vs2.root());
@@ -116,6 +140,18 @@ fn save_and_load_from_stream_var_store() {
     assert_eq!(f64_from(&u1.mean(Kind::Float)), 42.0);
     assert_eq!(f64_from(&u2.mean(Kind::Float)), 42.0);
     assert_eq!(f64_from(&v2.mean(Kind::Float)), 2.0);
+    fs::remove_file(&filename).unwrap();
+
+    // Save and reload in half-precision
+    vs1.half();
+    let mut vs2 = VarStore::new(Device::Cpu);
+    let (u2, v2) = add(&vs2.root());
+    vs1.save(&filename).unwrap();
+    vs2.load_from_stream(std::fs::File::open(&filename).unwrap()).unwrap();
+    assert_eq!(u2.kind(), Kind::Half);
+    assert_eq!(v2.kind(), Kind::Half);
+    assert_eq!(f64_from(&u2.mean(Kind::Half)), 42.0);
+    assert_eq!(f64_from(&v2.mean(Kind::Half)), 2.0);
     fs::remove_file(filename).unwrap();
 }
 
@@ -216,6 +252,44 @@ fn save_and_load_partial_var_store_incomplete_file() {
     assert_eq!(f64_from(&u2.mean(Kind::Float)), 42.0);
     assert_eq!(f64_from(&v2.mean(Kind::Float)), 1.0);
     assert_eq!(missing_variables, vec!(String::from("a.b.t2")));
+    fs::remove_file(filename).unwrap();
+}
+
+#[test]
+fn save_and_load_var_store_half() {
+    let filename = std::env::temp_dir().join(format!("tch-vs-load-half-{}", std::process::id()));
+    let add = |vs: &tch::nn::Path| {
+        let v = vs.sub("a").sub("b").ones("t2", &[3]);
+        let u = vs.zeros("t1", &[4]);
+        let _w = vs.sub("a").sub("b").sub("ccc").ones("t123", &[3]);
+        let _w = vs.sub("a").sub("b").sub("ccc").ones("t123", &[3]);
+        (u, v)
+    };
+    let mut vs1 = VarStore::new(Device::Cpu);
+    let mut vs2 = VarStore::new(Device::Cpu);
+    let (mut u1, mut v1) = add(&vs1.root());
+    let (u2, v2) = add(&vs2.root());
+    tch::no_grad(|| {
+        u1 += 42.0;
+        v1 *= 2.0;
+    });
+    vs1.half();
+    assert_eq!(u1.kind(), Kind::Half);
+    assert_eq!(v1.kind(), Kind::Half);
+    assert_eq!(f64_from(&u1.mean(Kind::Half)), 42.0);
+    assert_eq!(f64_from(&v1.mean(Kind::Half)), 2.0);
+    assert_eq!(u2.kind(), Kind::Float);
+    assert_eq!(v2.kind(), Kind::Float);
+    assert_eq!(f64_from(&u2.mean(Kind::Float)), 0.0);
+    assert_eq!(f64_from(&v2.mean(Kind::Float)), 1.0);
+    vs1.save(&filename).unwrap();
+    vs2.load(&filename).unwrap();
+
+    // vs2 reloaded as half precision
+    assert_eq!(u2.kind(), Kind::Half);
+    assert_eq!(v2.kind(), Kind::Half);
+    assert_eq!(f64_from(&u2.mean(Kind::Half)), 42.0);
+    assert_eq!(f64_from(&v2.mean(Kind::Half)), 2.0);
     fs::remove_file(filename).unwrap();
 }
 


### PR DESCRIPTION
Fixes https://github.com/LaurentMazare/tch-rs/issues/757

This PR modifies the internal load mechanism to update the precision of the `VarStore` variable if they do not match the loaded tensors precision. This allows loading varstore snapshot of arbitrary precision without requiring further user intervention.

The save/load tests have been extended to test the new feature on half-precision weights,