### PR TITLE
Add `c10::Device` to IValue enum

### DIFF
--- a/src/wrappers/jit.rs
+++ b/src/wrappers/jit.rs
@@ -307,7 +307,7 @@ impl IValue {
                 unsafe_torch_err!(ati_clone(*c_ivalue))
             }
             IValue::Device(device) => {
-                ati_device(device.c_int())   
+                ati_device(device.c_int())
             }
         });
         Ok(c)

--- a/src/wrappers/jit.rs
+++ b/src/wrappers/jit.rs
@@ -29,6 +29,7 @@ pub enum IValue {
     // Eq or Hash out of the box in rust. TODO: improve this?
     GenericDict(Vec<(IValue, IValue)>),
     Object(Object),
+    Device(Device),
 }
 
 impl IValue {
@@ -49,6 +50,7 @@ impl IValue {
             IValue::GenericList(_) => "GenericList",
             IValue::GenericDict(_) => "GenericDict",
             IValue::Object(_) => "Object",
+            IValue::Device(_) => "Device",
         }
     }
 }
@@ -233,6 +235,7 @@ impl_from!(Vec<crate::Tensor>, TensorList);
 impl_from!(Vec<IValue>, GenericList);
 impl_from!(Vec<(IValue, IValue)>, GenericDict);
 impl_from!(Object, Object);
+impl_from!(Device, Device);
 
 impl From<&str> for IValue {
     fn from(s: &str) -> Self {
@@ -302,6 +305,9 @@ impl IValue {
             IValue::Object(Object { c_ivalue }) => {
                 // Clone the object if necessary before passing the pointer to the C++ side.
                 unsafe_torch_err!(ati_clone(*c_ivalue))
+            }
+            IValue::Device(device) => {
+                ati_device(device.c_int())   
             }
         });
         Ok(c)

--- a/torch-sys/libtch/torch_api.cpp
+++ b/torch-sys/libtch/torch_api.cpp
@@ -1452,6 +1452,14 @@ ivalue ati_tensor_list(tensor *is, int nvalues) {
   return nullptr;
 }
 
+ivalue ati_device(int device_idx) {
+  PROTECT(
+    return new torch::jit::IValue(device_of_int(device_idx));
+  )
+  return nullptr;
+}
+
+
 int ati_tag(ivalue i) {
   PROTECT(
     if (i->isNone()) return 0;

--- a/torch-sys/libtch/torch_api.h
+++ b/torch-sys/libtch/torch_api.h
@@ -245,6 +245,7 @@ ivalue ati_double_list(double *, int);
 ivalue ati_bool_list(char *, int);
 ivalue ati_string_list(char **, int);
 ivalue ati_tensor_list(tensor *, int);
+ivalue ati_device(int);
 
 tensor ati_to_tensor(ivalue);
 int64_t ati_to_int(ivalue);

--- a/torch-sys/src/lib.rs
+++ b/torch-sys/src/lib.rs
@@ -249,6 +249,7 @@ extern "C" {
     pub fn ati_bool_list(v: *const c_char, n: c_int) -> *mut CIValue;
     pub fn ati_string_list(v: *const *const c_char, n: c_int) -> *mut CIValue;
     pub fn ati_tensor_list(v: *const *mut C_tensor, n: c_int) -> *mut CIValue;
+    pub fn ati_device(device_idx: c_int) -> *mut CIValue;
 
     // Type query
     pub fn ati_tag(arg: *mut CIValue) -> c_int;


### PR DESCRIPTION
## Summary 
- Add `c10::Device` to `tch::IValue` enum. 
- The `c10::Device` is one of variant in the torch `IValue` enum. https://github.com/pytorch/pytorch/blob/d990dada86a8ad94882b5c23e859b88c0c255bda/aten/src/ATen/core/ivalue.h#L923 