### PR TITLE
Change visibility of `nn::Path::add` method to public.

### DIFF
--- a/src/nn/var_store.rs
+++ b/src/nn/var_store.rs
@@ -496,7 +496,7 @@ impl<'a> Path<'a> {
         self.set_float_kind(Kind::Double);
     }
 
-    pub(crate) fn add(&self, name: &str, tensor: Tensor, trainable: bool) -> Tensor {
+    pub fn add(&self, name: &str, tensor: Tensor, trainable: bool) -> Tensor {
         let path = self.path(name);
         let mut variables = self.var_store.variables_.lock().unwrap();
         let path = if variables.named_variables.contains_key(&path) {


### PR DESCRIPTION
**Description**

This pull request updates the visibility of the `nn::Path::add` method from `pub(crate)` to `pub`. The updated method signature is:
```
pub fn add(&self, name: &str, tensor: Tensor, trainable: bool) -> Tensor
```


**Reason for Change**

Previously, the add method was restricted to crate-level visibility (`pub(crate)`), which limited its usage. This change makes the method accessible outside the crate, enabling users to add existing tensors to a `VarStore`.


**Use Case**

While implementing Python bindings, I needed to add tensors from Python to `VarStore`. Making the add method public makes this possible.