### PR TITLE
Add function load_buffer_on_device

### DIFF
--- a/src/wrappers/jit.rs
+++ b/src/wrappers/jit.rs
@@ -470,6 +470,16 @@ impl CModule {
         Ok(CModule { c_module })
     }
 
+    /// Loads a PyTorch saved JIT model from a read instance.
+    ///
+    /// This function loads the buffer directly on the specified device,
+    pub fn load_buffer_on_device(buffer: &Vec<u8>, device: Device) -> Result<CModule, TchError> {
+        let buffer_ptr = buffer.as_ptr() as *const libc::c_char;
+        let c_module =
+            unsafe_torch_err!(atm_load_str_on_device(buffer_ptr, buffer.len(), device.c_int()));
+        Ok(CModule { c_module })
+    }
+
     /// Performs the forward pass for a model on some specified tensor inputs. This is equivalent
     /// to calling method_ts with the 'forward' method name, and returns a single tensor.
     pub fn forward_ts<T: Borrow<Tensor>>(&self, ts: &[T]) -> Result<Tensor, TchError> {

--- a/src/wrappers/jit.rs
+++ b/src/wrappers/jit.rs
@@ -470,16 +470,6 @@ impl CModule {
         Ok(CModule { c_module })
     }
 
-    /// Loads a PyTorch saved JIT model from a read instance.
-    ///
-    /// This function loads the buffer directly on the specified device,
-    pub fn load_buffer_on_device(buffer: &Vec<u8>, device: Device) -> Result<CModule, TchError> {
-        let buffer_ptr = buffer.as_ptr() as *const libc::c_char;
-        let c_module =
-            unsafe_torch_err!(atm_load_str_on_device(buffer_ptr, buffer.len(), device.c_int()));
-        Ok(CModule { c_module })
-    }
-
     /// Performs the forward pass for a model on some specified tensor inputs. This is equivalent
     /// to calling method_ts with the 'forward' method name, and returns a single tensor.
     pub fn forward_ts<T: Borrow<Tensor>>(&self, ts: &[T]) -> Result<Tensor, TchError> {


### PR DESCRIPTION
Due to unknown reason, repeat calling of forward method of some models might not produce identical results. Therefore, I need to load the model repeatedly, to ensure consistency. By creating a memory buffer, I hope it will speed up the process a little bit.

let mut file = std::fs::File::open(model_path).unwrap();
let mut buffer: Vec<u8> = Vec::new();
file.read_to_end(&mut buffer).unwrap();
let mut model = tch::CModule::load_buffer_on_device(&buffer, device).unwrap();