### PR TITLE
Fix cargo run --example basics run for non-cuda computers

### DIFF
--- a/examples/basics.rs
+++ b/examples/basics.rs
@@ -31,6 +31,12 @@ fn main() {
     grad_example();
     println!("has_mps: {}", tch::utils::has_mps());
     println!("has_vulkan: {}", tch::utils::has_vulkan());
-    println!("version_cudnn: {}", tch::utils::version_cudnn());
-    println!("version_cudart: {}", tch::utils::version_cudart());
+
+    if tch::Cuda::is_available() {
+        println!("version_cudnn: {}", tch::utils::version_cudnn());
+    }
+
+    if tch::Cuda::cudnn_is_available() {
+        println!("version_cudart: {}", tch::utils::version_cudart());
+    }
 }


### PR DESCRIPTION
Addresses an issue where computers with non-cuda hardware cannot complete the examples/basics.rs test because of 2 calls to unavailable libraries.