### PR TITLE
Add some verbosity in torch-sys:build.rs for results of command PYTHON_PRINT_PYTORCH_DETAILS if it has a non-empty stderr. resolves #843

### DIFF
--- a/torch-sys/build.rs
+++ b/torch-sys/build.rs
@@ -8,7 +8,6 @@
 
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
-use std::str::Utf8Error;
 use std::{env, fs, io};
 
 const TORCH_VERSION: &str = "2.2.0";
@@ -233,9 +232,6 @@ impl SystemInfo {
                     format!("The command output to retrieve PyTorch details during build time has a non empty stderr field : {output_stderr}")
                 );
             }
-        
-
-
             let mut cxx11_abi = None;
             for line in String::from_utf8_lossy(&output.stdout).lines() {
                 if let Some(version) = line.strip_prefix("LIBTORCH_VERSION: ") {

--- a/torch-sys/build.rs
+++ b/torch-sys/build.rs
@@ -12,6 +12,9 @@ use std::{env, fs, io};
 
 const TORCH_VERSION: &str = "2.2.0";
 const PYTHON_PRINT_PYTORCH_DETAILS: &str = r"
+import sys
+print('SYS.EXE', sys.executable)
+print('SYS.PATH', sys.path)
 import torch
 from torch.utils import cpp_extension
 print('LIBTORCH_VERSION:', torch.__version__.split('+')[0])
@@ -191,6 +194,7 @@ impl SystemInfo {
         };
         let mut libtorch_include_dirs = vec![];
         if cfg!(feature = "python-extension") {
+            
             let output = std::process::Command::new(&python_interpreter)
                 .arg("-c")
                 .arg(PYTHON_PRINT_INCLUDE_PATH)
@@ -209,6 +213,8 @@ impl SystemInfo {
                 .arg(PYTHON_PRINT_PYTORCH_DETAILS)
                 .output()
                 .with_context(|| format!("error running {python_interpreter:?}"))?;
+            println!("cargo:warning={}", format!("DEBUG - Show Python command output : {}", std::str::from_utf8(&output.stdout).unwrap_or("Unrecognised String")));
+
             let mut cxx11_abi = None;
             for line in String::from_utf8_lossy(&output.stdout).lines() {
                 if let Some(version) = line.strip_prefix("LIBTORCH_VERSION: ") {

--- a/torch-sys/build.rs
+++ b/torch-sys/build.rs
@@ -45,7 +45,6 @@ LIBTORCH_USE_PYTORCH=1 is detected, but PyTorch Python package has not been foun
 It seems like that the Rust code uses the wrong Python interpreter, without torch installed on it.
 ";
 
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum LinkType {
     Dynamic,
@@ -200,7 +199,6 @@ impl SystemInfo {
         };
         let mut libtorch_include_dirs = vec![];
         if cfg!(feature = "python-extension") {
-            
             let output = std::process::Command::new(&python_interpreter)
                 .arg("-c")
                 .arg(PYTHON_PRINT_INCLUDE_PATH)


### PR DESCRIPTION
Would help users to debug when the Python command executed on Rust side fails.