### PR TITLE
Temporary Fix for GLOG

### DIFF
--- a/torch-sys/build.rs
+++ b/torch-sys/build.rs
@@ -385,6 +385,7 @@ impl SystemInfo {
                     .flag(&format!("-Wl,-rpath={}", self.libtorch_lib_dir.display()))
                     .flag("-std=c++17")
                     .flag(&format!("-D_GLIBCXX_USE_CXX11_ABI={}", self.cxx11_abi))
+                    .flag("-DGLOG_USE_GLOG_EXPORT")
                     .files(&c_files)
                     .compile("tch");
             }
@@ -398,6 +399,7 @@ impl SystemInfo {
                     .warnings(false)
                     .includes(&self.libtorch_include_dirs)
                     .flag("/std:c++17")
+                    .flag("/p:DefineConstants=GLOG_USE_GLOG_EXPORT")
                     .files(&c_files)
                     .compile("tch");
             }


### PR DESCRIPTION
Here is a temporary fix for #851 that appears to work when tested on my arch box. In the future would strongly recommend excluding GLOG in the bindings generator.