### PR TITLE
Fix bf16 Element::KIND to use BFloat16 instead of Half

### DIFF
--- a/src/wrappers/kind.rs
+++ b/src/wrappers/kind.rs
@@ -156,7 +156,7 @@ unsafe impl Element for half::f16 {
 }
 
 unsafe impl Element for half::bf16 {
-    const KIND: Kind = Kind::Half;
+    const KIND: Kind = Kind::BFloat16;
     const ZERO: Self = half::bf16::ZERO;
 }
 


### PR DESCRIPTION
Fixes #995

The `Element` implementation for `half::bf16` incorrectly mapped `KIND` to `Kind::Half` instead of `Kind::BFloat16`, causing data corruption when creating or reading bf16 tensors via `from_slice`/`try_into`.