### PR TITLE
Add FP8 tensor dtypes

### DIFF
--- a/src/tensor/display.rs
+++ b/src/tensor/display.rs
@@ -23,7 +23,11 @@ impl BasicKind {
                 | Kind::QInt32
                 | Kind::Half
                 | Kind::Float
-                | Kind::Double => BasicKind::Float,
+                | Kind::Double
+                | Kind::Float8e5m2
+                | Kind::Float8e4m3fn
+                | Kind::Float8e5m2fnuz
+                | Kind::Float8e4m3fnuz => BasicKind::Float,
                 Kind::Bool => BasicKind::Bool,
                 Kind::ComplexHalf | Kind::ComplexFloat | Kind::ComplexDouble => BasicKind::Complex,
             },
@@ -54,7 +58,11 @@ impl std::fmt::Debug for Tensor {
                         | Kind::QInt32
                         | Kind::Half
                         | Kind::Float
-                        | Kind::Double => (false, true),
+                        | Kind::Double
+                        | Kind::Float8e5m2
+                        | Kind::Float8e4m3fn
+                        | Kind::Float8e5m2fnuz
+                        | Kind::Float8e4m3fnuz => (false, true),
                         Kind::Bool
                         | Kind::ComplexHalf
                         | Kind::ComplexFloat

--- a/src/wrappers/kind.rs
+++ b/src/wrappers/kind.rs
@@ -22,6 +22,10 @@ pub enum Kind {
     QUInt8,
     QInt32,
     BFloat16,
+    Float8e5m2,
+    Float8e4m3fn,
+    Float8e5m2fnuz,
+    Float8e4m3fnuz,
 }
 
 impl Kind {
@@ -44,6 +48,10 @@ impl Kind {
             Kind::QUInt8 => 13,
             Kind::QInt32 => 14,
             Kind::BFloat16 => 15,
+            Kind::Float8e5m2 => 23,
+            Kind::Float8e4m3fn => 24,
+            Kind::Float8e5m2fnuz => 25,
+            Kind::Float8e4m3fnuz => 26,
         }
     }
 
@@ -65,6 +73,10 @@ impl Kind {
             13 => Ok(Kind::QUInt8),
             14 => Ok(Kind::QInt32),
             15 => Ok(Kind::BFloat16),
+            23 => Ok(Kind::Float8e5m2),
+            24 => Ok(Kind::Float8e4m3fn),
+            25 => Ok(Kind::Float8e5m2fnuz),
+            26 => Ok(Kind::Float8e4m3fnuz),
             _ => Err(crate::TchError::UnknownKind(v)),
         }
     }
@@ -87,6 +99,10 @@ impl Kind {
             Kind::QUInt8 => 1,
             Kind::QInt32 => 4,
             Kind::BFloat16 => 2,
+            Kind::Float8e5m2 => 1,
+            Kind::Float8e4m3fn => 1,
+            Kind::Float8e5m2fnuz => 1,
+            Kind::Float8e4m3fnuz => 1,
         }
     }
 }

--- a/tests/tensor_tests.rs
+++ b/tests/tensor_tests.rs
@@ -490,3 +490,19 @@ fn convert_ndarray() {
     let array_3d: ndarray::ArrayD<i64> = t_3d.as_ref().try_into().unwrap();
     assert_eq!(array_3d.as_slice(), ndarray::array![[[0, 1], [2, 3]], [[4, 5], [6, 7]]].as_slice());
 }
+
+#[test]
+fn fp8_tensor() {
+    let float8_types = [
+        tch::Kind::Float8e5m2,
+        tch::Kind::Float8e4m3fn,
+        tch::Kind::Float8e5m2fnuz,
+        tch::Kind::Float8e4m3fnuz,
+    ];
+
+    for &kind in &float8_types {
+        let t = Tensor::from_slice(&[1.0f32, 2.0, 3.0, 4.0]).to_kind(kind);
+        assert_eq!(t.kind(), kind);
+        assert_eq!(t.kind().elt_size_in_bytes(), 1);
+    }
+}


### PR DESCRIPTION
Add enum variants for [8-bit floating point tensor dtypes](https://pytorch.org/docs/stable/tensors.html). 

`c_int` values are sourced from here: 
https://github.com/pytorch/pytorch/blob/v2.5.1/c10/core/ScalarType.h#L80-L83
