### PR TITLE
Enable the function linalg_vector_norm

### DIFF
--- a/gen/gen.ml
+++ b/gen/gen.ml
@@ -37,7 +37,6 @@ let excluded_functions =
     ; "stride"
     ; "_assert_async"
     ; "gradient"
-    ; "linalg_vector_norm"
     ; "linalg_vector_norm_out"
     ; "linalg_matrix_norm"
     ; "linalg_matrix_norm_out"

--- a/src/wrappers/tensor_fallible_generated.rs
+++ b/src/wrappers/tensor_fallible_generated.rs
@@ -21107,6 +21107,26 @@ impl Tensor {
         Ok(Tensor { c_tensor: c_tensors[0] })
     }
 
+    pub fn f_linalg_vector_norm<S: Into<Scalar>>(
+        &self,
+        ord: S,
+        dim: impl IntListOption,
+        keepdim: bool,
+        dtype: impl Into<Option<Kind>>,
+    ) -> Result<Tensor, TchError> {
+        let mut c_tensors = [std::ptr::null_mut(); 1];
+        unsafe_torch_err!(atg_linalg_vector_norm(
+            c_tensors.as_mut_ptr(),
+            self.c_tensor,
+            ord.into().c_scalar,
+            dim.as_ptr(),
+            dim.len_i32(),
+            if keepdim { 1 } else { 0 },
+            dtype.into().map_or(-1, |s| s.c_int())
+        ));
+        Ok(Tensor { c_tensor: c_tensors[0] })
+    }
+
     pub fn f_linear<T: Borrow<Tensor>>(
         &self,
         weight: &Tensor,

--- a/src/wrappers/tensor_generated.rs
+++ b/src/wrappers/tensor_generated.rs
@@ -10861,6 +10861,16 @@ impl Tensor {
         Tensor::f_linalg_vecdot_out(out, x, y, dim).unwrap()
     }
 
+    pub fn linalg_vector_norm<S: Into<Scalar>>(
+        &self,
+        ord: S,
+        dim: impl IntListOption,
+        keepdim: bool,
+        dtype: impl Into<Option<Kind>>,
+    ) -> Tensor {
+        self.f_linalg_vector_norm(ord, dim, keepdim, dtype).unwrap()
+    }
+
     pub fn linear<T: Borrow<Tensor>>(&self, weight: &Tensor, bias: Option<T>) -> Tensor {
         self.f_linear(weight, bias).unwrap()
     }

--- a/torch-sys/libtch/torch_api_generated.cpp
+++ b/torch-sys/libtch/torch_api_generated.cpp
@@ -10278,6 +10278,13 @@ void atg_linalg_vecdot_out(tensor *out__, tensor out, tensor x, tensor y, int64_
   )
 }
 
+void atg_linalg_vector_norm(tensor *out__, tensor self, scalar ord, int64_t *dim_data, int dim_len, int keepdim, int dtype) {
+  PROTECT(
+    auto outputs__ = torch::linalg_vector_norm(*self, *ord, dim_data == nullptr ? c10::nullopt : c10::optional<torch::IntArrayRef>(torch::IntArrayRef(dim_data, dim_len)), (bool)keepdim, dtype < 0 ? c10::nullopt : c10::optional<at::ScalarType>(at::ScalarType(dtype)));
+    out__[0] = new torch::Tensor(outputs__);
+  )
+}
+
 void atg_linear(tensor *out__, tensor input, tensor weight, tensor bias) {
   PROTECT(
     auto outputs__ = torch::linear(*input, *weight, (bias ? *bias : torch::Tensor()));

--- a/torch-sys/libtch/torch_api_generated.h
+++ b/torch-sys/libtch/torch_api_generated.h
@@ -1425,6 +1425,7 @@ void atg_linalg_tensorsolve_out(tensor *, tensor out, tensor self, tensor other,
 void atg_linalg_vander(tensor *, tensor x, int64_t n_v, uint8_t n_null);
 void atg_linalg_vecdot(tensor *, tensor x, tensor y, int64_t dim);
 void atg_linalg_vecdot_out(tensor *, tensor out, tensor x, tensor y, int64_t dim);
+void atg_linalg_vector_norm(tensor *, tensor self, scalar ord, int64_t *dim_data, int dim_len, int keepdim, int dtype);
 void atg_linear(tensor *, tensor input, tensor weight, tensor bias);
 void atg_linear_out(tensor *, tensor out, tensor input, tensor weight, tensor bias);
 void atg_linspace(tensor *, scalar start, scalar end, int64_t steps, int options_kind, int options_device);

--- a/torch-sys/src/c_generated.rs
+++ b/torch-sys/src/c_generated.rs
@@ -8647,6 +8647,15 @@ extern "C" {
         y_: *mut C_tensor,
         dim_: i64,
     );
+    pub fn atg_linalg_vector_norm(
+        out__: *mut *mut C_tensor,
+        self_: *mut C_tensor,
+        ord_: *mut C_scalar,
+        dim_data: *const i64,
+        dim_len: c_int,
+        keepdim_: c_int,
+        dtype_: c_int,
+    );
     pub fn atg_linear(
         out__: *mut *mut C_tensor,
         input_: *mut C_tensor,


### PR DESCRIPTION
This pull request is to enable the function linalg_vector_norm, disable in the original code.

I need it to compute the L2 norm of matrices and vectors.

It looks like it was disabled because of compile errors, caused by the removal of the parameter ord in the code generator, because it had a default value. After removing the default_value attribute in Declarations-v2.0.0.yaml, the code is correctly generated.

Of course, there are better solutions, but I wasn't able to make changes in the Ocaml code in gen/gen.ml.

Thank you for your time.