### PR TITLE
npy: fix parsing of complex dtypes

### DIFF
--- a/src/tensor/npy.rs
+++ b/src/tensor/npy.rs
@@ -140,8 +140,8 @@ impl Header {
                     "b" | "i1" => Kind::Int8,
                     "B" | "u1" => Kind::Uint8,
                     "?" | "b1" => Kind::Bool,
-                    "F" | "F4" => Kind::ComplexFloat,
-                    "D" | "F8" => Kind::ComplexDouble,
+                    "F" | "F4" | "c8" => Kind::ComplexFloat,
+                    "D" | "F8" | "c16" => Kind::ComplexDouble,
                     descr => {
                         return Err(TchError::FileFormat(format!("unrecognized descr {descr}")))
                     }


### PR DESCRIPTION
An exported `.npy` file with complex single float dtype fails to be loaded with `FileFormat("unrecognized descr c8")` (similarly with `c16` for complex double).
According to [the documentation](https://numpy.org/doc/2.1/reference/arrays.dtypes.html), `c{size}` are the only values that should be parsed as complex. I could not find any reference of `F` or `D` as introduced in #468.