### PR TITLE
Make indexing with empty ranges consistent

### DIFF
--- a/tests/tensor_indexing.rs
+++ b/tests/tensor_indexing.rs
@@ -68,6 +68,21 @@ fn range_index() {
     let result = tensor.i(..=1);
     assert_eq!(result.size(), &[2, 3]);
     assert_eq!(vec_i64_from(&result), &[0, 1, 2, 3, 4, 5]);
+
+    // Negative Cases
+    //
+    // Rust considers both `0..0` and `1..0` to be valid, empty ranges.
+    let tensor = Tensor::arange_start(0, 4 * 3, opt).view([4, 3]);
+    let result = tensor.i(0..0);
+    assert_eq!(result.size(), &[0, 3]);
+    assert_eq!(vec_i64_from(&result), &[] as &[i64]);
+
+    // Clippy doesn't like explicitly reversed ranges, so let's pretend the bounds were computed.
+    let (start, end) = (1, 0);
+    let tensor = Tensor::arange_start(0, 4 * 3, opt).view([4, 3]);
+    let result = tensor.i(start..end);
+    assert_eq!(result.size(), &[0, 3]);
+    assert_eq!(vec_i64_from(&result), &[] as &[i64]);
 }
 
 #[test]


### PR DESCRIPTION
This brings the `IndexOp` functionality more in line with the analogous operation in Python, rather than panicking when the computed length of the range is negative.

```py
>>> import torch
>>> x = torch.randn([2, 3, 4])
>>> x[:, 1:1, :]
tensor([], size=(2, 0, 4))
>>> x[:, 1:0, :]
tensor([], size=(2, 0, 4))
```

Prior to this change, the second `let` below would cause a panic.

```rust
// Assume `x` is a `Tensor` like the one in the above Python example.
let good = x.i((.., 1..1, ..));
let oops = x.i((.., 1..0, ..));
```

Of course, this only causes a problem when the bounds of the range are computed at run time. :slightly_smiling_face:

### Is this a breaking change?

Arguably, no—unless someone can make the case that existing code relies on panics. Logic that potentially produces a zero-length empty range should also appropriately handle the logically empty `Tensor` resulting from indexing with it or any other empty range.