### PR TITLE
Implement Rust array to Tensor conversion.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ image = { version = "0.24.5", optional = true }
 clap = { version = "4.2.4", features = ["derive"], optional = true }
 serde_json = { version = "1.0.96", optional = true }
 memmap2 = { version = "0.6.1", optional = true }
+slice-of-array = "0.3.2"
 
 [dev-dependencies]
 anyhow = "1"

--- a/src/tensor/convert.rs
+++ b/src/tensor/convert.rs
@@ -180,3 +180,61 @@ impl<T: Element> TryFrom<Vec<T>> for Tensor {
         Self::try_from(&value)
     }
 }
+
+/// Create a tensor from a 1-dimensional array.
+impl<T: Element, const N: usize> TryFrom<[T; N]> for Tensor {
+    type Error = TchError;
+
+    fn try_from(value: [T; N]) -> Result<Self, Self::Error> {
+        Self::f_from_slice(value.as_slice())
+    }
+}
+
+/// Create a tensor from a reference to a 1-dimensional array.
+impl<T: Element, const N: usize> TryFrom<&[T; N]> for Tensor {
+    type Error = TchError;
+
+    fn try_from(value: &[T; N]) -> Result<Self, Self::Error> {
+        Self::f_from_slice(value.as_slice())
+    }
+}
+
+/// Create a tensor from a 2-dimensional array.
+impl<T: Element, const N1: usize, const N2: usize> TryFrom<[[T; N2]; N1]> for Tensor {
+    type Error = TchError;
+
+    fn try_from(value: [[T; N2]; N1]) -> Result<Self, Self::Error> {
+        use ::slice_of_array::prelude::*;
+        let slice = value.as_slice().flat();
+        let tensor = Self::f_from_slice(slice)?;
+        tensor.f_view([N1 as i64, N2 as i64])
+    }
+}
+
+/// Create a tensor from a 3-dimensional array.
+impl<T: Element, const N1: usize, const N2: usize, const N3: usize> TryFrom<[[[T; N3]; N2]; N1]>
+    for Tensor
+{
+    type Error = TchError;
+
+    fn try_from(value: [[[T; N3]; N2]; N1]) -> Result<Self, Self::Error> {
+        use ::slice_of_array::prelude::*;
+        let slice = value.as_slice().flat().flat();
+        let tensor = Self::f_from_slice(slice)?;
+        tensor.f_view([N1 as i64, N2 as i64, N3 as i64])
+    }
+}
+
+/// Create a tensor from a 4-dimensional array.
+impl<T: Element, const N1: usize, const N2: usize, const N3: usize, const N4: usize>
+    TryFrom<[[[[T; N4]; N3]; N2]; N1]> for Tensor
+{
+    type Error = TchError;
+
+    fn try_from(value: [[[[T; N4]; N3]; N2]; N1]) -> Result<Self, Self::Error> {
+        use ::slice_of_array::prelude::*;
+        let slice = value.as_slice().flat().flat().flat();
+        let tensor = Self::f_from_slice(slice)?;
+        tensor.f_view([N1 as i64, N2 as i64, N3 as i64, N4 as i64])
+    }
+}

--- a/tests/tensor_tests.rs
+++ b/tests/tensor_tests.rs
@@ -283,6 +283,111 @@ fn from_slice() -> Result<()> {
 }
 
 #[test]
+fn from_one_dimensional_array() -> Result<()> {
+    assert_eq!(vec_i32_from(&Tensor::try_from([-1_i32, 0, 1])?), vec![-1, 0, 1]);
+    assert_eq!(vec_i64_from(&Tensor::try_from([-1_i64, 0, 1])?), vec![-1, 0, 1]);
+    assert_eq!(
+        vec_f16_from(&Tensor::try_from([
+            f16::from_f64(-1.0),
+            f16::from_f64(0.0),
+            f16::from_f64(1.0)
+        ])?),
+        vec![f16::from_f64(-1.0), f16::from_f64(0.0), f16::from_f64(1.0)]
+    );
+    assert_eq!(vec_f32_from(&Tensor::try_from([-1_f32, 0.0, 1.0])?), vec![-1.0, 0.0, 1.0]);
+    assert_eq!(vec_f64_from(&Tensor::try_from([-1_f64, 0.0, 1.0])?), vec![-1.0, 0.0, 1.0]);
+    assert_eq!(vec_bool_from(&Tensor::try_from([true, false])?), vec![true, false]);
+    Ok(())
+}
+
+#[test]
+fn from_two_dimensional_array() -> Result<()> {
+    use ::slice_of_array::prelude::*;
+
+    let array = [[-1_i32, 0, 1], [-2, 0, 2]];
+    assert_eq!(vec_i32_from(&Tensor::try_from(array)?), array.flat());
+
+    let array = [[-1_i64, 0, 1], [-2, 0, 2]];
+    assert_eq!(vec_i64_from(&Tensor::try_from(array)?), array.flat());
+
+    let array = [
+        [f16::from_f64(-1.0), f16::from_f64(0.0), f16::from_f64(1.0)],
+        [f16::from_f64(-2.0), f16::from_f64(0.0), f16::from_f64(2.0)],
+    ];
+    assert_eq!(vec_f16_from(&Tensor::try_from(array)?), array.flat());
+
+    let array = [[-1.0_f32, 0.0, 1.0], [-2.0, 0.0, 2.0]];
+    assert_eq!(vec_f32_from(&Tensor::try_from(array)?), array.flat());
+
+    let array = [[-1.0_f64, 0.0, 1.0], [-2.0, 0.0, 2.0]];
+    assert_eq!(vec_f64_from(&Tensor::try_from(array)?), array.flat());
+
+    Ok(())
+}
+
+#[test]
+fn from_three_dimensional_array() -> Result<()> {
+    use ::slice_of_array::prelude::*;
+
+    let array = [[[-1_i32, 0, 1], [-2, 0, 2]], [[-3, 0, 3], [-4, 0, 4]]];
+    assert_eq!(vec_i32_from(&Tensor::try_from(array)?), array.flat().flat());
+
+    let array = [[[-1_i64, 0, 1], [-2, 0, 2]], [[-3, 0, 3], [-4, 0, 4]]];
+    assert_eq!(vec_i64_from(&Tensor::try_from(array)?), array.flat().flat());
+
+    let array = [
+        [
+            [f16::from_f64(-1.0), f16::from_f64(0.0), f16::from_f64(1.0)],
+            [f16::from_f64(-2.0), f16::from_f64(0.0), f16::from_f64(2.0)],
+        ],
+        [
+            [f16::from_f64(-3.0), f16::from_f64(0.0), f16::from_f64(3.0)],
+            [f16::from_f64(-4.0), f16::from_f64(0.0), f16::from_f64(4.0)],
+        ],
+    ];
+    assert_eq!(vec_f16_from(&Tensor::try_from(array)?), array.flat().flat());
+
+    let array = [[[-1_f32, 0.0, 1.0], [-2.0, 0.0, 2.0]], [[-3.0, 0.0, 3.0], [-4.0, 0.0, 4.0]]];
+    assert_eq!(vec_f32_from(&Tensor::try_from(array)?), array.flat().flat());
+
+    let array = [[[-1_f64, 0.0, 1.0], [-2.0, 0.0, 2.0]], [[-3.0, 0.0, 3.0], [-4.0, 0.0, 4.0]]];
+    assert_eq!(vec_f64_from(&Tensor::try_from(array)?), array.flat().flat());
+
+    Ok(())
+}
+
+#[test]
+fn from_four_dimensional_array() -> Result<()> {
+    use ::slice_of_array::prelude::*;
+
+    let array = [[[[-1_i32, 0, 1], [-2, 0, 2]], [[-3, 0, 3], [-4, 0, 4]]]];
+    assert_eq!(vec_i32_from(&Tensor::try_from(array)?), array.flat().flat().flat());
+
+    let array = [[[[-1_i64, 0, 1], [-2, 0, 2]], [[-3, 0, 3], [-4, 0, 4]]]];
+    assert_eq!(vec_i64_from(&Tensor::try_from(array)?), array.flat().flat().flat());
+
+    let array = [[
+        [
+            [f16::from_f64(-1.0), f16::from_f64(0.0), f16::from_f64(1.0)],
+            [f16::from_f64(-2.0), f16::from_f64(0.0), f16::from_f64(2.0)],
+        ],
+        [
+            [f16::from_f64(-3.0), f16::from_f64(0.0), f16::from_f64(3.0)],
+            [f16::from_f64(-4.0), f16::from_f64(0.0), f16::from_f64(4.0)],
+        ],
+    ]];
+    assert_eq!(vec_f16_from(&Tensor::try_from(array)?), array.flat().flat().flat());
+
+    let array = [[[[-1_f32, 0.0, 1.0], [-2.0, 0.0, 2.0]], [[-3.0, 0.0, 3.0], [-4.0, 0.0, 4.0]]]];
+    assert_eq!(vec_f32_from(&Tensor::try_from(array)?), array.flat().flat().flat());
+
+    let array = [[[[-1_f64, 0.0, 1.0], [-2.0, 0.0, 2.0]], [[-3.0, 0.0, 3.0], [-4.0, 0.0, 4.0]]]];
+    assert_eq!(vec_f64_from(&Tensor::try_from(array)?), array.flat().flat().flat());
+
+    Ok(())
+}
+
+#[test]
 fn test_device() {
     let x = Tensor::from(1);
     assert_eq!(x.device(), Device::Cpu);


### PR DESCRIPTION
It adds the feature to convert a 1-, 2-, 3- or 4-dimensional Rust array to a tch Tensor.
It makes this writing doable.

```rust
let tensor = Tensor::try_from([
    [1i64, 2, 3],
    [4, 5, 6],
    [7, 8, 9],
])?;
```