### PR TITLE
Fix glog for pytorch 2.3.x branch.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tch"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Laurent Mazare <lmazare@gmail.com>"]
 edition = "2021"
 build = "build.rs"
@@ -22,7 +22,7 @@ libc = "0.2.0"
 ndarray = "0.15"
 rand = "0.8"
 thiserror = "1"
-torch-sys = { version = "0.16.0", path = "torch-sys" }
+torch-sys = { version = "0.16.1", path = "torch-sys" }
 zip = "0.6"
 half = "2"
 safetensors = "0.3.0"

--- a/examples/min-gpt/main.rs
+++ b/examples/min-gpt/main.rs
@@ -80,7 +80,7 @@ fn causal_self_attention(p: &nn::Path, cfg: Config) -> impl ModuleT {
         let q = xs.apply(&query).view(sizes).transpose(1, 2);
         let v = xs.apply(&value).view(sizes).transpose(1, 2);
         let att = q.matmul(&k.transpose(-2, -1)) * (1.0 / f64::sqrt(sizes[3] as f64));
-        let att = att.masked_fill(&mask.i((.., .., ..sz_t, ..sz_t)).eq(0.), std::f64::NEG_INFINITY);
+        let att = att.masked_fill(&mask.i((.., .., ..sz_t, ..sz_t)).eq(0.), f64::NEG_INFINITY);
         let att = att.softmax(-1, Kind::Float).dropout(cfg.attn_pdrop, train);
         let ys = att.matmul(&v).transpose(1, 2).contiguous().view([sz_b, sz_t, sz_c]);
         ys.apply(&proj).dropout(cfg.resid_pdrop, train)

--- a/examples/python-extension/Cargo.toml
+++ b/examples/python-extension/Cargo.toml
@@ -18,6 +18,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.21", features = ["extension-module"] }
-pyo3-tch = { path = "../../pyo3-tch", version = "0.16.0" }
-tch = { path = "../..", features = ["python-extension"], version = "0.16.0" }
-torch-sys = { path = "../../torch-sys", features = ["python-extension"], version = "0.16.0" }
+pyo3-tch = { path = "../../pyo3-tch", version = "0.16.1" }
+tch = { path = "../..", features = ["python-extension"], version = "0.16.1" }
+torch-sys = { path = "../../torch-sys", features = ["python-extension"], version = "0.16.1" }

--- a/examples/yolo/darknet.rs
+++ b/examples/yolo/darknet.rs
@@ -17,7 +17,7 @@ struct Block {
 
 impl Block {
     fn get(&self, key: &str) -> Result<&str> {
-        match self.parameters.get(&key.to_string()) {
+        match self.parameters.get(key) {
             None => bail!("cannot find {} in {}", key, self.block_type),
             Some(value) => Ok(value),
         }
@@ -32,7 +32,7 @@ pub struct Darknet {
 
 impl Darknet {
     fn get(&self, key: &str) -> Result<&str> {
-        match self.parameters.get(&key.to_string()) {
+        match self.parameters.get(key) {
             None => bail!("cannot find {} in net parameters", key),
             Some(value) => Ok(value),
         }

--- a/pyo3-tch/Cargo.toml
+++ b/pyo3-tch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-tch"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Laurent Mazare <lmazare@gmail.com>"]
 edition = "2021"
 build = "build.rs"
@@ -12,6 +12,6 @@ categories = ["science"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-tch = { path = "..", features = ["python-extension"], version = "0.16.0" }
-torch-sys = { path = "../torch-sys", features = ["python-extension"], version = "0.16.0" }
+tch = { path = "..", features = ["python-extension"], version = "0.16.1" }
+torch-sys = { path = "../torch-sys", features = ["python-extension"], version = "0.16.1" }
 pyo3 = { version = "0.21", features = ["extension-module"] }

--- a/src/nn/init.rs
+++ b/src/nn/init.rs
@@ -107,7 +107,7 @@ pub fn f_init(i: Init, dims: &[i64], device: Device) -> Result<Tensor, TchError>
             // Optimize the case for which a single C++ code can be done.
             if cst == 0. {
                 Tensor::f_zeros(dims, (Kind::Float, device))
-            } else if (cst - 1.).abs() <= std::f64::EPSILON {
+            } else if (cst - 1.).abs() <= f64::EPSILON {
                 Tensor::f_ones(dims, (Kind::Float, device))
             } else {
                 Tensor::f_ones(dims, (Kind::Float, device)).map(|t| t * cst)
@@ -117,7 +117,7 @@ pub fn f_init(i: Init, dims: &[i64], device: Device) -> Result<Tensor, TchError>
             Tensor::f_zeros(dims, (Kind::Float, device))?.f_uniform_(lo, up)
         }
         Init::Randn { mean, stdev } => {
-            if mean == 0. && (stdev - 1.).abs() <= std::f64::EPSILON {
+            if mean == 0. && (stdev - 1.).abs() <= f64::EPSILON {
                 Tensor::f_randn(dims, (Kind::Float, device))
             } else {
                 Tensor::f_randn(dims, (Kind::Float, device)).map(|t| t * stdev + mean)

--- a/torch-sys/Cargo.toml
+++ b/torch-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "torch-sys"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Laurent Mazare <lmazare@gmail.com>"]
 edition = "2021"
 build = "build.rs"

--- a/torch-sys/build.rs
+++ b/torch-sys/build.rs
@@ -382,9 +382,9 @@ impl SystemInfo {
                     .pic(true)
                     .warnings(false)
                     .includes(&self.libtorch_include_dirs)
-                    .flag(&format!("-Wl,-rpath={}", self.libtorch_lib_dir.display()))
+                    .flag(format!("-Wl,-rpath={}", self.libtorch_lib_dir.display()))
                     .flag("-std=c++17")
-                    .flag(&format!("-D_GLIBCXX_USE_CXX11_ABI={}", self.cxx11_abi))
+                    .flag(format!("-D_GLIBCXX_USE_CXX11_ABI={}", self.cxx11_abi))
                     .flag("-DGLOG_USE_GLOG_EXPORT")
                     .files(&c_files)
                     .compile("tch");

--- a/torch-sys/build.rs
+++ b/torch-sys/build.rs
@@ -385,6 +385,7 @@ impl SystemInfo {
                     .flag(&format!("-Wl,-rpath={}", self.libtorch_lib_dir.display()))
                     .flag("-std=c++17")
                     .flag(&format!("-D_GLIBCXX_USE_CXX11_ABI={}", self.cxx11_abi))
+                    .flag("-DGLOG_USE_GLOG_EXPORT")
                     .files(&c_files)
                     .compile("tch");
             }
@@ -398,6 +399,7 @@ impl SystemInfo {
                     .warnings(false)
                     .includes(&self.libtorch_include_dirs)
                     .flag("/std:c++17")
+                    .flag("/p:DefineConstants=GLOG_USE_GLOG_EXPORT")
                     .files(&c_files)
                     .compile("tch");
             }


### PR DESCRIPTION
Sadly I can't update to pytorch 2.4.0 yet, but glog is already broken (same problem as #852).

So I would be very happy if we can backport this to the 2.3.0 branch and have a release so I can get back to using a semver dependency <3 