### PR TITLE
Bump the cc version.

### DIFF
--- a/torch-sys/Cargo.toml
+++ b/torch-sys/Cargo.toml
@@ -17,7 +17,7 @@ libc = "0.2.0"
 
 [build-dependencies]
 anyhow = "1.0"
-cc = "1.0"
+cc = "1.0.61"
 ureq = { version = "2.6", optional = true, features = ["json"] }
 serde_json = { version = "1.0", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }


### PR DESCRIPTION
This should fix #764 as `includes` was only introduced in `cc` 1.0.61.