### PR TITLE
torch-sys: use cl.exe /D syntax for GLOG_USE_GLOG_EXPORT on Windows

### DIFF
--- a/torch-sys/build.rs
+++ b/torch-sys/build.rs
@@ -398,7 +398,7 @@ impl SystemInfo {
                     .warnings(false)
                     .includes(&self.libtorch_include_dirs)
                     .flag("/std:c++17")
-                    .flag("/p:DefineConstants=GLOG_USE_GLOG_EXPORT")
+                    .flag("/DGLOG_USE_GLOG_EXPORT")
                     .files(&c_files)
                     .compile("tch");
             }


### PR DESCRIPTION
On Windows, the libtch wrapper build passes `/p:DefineConstants=GLOG_USE_GLOG_EXPORT` to `cl.exe`. `/p:` is MSBuild property syntax, not a `cl.exe` option, so every compiler invocation emits

```
cl : Command line warning D9002 : ignoring unknown option '/p:DefineConstants=GLOG_USE_GLOG_EXPORT'
```

and the macro is silently never defined. This switches it to `/DGLOG_USE_GLOG_EXPORT`, matching what the unix branch does with `-DGLOG_USE_GLOG_EXPORT`.

Verified on Windows 11 / MSVC against libtorch 2.12.0: the D9002 warnings are gone and the test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)