### PR TITLE
Improve error output for tensor mismatch by pruning C++ backtrace

### DIFF
--- a/src/wrappers/utils.rs
+++ b/src/wrappers/utils.rs
@@ -14,11 +14,18 @@ pub(super) unsafe fn ptr_to_string(ptr: *mut c_char) -> Option<String> {
     }
 }
 
+fn clean_error(c_error: String) -> String {
+    match c_error.find("\nException raised from") {
+        None => c_error,
+        Some(index) => c_error[..index].to_string(),
+    }
+}
+
 pub(super) fn read_and_clean_error() -> Result<(), TchError> {
     unsafe {
         match ptr_to_string(torch_sys::get_and_reset_last_err()) {
             None => Ok(()),
-            Some(c_error) => Err(TchError::Torch(c_error)),
+            Some(c_error) => Err(TchError::Torch(clean_error(c_error))),
         }
     }
 }
@@ -153,5 +160,22 @@ impl QEngine {
     pub fn set(self) -> Result<(), TchError> {
         unsafe_torch_err!(torch_sys::at_set_qengine(self.to_cint()));
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_clean_error() {
+        let err = "mat1 and mat2 must have the same dtype, but got Int and Float\nException raised from meta at /Users/runner/work/pytorch/pytorch/pytorch/aten/src/ATen/native/LinearAlgebra.cpp:195 (most recent call first):\nframe #0: c10::Error::Error(c10::SourceLocation, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>) + 52 (0x1009b55dc in libc10.dylib)\n".to_string();
+        assert_eq!(clean_error(err), "mat1 and mat2 must have the same dtype, but got Int and Float");
+
+        let err2 = "Some other error without exception header".to_string();
+        assert_eq!(clean_error(err2), "Some other error without exception header");
+
+        let err3 = "Multi-line error\nthat should stay\nException raised from somewhere".to_string();
+        assert_eq!(clean_error(err3), "Multi-line error\nthat should stay");
     }
 }


### PR DESCRIPTION
This PR improves the error messages returned by the PyTorch C++ API by removing the verbose C++ stack traces. Currently, when a tensor mismatch occurs (e.g., dtype or shape mismatch), the error message includes a long C++ backtrace which can be overwhelming and confusing for Rust users.

### Changes:
- Implemented a [clean_error](cci:1://file:///home/ibrahim/Desktop/tch-rs/src/wrappers/utils.rs:16:0-21:1) helper in [src/wrappers/utils.rs](cci:7://file:///home/ibrahim/Desktop/tch-rs/src/wrappers/utils.rs:0:0-0:0) to truncate error strings at the `\nException raised from` delimiter.
- Updated [read_and_clean_error](cci:1://file:///home/ibrahim/Desktop/tch-rs/src/wrappers/utils.rs:23:0-30:1) to apply this cleaning logic to all Torch errors.
- Added unit tests in [src/wrappers/utils.rs](cci:7://file:///home/ibrahim/Desktop/tch-rs/src/wrappers/utils.rs:0:0-0:0) to verify the pruning logic with various sample error strings.

### Results:
- **Before**: `Torch("mat1 and mat2 must have the same dtype, but got Int and Float\nException raised from meta at ... [long C++ backtrace]")`
- **After**: `Torch("mat1 and mat2 must have the same dtype, but got Int and Float")`

Fixes #1019
