### PR TITLE
Expose `{keep,create}_graph` on `.backward()`.

### DIFF
--- a/src/wrappers/tensor.rs
+++ b/src/wrappers/tensor.rs
@@ -300,6 +300,15 @@ impl Tensor {
         self.f_backward().unwrap()
     }
 
+    pub fn f_backward_with(&self, keep_graph: bool, create_graph: bool) -> Result<(), TchError> {
+        unsafe_torch_err!(at_backward(self.c_tensor, keep_graph as c_int, create_graph as c_int));
+        Ok(())
+    }
+
+    pub fn backward_with(&self, keep_graph: bool, create_graph: bool) {
+        self.f_backward_with(keep_graph, create_graph).unwrap()
+    }
+
     pub fn f_run_backward<T1, T2>(
         tensors: &[T1],
         inputs: &[T2],


### PR DESCRIPTION
I *suppose* I am needing this today, for a sophisticated variant of what @LaurentMazare suggested [there](https://github.com/LaurentMazare/tch-rs/issues/71#issuecomment-512148217), although I am not yet 100% sure that this is going to solve my problem.

Maybe there was a good reason that these parameters where not exposed in the first place? Why then? What is the difference between `.backward` and `.run_backward`?

If there was none, then I'm happy to bikeshed this method's name: `.backward_with`? `.backward_graph`? `.backward_pass`?