### PR TITLE
Feat:   Allow Load/Save safetensors with IO trait

### DIFF
--- a/examples/tensor-tools.rs
+++ b/examples/tensor-tools.rs
@@ -25,7 +25,7 @@ pub fn main() -> Result<()> {
                         println!("{filename}: {name} {tensor:?}")
                     }
                 } else if filename.ends_with(".safetensors") {
-                    let tensors = tch::Tensor::read_safetensors(filename)?;
+                    let tensors = tch::Tensor::read_safetensors_file(filename)?;
                     for (name, tensor) in tensors.iter() {
                         println!("{filename}: {name} {tensor:?}")
                     }
@@ -51,7 +51,7 @@ pub fn main() -> Result<()> {
             let tensors = if src_filename.ends_with(".npz") {
                 tch::Tensor::read_npz(src_filename)?
             } else if src_filename.ends_with(".safetensors") {
-                tch::Tensor::read_safetensors(src_filename)?
+                tch::Tensor::read_safetensors_file(src_filename)?
             } else if src_filename.ends_with(".ot") {
                 tch::Tensor::load_multi(src_filename)?
             } else if src_filename.ends_with(".bin") || src_filename.ends_with(".zip") {
@@ -65,7 +65,7 @@ pub fn main() -> Result<()> {
             if dst_filename.ends_with(".npz") {
                 tch::Tensor::write_npz(&tensors, dst_filename)?
             } else if dst_filename.ends_with(".safetensors") {
-                tch::Tensor::write_safetensors(&tensors, dst_filename)?
+                tch::Tensor::persist_safetensors(&tensors, dst_filename)?
             } else if dst_filename.ends_with(".ot") {
                 tch::Tensor::save_multi(&tensors, dst_filename)?
             } else {

--- a/src/nn/var_store.rs
+++ b/src/nn/var_store.rs
@@ -166,7 +166,7 @@ impl VarStore {
         let variables = self.variables_.lock().unwrap();
         let named_tensors = variables.named_variables.iter().collect::<Vec<_>>();
         match path.as_ref().extension().and_then(|x| x.to_str()) {
-            Some("safetensors") => Tensor::write_safetensors(named_tensors.as_slice(), path),
+            Some("safetensors") => Tensor::persist_safetensors(named_tensors.as_slice(), path),
             Some(_) | None => Tensor::save_multi(named_tensors.as_slice(), path),
         }
     }
@@ -187,7 +187,7 @@ impl VarStore {
     ) -> Result<HashMap<String, Tensor>, TchError> {
         let named_tensors = match path.as_ref().extension().and_then(|x| x.to_str()) {
             Some("bin") | Some("pt") => Tensor::loadz_multi_with_device(&path, self.device),
-            Some("safetensors") => Tensor::read_safetensors(path),
+            Some("safetensors") => Tensor::read_safetensors_file(path),
             Some(_) | None => Tensor::load_multi_with_device(&path, self.device),
         };
         Ok(named_tensors?.into_iter().collect())

--- a/tests/serialization_tests.rs
+++ b/tests/serialization_tests.rs
@@ -164,8 +164,8 @@ fn save_and_load_safetensors() {
     let tmp_file = TmpFile::create("save-and-load-safetensors");
     let pi = Tensor::from_slice(&[3.0, 1.0, 4.0, 1.0, 5.0]);
     let e = Tensor::from_slice(&[2, 7, 1, 8, 2, 8, 1, 8, 2, 8, 4, 6]);
-    Tensor::write_safetensors(&[(&"pi", &pi), (&"e", &e)], &tmp_file).unwrap();
-    let named_tensors = Tensor::read_safetensors(&tmp_file).unwrap();
+    Tensor::persist_safetensors(&[(&"pi", &pi), (&"e", &e)], &tmp_file).unwrap();
+    let named_tensors = Tensor::read_safetensors_file(&tmp_file).unwrap();
     assert_eq!(named_tensors.len(), 2);
     for (name, tensor) in named_tensors {
         match name.as_str() {
@@ -182,8 +182,8 @@ fn save_and_load_safetensors_half() {
     let pi = Tensor::from_slice(&[3.0, 1.0, 4.0, 1.0, 5.0]).to_dtype(Kind::Half, true, false);
     let e =
         Tensor::from_slice(&[2, 7, 1, 8, 2, 8, 1, 8, 2, 8, 4, 6]).to_dtype(Kind::Half, true, false);
-    Tensor::write_safetensors(&[(&"pi", &pi), (&"e", &e)], &tmp_file).unwrap();
-    let named_tensors = Tensor::read_safetensors(&tmp_file).unwrap();
+    Tensor::persist_safetensors(&[(&"pi", &pi), (&"e", &e)], &tmp_file).unwrap();
+    let named_tensors = Tensor::read_safetensors_file(&tmp_file).unwrap();
     assert_eq!(named_tensors.len(), 2);
     for (name, tensor) in named_tensors {
         match name.as_str() {


### PR DESCRIPTION
Current API only support interact with `safetensor` file. This PR enable load/save safetensors with IO trait.