### PR TITLE
Add inference mode support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,9 @@ pub use wrappers::{
 
 mod tensor;
 pub use tensor::{
-    autocast, display, index, no_grad, no_grad_guard, with_grad, IndexOp, NewAxis, NoGradGuard,
-    Reduction, Shape, Tensor, TensorIndexer,
+    autocast, display, index, inference_mode, is_inference_mode_enabled, no_grad, no_grad_guard,
+    with_grad, IndexOp, InferenceModeGuard, NewAxis, NoGradGuard, Reduction, Shape, Tensor,
+    TensorIndexer,
 };
 
 pub mod nn;

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -10,7 +10,8 @@ mod ops;
 mod safetensors;
 
 pub use super::wrappers::tensor::{
-    autocast, no_grad, no_grad_guard, with_grad, NoGradGuard, Reduction, Tensor,
+    autocast, inference_mode, is_inference_mode_enabled, no_grad, no_grad_guard, with_grad,
+    InferenceModeGuard, NoGradGuard, Reduction, Tensor,
 };
 pub use index::{IndexOp, NewAxis, TensorIndexer};
 

--- a/src/wrappers/tensor.rs
+++ b/src/wrappers/tensor.rs
@@ -8,8 +8,11 @@ use super::{
 use crate::TchError;
 use libc::{c_char, c_int, c_void};
 use std::borrow::Borrow;
+use std::cell::Cell;
 use std::io::{Read, Seek, Write};
+use std::marker::PhantomData;
 use std::path::Path;
+use std::ptr;
 use torch_sys::io::ReadStream;
 use torch_sys::*;
 
@@ -843,6 +846,127 @@ pub struct NoGradGuard {
 /// for more details.
 pub fn no_grad_guard() -> NoGradGuard {
     NoGradGuard { enabled: grad_set_enabled(false) }
+}
+
+fn inference_mode_guard_new() -> *mut C_inference_mode_guard {
+    unsafe_torch!(at_inference_mode_guard_new())
+}
+
+#[derive(Clone, Copy)]
+struct InferenceModeGuardState {
+    count: usize,
+    c_guard: *mut C_inference_mode_guard,
+}
+
+thread_local! {
+    static INFERENCE_MODE_GUARD_STATE: Cell<InferenceModeGuardState> =
+        Cell::new(InferenceModeGuardState { count: 0, c_guard: ptr::null_mut() });
+}
+
+fn inference_mode_guard_enter() {
+    INFERENCE_MODE_GUARD_STATE.with(|state| {
+        let mut state_value = state.get();
+        if state_value.count == 0 {
+            state_value.c_guard = inference_mode_guard_new();
+        }
+        state_value.count += 1;
+        state.set(state_value);
+    });
+}
+
+fn inference_mode_guard_exit() {
+    INFERENCE_MODE_GUARD_STATE.with(|state| {
+        let mut state_value = state.get();
+        debug_assert!(state_value.count > 0);
+
+        state_value.count -= 1;
+        if state_value.count == 0 {
+            let c_guard = state_value.c_guard;
+            state_value.c_guard = ptr::null_mut();
+            state.set(state_value);
+            unsafe_torch!(at_inference_mode_guard_free(c_guard));
+        } else {
+            state.set(state_value);
+        }
+    });
+}
+
+/// Returns true if inference mode is currently enabled.
+///
+/// Inference mode is a more aggressive version of `no_grad` that provides
+/// better performance at the cost of not being able to access saved tensors
+/// or any autograd history.
+pub fn is_inference_mode_enabled() -> bool {
+    unsafe_torch!(at_inference_mode_is_enabled() != 0)
+}
+
+/// Runs a closure in inference mode.
+///
+/// Inference mode is a more aggressive version of `no_grad` that provides
+/// better performance at the cost of not being able to access saved tensors
+/// or any autograd history. Views created in inference mode are not tracked
+/// and behave like copies.
+///
+/// Use this for pure inference workloads where you don't need any autograd
+/// functionality. For inference that might need to access autograd metadata,
+/// use `no_grad` instead.
+///
+/// # Example
+/// ```
+/// use tch::{inference_mode, Tensor};
+///
+/// inference_mode(|| {
+///     let x = Tensor::randn([10, 10], (tch::Kind::Float, tch::Device::Cpu));
+///     let y = x.matmul(&x);
+///     // y does not track gradients, views are not tracked
+/// });
+/// ```
+pub fn inference_mode<T, F>(f: F) -> T
+where
+    F: FnOnce() -> T,
+{
+    let _guard = InferenceModeGuard::new();
+    f()
+}
+
+/// A RAII guard that enables inference mode until deallocated.
+///
+/// Inference mode provides better performance than `no_grad` by completely
+/// disabling autograd history tracking. Views created in inference mode
+/// behave like copies and don't track gradients.
+///
+/// Inference mode remains enabled until all guards in the current thread are
+/// dropped.
+///
+/// # Example
+/// ```
+/// use tch::InferenceModeGuard;
+///
+/// let _guard = InferenceModeGuard::new();
+/// // Inference mode is active within this scope
+/// ```
+pub struct InferenceModeGuard {
+    _not_send: PhantomData<*mut ()>,
+}
+
+impl InferenceModeGuard {
+    /// Creates a new inference mode guard, enabling inference mode.
+    pub fn new() -> InferenceModeGuard {
+        inference_mode_guard_enter();
+        InferenceModeGuard { _not_send: PhantomData }
+    }
+}
+
+impl Default for InferenceModeGuard {
+    fn default() -> InferenceModeGuard {
+        InferenceModeGuard::new()
+    }
+}
+
+impl Drop for InferenceModeGuard {
+    fn drop(&mut self) {
+        inference_mode_guard_exit();
+    }
 }
 
 impl std::convert::AsRef<Tensor> for Tensor {

--- a/tests/inference_mode_tests.rs
+++ b/tests/inference_mode_tests.rs
@@ -1,0 +1,239 @@
+use tch::{
+    inference_mode, is_inference_mode_enabled, no_grad, Device, InferenceModeGuard, Kind, Tensor,
+};
+
+#[test]
+fn test_inference_mode_basic() {
+    // Test that inference mode is initially disabled
+    assert!(!is_inference_mode_enabled());
+
+    // Test that inference mode disables gradient tracking
+    inference_mode(|| {
+        assert!(is_inference_mode_enabled());
+
+        let x = Tensor::randn([10, 10], (Kind::Float, Device::Cpu));
+        let x = x.set_requires_grad(true);
+        let y = x.matmul(&x);
+
+        // In inference mode, requires_grad is ignored for output
+        assert!(!y.requires_grad());
+    });
+
+    // Test that inference mode is restored after closure
+    assert!(!is_inference_mode_enabled());
+}
+
+#[test]
+fn test_inference_mode_guard() {
+    // Test RAII guard pattern
+    assert!(!is_inference_mode_enabled());
+
+    {
+        let _guard = InferenceModeGuard::new();
+        assert!(is_inference_mode_enabled());
+    }
+
+    // Guard is dropped, inference mode should be disabled
+    assert!(!is_inference_mode_enabled());
+}
+
+#[test]
+fn test_inference_mode_guard_default() {
+    // Test Default trait implementation
+    assert!(!is_inference_mode_enabled());
+
+    {
+        let _guard: InferenceModeGuard = Default::default();
+        assert!(is_inference_mode_enabled());
+    }
+
+    assert!(!is_inference_mode_enabled());
+}
+
+#[test]
+fn test_nested_inference_mode() {
+    // Test nested inference_mode calls
+    inference_mode(|| {
+        assert!(is_inference_mode_enabled());
+
+        inference_mode(|| {
+            // Still enabled in nested call
+            assert!(is_inference_mode_enabled());
+        });
+
+        // Should still be enabled after nested call returns
+        assert!(is_inference_mode_enabled());
+    });
+
+    assert!(!is_inference_mode_enabled());
+}
+
+#[test]
+fn test_inference_mode_with_no_grad() {
+    // Test interaction with no_grad
+
+    // Case 1: inference_mode inside no_grad
+    no_grad(|| {
+        assert!(!is_inference_mode_enabled()); // no_grad doesn't enable inference_mode
+        inference_mode(|| {
+            assert!(is_inference_mode_enabled());
+        });
+        // Back to no_grad context, inference_mode should be disabled
+        assert!(!is_inference_mode_enabled());
+    });
+
+    // Case 2: no_grad inside inference_mode
+    inference_mode(|| {
+        assert!(is_inference_mode_enabled());
+        no_grad(|| {
+            // Inference mode remains enabled; no_grad does not disable it
+            // The key difference is that inference_mode disables view tracking
+            // while no_grad keeps view tracking enabled
+            assert!(is_inference_mode_enabled());
+        });
+        assert!(is_inference_mode_enabled());
+    });
+
+    assert!(!is_inference_mode_enabled());
+}
+
+#[test]
+fn test_inference_mode_preserves_state() {
+    // Test that inference mode properly saves and restores previous state
+
+    // Start with inference mode enabled via guard
+    let guard = InferenceModeGuard::new();
+    assert!(is_inference_mode_enabled());
+
+    // Nested inference_mode should preserve the fact that it was already enabled
+    inference_mode(|| {
+        assert!(is_inference_mode_enabled());
+    });
+
+    // Should still be enabled since we had the guard
+    assert!(is_inference_mode_enabled());
+
+    // Drop the guard
+    drop(guard);
+    assert!(!is_inference_mode_enabled());
+}
+
+#[test]
+fn test_inference_mode_restores_state_after_panic() {
+    assert!(!is_inference_mode_enabled());
+
+    let result = std::panic::catch_unwind(|| {
+        inference_mode(|| {
+            assert!(is_inference_mode_enabled());
+            panic!("intentional panic to verify inference mode cleanup");
+        });
+    });
+
+    assert!(result.is_err());
+    assert!(!is_inference_mode_enabled());
+}
+
+#[test]
+fn test_inference_mode_computation() {
+    // Test that computations actually work in inference mode
+    inference_mode(|| {
+        let a = Tensor::randn([100, 100], (Kind::Float, Device::Cpu));
+        let b = Tensor::randn([100, 100], (Kind::Float, Device::Cpu));
+
+        // Perform various operations
+        let c = a.matmul(&b);
+        let d = c.relu();
+        let e = d.sum(Kind::Float);
+
+        // Results should be valid tensors
+        assert_eq!(c.size(), vec![100i64, 100]);
+        assert_eq!(d.size(), vec![100i64, 100]);
+        assert_eq!(e.size(), Vec::<i64>::new());
+
+        // None should require grad in inference mode
+        assert!(!c.requires_grad());
+        assert!(!d.requires_grad());
+        assert!(!e.requires_grad());
+    });
+}
+
+#[test]
+fn test_inference_mode_thread_safety() {
+    use std::thread;
+
+    // Test that inference mode is thread-local
+    assert!(!is_inference_mode_enabled());
+
+    let handle = thread::spawn(|| {
+        // In new thread, inference mode should be disabled by default
+        assert!(!is_inference_mode_enabled());
+
+        inference_mode(|| {
+            // Enabled in this thread
+            assert!(is_inference_mode_enabled());
+        });
+
+        // Disabled again in this thread
+        assert!(!is_inference_mode_enabled());
+    });
+
+    // Main thread should not be affected
+    assert!(!is_inference_mode_enabled());
+
+    handle.join().unwrap();
+
+    // Still disabled in main thread
+    assert!(!is_inference_mode_enabled());
+}
+
+#[test]
+fn test_inference_mode_view_behavior() {
+    // Test view operations in inference mode
+    inference_mode(|| {
+        let x = Tensor::randn([10, 10], (Kind::Float, Device::Cpu));
+        let y = x.view([5, 20]);
+        let z = y.view([2, 5, 10]);
+
+        // Views should work correctly
+        assert_eq!(y.size(), vec![5, 20]);
+        assert_eq!(z.size(), vec![2, 5, 10]);
+
+        // In inference mode, views are not tracked as views (they behave like copies)
+        // The actual tensor data is shared, but autograd doesn't track the view relationship
+        assert!(!y.requires_grad());
+        assert!(!z.requires_grad());
+    });
+}
+
+#[test]
+fn test_inference_mode_with_guard_nested() {
+    // Test mixing inference_mode closure with guards
+    let outer_guard = InferenceModeGuard::new();
+    assert!(is_inference_mode_enabled());
+
+    {
+        let _inner_guard = InferenceModeGuard::new();
+        assert!(is_inference_mode_enabled());
+    }
+
+    // Should still be enabled because outer guard exists
+    assert!(is_inference_mode_enabled());
+
+    drop(outer_guard);
+    assert!(!is_inference_mode_enabled());
+}
+
+#[test]
+fn test_inference_mode_guards_can_drop_out_of_order() {
+    assert!(!is_inference_mode_enabled());
+
+    let outer_guard = InferenceModeGuard::new();
+    let inner_guard = InferenceModeGuard::new();
+    assert!(is_inference_mode_enabled());
+
+    drop(outer_guard);
+    assert!(is_inference_mode_enabled());
+
+    drop(inner_guard);
+    assert!(!is_inference_mode_enabled());
+}

--- a/torch-sys/libtch/torch_api.cpp
+++ b/torch-sys/libtch/torch_api.cpp
@@ -1,5 +1,6 @@
 #include "torch_api.h"
 #include <ATen/autocast_mode.h>
+#include <c10/core/InferenceMode.h>
 #include <stdexcept>
 #include <torch/csrc/autograd/engine.h>
 #include <torch/csrc/jit/codegen/cuda/interface.h>
@@ -212,6 +213,20 @@ int at_requires_grad(tensor t) {
 int at_grad_set_enabled(int b) {
   PROTECT(bool is_enabled = torch::autograd::GradMode::is_enabled();
           torch::autograd::GradMode::set_enabled(b); return is_enabled;)
+  return -1;
+}
+
+inference_mode_guard at_inference_mode_guard_new() {
+  PROTECT(return new c10::InferenceMode(true);)
+  return nullptr;
+}
+
+void at_inference_mode_guard_free(inference_mode_guard guard) {
+  PROTECT(delete static_cast<c10::InferenceMode *>(guard);)
+}
+
+int at_inference_mode_is_enabled() {
+  PROTECT(return c10::InferenceMode::is_enabled();)
   return -1;
 }
 

--- a/torch-sys/libtch/torch_api.h
+++ b/torch-sys/libtch/torch_api.h
@@ -14,6 +14,7 @@ typedef torch::Scalar *scalar;
 typedef torch::optim::Optimizer *optimizer;
 typedef torch::jit::script::Module *module;
 typedef torch::jit::IValue *ivalue;
+typedef void *inference_mode_guard;
 #define PROTECT(x) \
   try { \
     x \
@@ -26,6 +27,7 @@ typedef void *optimizer;
 typedef void *scalar;
 typedef void *module;
 typedef void *ivalue;
+typedef void *inference_mode_guard;
 #endif
 
 char *get_and_reset_last_err(); // thread-local
@@ -58,6 +60,9 @@ bool at_autocast_set_enabled(bool b);
 void at_backward(tensor, int, int);
 int at_requires_grad(tensor);
 int at_grad_set_enabled(int);
+inference_mode_guard at_inference_mode_guard_new(void);
+void at_inference_mode_guard_free(inference_mode_guard);
+int at_inference_mode_is_enabled(void);
 
 tensor at_get(tensor, int index);
 void at_fill_double(tensor, double);

--- a/torch-sys/src/lib.rs
+++ b/torch-sys/src/lib.rs
@@ -26,6 +26,11 @@ pub struct C_tensor {
     _private: [u8; 0],
 }
 
+#[repr(C)]
+pub struct C_inference_mode_guard {
+    _private: [u8; 0],
+}
+
 extern "C" {
     pub fn at_new_tensor() -> *mut C_tensor;
     pub fn at_shallow_clone(arg: *mut C_tensor) -> *mut C_tensor;
@@ -95,6 +100,9 @@ extern "C" {
         device: c_int,
     ) -> *mut C_tensor;
     pub fn at_grad_set_enabled(b: c_int) -> c_int;
+    pub fn at_inference_mode_guard_new() -> *mut C_inference_mode_guard;
+    pub fn at_inference_mode_guard_free(arg: *mut C_inference_mode_guard);
+    pub fn at_inference_mode_is_enabled() -> c_int;
     pub fn at_save(arg: *mut C_tensor, filename: *const c_char);
     pub fn at_save_to_stream(arg: *mut C_tensor, stream_ptr: *mut c_void);
     pub fn at_load(filename: *const c_char) -> *mut C_tensor;


### PR DESCRIPTION
Add Rust bindings for libtorch inference mode. Closes #977.